### PR TITLE
feat: GL001 mutable image tags

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -65,6 +65,14 @@ func FindKeyNode(node *yaml.Node, key string) (keyNode, valueNode *yaml.Node) {
 	return nil, nil
 }
 
+// Unwrap returns the first content node of a DocumentNode, or the node itself.
+func Unwrap(node *yaml.Node) *yaml.Node {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return node.Content[0]
+	}
+	return node
+}
+
 // reservedKeys are top-level GitLab CI keys that are configuration, not job definitions.
 var reservedKeys = map[string]bool{
 	"stages":        true,

--- a/rules/all.go
+++ b/rules/all.go
@@ -1,0 +1,9 @@
+package rules
+
+import "github.com/glsec/glsec/internal/rule"
+
+func All() []rule.Rule {
+	return []rule.Rule{
+		GL001,
+	}
+}

--- a/rules/gl001.go
+++ b/rules/gl001.go
@@ -1,0 +1,132 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl001 struct{}
+
+var GL001 = &gl001{}
+
+func (r *gl001) ID() string { return "GL001" }
+
+func (r *gl001) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkImageNode(parser.FindKey(mapping, "image"), file)...)
+	findings = append(findings, checkServicesNode(parser.FindKey(mapping, "services"), file)...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkImageNode(parser.FindKey(def, "image"), file)...)
+		findings = append(findings, checkServicesNode(parser.FindKey(def, "services"), file)...)
+	}
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		findings = append(findings, checkImageNode(parser.FindKey(job, "image"), file)...)
+		findings = append(findings, checkServicesNode(parser.FindKey(job, "services"), file)...)
+	})
+
+	return findings
+}
+
+// mutableTags is the set of well-known mutable image tags.
+var mutableTags = map[string]bool{
+	"latest":  true,
+	"stable":  true,
+	"edge":    true,
+	"dev":     true,
+	"main":    true,
+	"master":  true,
+	"nightly": true,
+	"rolling": true,
+	"canary":  true,
+	"beta":    true,
+	"alpha":   true,
+}
+
+func checkImageNode(node *yaml.Node, file string) []finding.Finding {
+	if node == nil {
+		return nil
+	}
+	ref, line, col := imageRef(node)
+	if ref == "" {
+		return nil
+	}
+	return checkRef(ref, line, col, file)
+}
+
+func checkServicesNode(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		ref, line, col := imageRef(item)
+		if ref == "" {
+			continue
+		}
+		findings = append(findings, checkRef(ref, line, col, file)...)
+	}
+	return findings
+}
+
+// imageRef extracts the image reference and source location from a node.
+// Handles both scalar ("node:latest") and mapping ({name: node:latest}) forms.
+func imageRef(node *yaml.Node) (ref string, line, col int) {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node.Value, node.Line, node.Column
+	case yaml.MappingNode:
+		_, val := parser.FindKeyNode(node, "name")
+		if val != nil {
+			return val.Value, val.Line, val.Column
+		}
+	}
+	return "", 0, 0
+}
+
+func checkRef(ref string, line, col int, file string) []finding.Finding {
+	if strings.Contains(ref, "@sha256:") {
+		return nil
+	}
+	tag := imageTag(ref)
+	if tag == "" {
+		return []finding.Finding{{
+			RuleID:   "GL001",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("image %q has no tag — defaults to latest (mutable)", ref),
+			File:     file, Line: line, Col: col,
+		}}
+	}
+	if mutableTags[tag] {
+		return []finding.Finding{{
+			RuleID:   "GL001",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("image %q uses mutable tag %q — pin to a specific version or digest", ref, tag),
+			File:     file, Line: line, Col: col,
+		}}
+	}
+	return nil
+}
+
+// imageTag extracts the tag from an image reference.
+// Returns empty string if no tag is present (implying latest).
+func imageTag(ref string) string {
+	if i := strings.Index(ref, "@"); i >= 0 {
+		return ""
+	}
+	last := ref
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		last = ref[i+1:]
+	}
+	if i := strings.Index(last, ":"); i >= 0 {
+		return last[i+1:]
+	}
+	return ""
+}

--- a/rules/gl001_test.go
+++ b/rules/gl001_test.go
@@ -1,0 +1,157 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL001.Check(doc.Root, "test.yml")
+}
+
+func TestGL001_MutableTag(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node:latest
+  script: [npm run build]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL001_NoTag(t *testing.T) {
+	f := findings(t, `
+build:
+  image: alpine
+  script: [echo hi]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL001_PinnedVersion(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node:20.11.0
+  script: [npm run build]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings, got %v", f)
+	}
+}
+
+func TestGL001_DigestPinned(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node@sha256:abc123def456
+  script: [npm run build]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for digest-pinned image")
+	}
+}
+
+func TestGL001_MappingForm(t *testing.T) {
+	f := findings(t, `
+build:
+  image:
+    name: node:latest
+    entrypoint: [""]
+  script: [npm run build]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for mapping form, got %d", len(f))
+	}
+}
+
+func TestGL001_Services(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node:20.11.0
+  services:
+    - docker:dind
+    - name: postgres:latest
+      alias: db
+  script: [npm run build]
+`)
+	// docker:dind is a named variant tag, not in mutableTags; only postgres:latest triggers
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (postgres:latest), got %d", len(f))
+	}
+}
+
+func TestGL001_DefaultBlock(t *testing.T) {
+	f := findings(t, `
+default:
+  image: ubuntu:latest
+  services:
+    - docker:dind
+
+build:
+  script: [make]
+`)
+	// docker:dind is a named variant tag; only ubuntu:latest triggers
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding from default block (ubuntu:latest), got %d", len(f))
+	}
+}
+
+func TestGL001_TopLevelImage(t *testing.T) {
+	f := findings(t, `
+image: ruby:latest
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for top-level image, got %d", len(f))
+	}
+}
+
+func TestGL001_LineNumbers(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node:latest
+  script: [npm run build]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}
+
+func TestGL001_Registry(t *testing.T) {
+	f := findings(t, `
+build:
+  image: registry.company.com:5000/node:20.11.0
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for pinned registry image, got %v", f)
+	}
+}
+
+func TestGL001_RegistryLatest(t *testing.T) {
+	f := findings(t, `
+build:
+  image: registry.company.com:5000/node:latest
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for registry image with latest tag, got %d", len(f))
+	}
+}


### PR DESCRIPTION
Closes #3

## What
First security rule: detects `image:` and `services:` entries that use mutable tags or no tag at all.

## Checks
- Job-level `image:`, top-level `image:`, `default.image:`
- Job-level `services:`, top-level `services:`, `default.services:`
- Both scalar form (`image: node:latest`) and mapping form (`image: {name: node:latest}`)
- Registry-qualified references (`registry.company.com:5000/node:latest`)

## Mutable tags detected
`latest`, `stable`, `edge`, `dev`, `main`, `master`, `nightly`, `rolling`, `canary`, `beta`, `alpha`

Named variant tags like `docker:dind` or `node:alpine` are intentionally not flagged — they denote an image variant, not a floating version pointer. Users should pin these with a version prefix (`docker:26-dind`).

Digest-pinned images (`node@sha256:...`) are explicitly allowed.

## Parser addition
Added `parser.Unwrap(node)` to avoid duplicating DocumentNode unwrapping logic in every rule.

## Test plan
- [x] `go test ./...` passes (12 test cases)
- [x] Covers: mutable tags, no tag, pinned version, digest pin, mapping form, services, default block, top-level image, registry URLs, line numbers