### PR TITLE
feat: GL002 variable injection in script blocks

### DIFF
--- a/rules/all.go
+++ b/rules/all.go
@@ -5,5 +5,6 @@ import "github.com/glsec/glsec/internal/rule"
 func All() []rule.Rule {
 	return []rule.Rule{
 		GL001,
+		GL002,
 	}
 }

--- a/rules/gl002.go
+++ b/rules/gl002.go
@@ -1,0 +1,106 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl002 struct{}
+
+var GL002 = &gl002{}
+
+func (r *gl002) ID() string { return "GL002" }
+
+// userControlledVars are GitLab CI predefined variables whose values are
+// set by external actors (commit authors, MR creators) and can contain
+// shell metacharacters like $(...) or `...`.
+var userControlledVars = []string{
+	"CI_COMMIT_REF_NAME",
+	"CI_COMMIT_TITLE",
+	"CI_COMMIT_MESSAGE",
+	"CI_COMMIT_DESCRIPTION",
+	"CI_MERGE_REQUEST_SOURCE_BRANCH_NAME",
+	"CI_MERGE_REQUEST_TITLE",
+	"CI_MERGE_REQUEST_DESCRIPTION",
+	"CI_PIPELINE_NAME",
+}
+
+// unquotedVarPatterns matches $VAR or ${VAR} not immediately preceded by '"'.
+// Using '"' as the only safe predecessor keeps the heuristic simple:
+// "$VAR" is the idiomatic safe form; anything else (unquoted args, assignments,
+// subshells) is potentially exploitable.
+var unquotedVarPatterns = func() []*regexp.Regexp {
+	out := make([]*regexp.Regexp, len(userControlledVars))
+	for i, v := range userControlledVars {
+		out[i] = regexp.MustCompile(`(?:^|[^"])\$\{?` + regexp.QuoteMeta(v) + `\}?`)
+	}
+	return out
+}()
+
+func (r *gl002) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	// top-level and default script blocks
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkScriptNode(node, file)...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkScriptNode(node, file)...)
+			}
+		}
+	}
+
+	// per-job script blocks
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkScriptNode(node, file)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkScriptNode(node *yaml.Node, file string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		findings = append(findings, checkScriptLine(item, file)...)
+	}
+	return findings
+}
+
+func checkScriptLine(node *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	for i, pat := range unquotedVarPatterns {
+		if pat.MatchString(node.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL002",
+				Severity: finding.Warn,
+				Message: fmt.Sprintf(
+					"unquoted user-controlled variable $%s in script — value is set by commit authors and may contain shell metacharacters",
+					userControlledVars[i],
+				),
+				File: file,
+				Line: node.Line,
+				Col:  node.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl002_test.go
+++ b/rules/gl002_test.go
@@ -1,0 +1,129 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings002(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL002.Check(doc.Root, "test.yml")
+}
+
+func TestGL002_UnquotedRefName(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - ./run.sh $CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL002_QuotedRefName(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo "$CI_COMMIT_REF_NAME"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for double-quoted variable, got %d", len(f))
+	}
+}
+
+func TestGL002_BraceForm(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo ${CI_COMMIT_REF_NAME}
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for brace form, got %d", len(f))
+	}
+}
+
+func TestGL002_MultipleVars(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo $CI_COMMIT_TITLE
+    - ./deploy.sh $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL002_SafeVariable(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo $CI_JOB_ID
+    - echo $CI_PROJECT_NAME
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for non-user-controlled variables, got %d", len(f))
+	}
+}
+
+func TestGL002_BeforeScript(t *testing.T) {
+	f := findings002(t, `
+build:
+  before_script:
+    - git checkout $CI_COMMIT_REF_NAME
+  script:
+    - make
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in before_script, got %d", len(f))
+	}
+}
+
+func TestGL002_TopLevelBeforeScript(t *testing.T) {
+	f := findings002(t, `
+before_script:
+  - echo $CI_COMMIT_MESSAGE
+
+build:
+  script:
+    - make
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in top-level before_script, got %d", len(f))
+	}
+}
+
+func TestGL002_LineNumbers(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - ./run.sh $CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}
+
+func TestGL002_SubshellInjection(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - make test BRANCH=$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for assignment context, got %d", len(f))
+	}
+}


### PR DESCRIPTION
Closes #4

## What
Detects user-controlled GitLab CI variables used unquoted in \`script:\`, \`before_script:\`, and \`after_script:\` blocks. These variables are set by commit authors or MR creators and can contain shell metacharacters like \`\$()\` or backticks.

## User-controlled variables checked
\`CI_COMMIT_REF_NAME\`, \`CI_COMMIT_TITLE\`, \`CI_COMMIT_MESSAGE\`, \`CI_COMMIT_DESCRIPTION\`, \`CI_MERGE_REQUEST_SOURCE_BRANCH_NAME\`, \`CI_MERGE_REQUEST_TITLE\`, \`CI_MERGE_REQUEST_DESCRIPTION\`, \`CI_PIPELINE_NAME\`

## Detection heuristic
Flags \`$VAR\` or \`${VAR}\` not immediately preceded by \`"\`. This is intentionally simple:
- \`./run.sh $CI_COMMIT_REF_NAME\` → flagged
- \`BRANCH=$CI_COMMIT_REF_NAME\` → flagged
- \`echo "$CI_COMMIT_REF_NAME"\` → not flagged (safe idiomatic form)

False positive surface: \`echo "text $CI_COMMIT_REF_NAME more"\` gets flagged because the \`$\` is preceded by a space inside a quoted string. This is a known limitation — full shell parsing would be required to eliminate it, which is out of scope. Even inside double quotes, \`\$()\` command substitution is still evaluated, so the finding is not entirely wrong.

Severity is WARN (not ERROR) to reflect the heuristic nature.

## Scope
- Checks job-level \`script\`, \`before_script\`, \`after_script\`
- Checks top-level \`before_script\` / \`after_script\`
- Checks \`default:\` block script keys

## Test plan
- [x] \`go test ./...\` passes (9 test cases)
- [x] Covers: unquoted args, quoted (safe), brace form, multiple vars, safe variables, before_script, top-level scripts, line numbers, assignment context