### PR TITLE
feat: GL003 unpinned include refs

### DIFF
--- a/rules/all.go
+++ b/rules/all.go
@@ -6,5 +6,6 @@ func All() []rule.Rule {
 	return []rule.Rule{
 		GL001,
 		GL002,
+		GL003,
 	}
 }

--- a/rules/gl003.go
+++ b/rules/gl003.go
@@ -1,0 +1,141 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl003 struct{}
+
+var GL003 = &gl003{}
+
+func (r *gl003) ID() string { return "GL003" }
+
+// shaPattern matches a full or short commit SHA (8–40 hex chars).
+var shaPattern = regexp.MustCompile(`^[0-9a-f]{8,40}$`)
+
+// mutableRefs are branch names that are clearly mutable version pointers.
+var mutableRefs = map[string]bool{
+	"main": true, "master": true, "dev": true, "develop": true,
+	"staging": true, "production": true, "latest": true, "HEAD": true,
+	"nightly": true, "canary": true, "edge": true,
+}
+
+func (r *gl003) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+	includeNode := parser.FindKey(mapping, "include")
+	if includeNode == nil {
+		return nil
+	}
+
+	// scalar shorthand (include: '/local/path.yml') is treated as local → safe
+	if includeNode.Kind == yaml.ScalarNode {
+		return nil
+	}
+
+	if includeNode.Kind != yaml.SequenceNode {
+		return nil
+	}
+
+	var findings []finding.Finding
+	for _, item := range includeNode.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		findings = append(findings, checkIncludeItem(item, file)...)
+	}
+	return findings
+}
+
+func checkIncludeItem(node *yaml.Node, file string) []finding.Finding {
+	if parser.FindKey(node, "local") != nil || parser.FindKey(node, "template") != nil {
+		return nil
+	}
+
+	if remote := parser.FindKey(node, "remote"); remote != nil {
+		return []finding.Finding{{
+			RuleID:   "GL003",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("remote include %q — URL content is mutable and unverified; use a project include with a pinned ref instead", remote.Value),
+			File:     file,
+			Line:     remote.Line,
+			Col:      remote.Column,
+		}}
+	}
+
+	if component := parser.FindKey(node, "component"); component != nil {
+		return checkComponentRef(component, file)
+	}
+
+	if project := parser.FindKey(node, "project"); project != nil {
+		return checkProjectRef(node, project, file)
+	}
+
+	return nil
+}
+
+func checkProjectRef(node *yaml.Node, projectNode *yaml.Node, file string) []finding.Finding {
+	refNode := parser.FindKey(node, "ref")
+	if refNode == nil {
+		return []finding.Finding{{
+			RuleID:   "GL003",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("project include %q missing \"ref\" — defaults to HEAD of default branch (mutable)", projectNode.Value),
+			File:     file,
+			Line:     projectNode.Line,
+			Col:      projectNode.Column,
+		}}
+	}
+	if isMutableRef(refNode.Value) {
+		return []finding.Finding{{
+			RuleID:   "GL003",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("project include %q uses mutable ref %q — pin to a commit SHA or tag", projectNode.Value, refNode.Value),
+			File:     file,
+			Line:     refNode.Line,
+			Col:      refNode.Column,
+		}}
+	}
+	return nil
+}
+
+func checkComponentRef(node *yaml.Node, file string) []finding.Finding {
+	// component refs follow the format: "gitlab.com/org/component@ref"
+	at := strings.LastIndex(node.Value, "@")
+	if at < 0 {
+		return []finding.Finding{{
+			RuleID:   "GL003",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("component include %q missing version — add @<tag-or-sha>", node.Value),
+			File:     file,
+			Line:     node.Line,
+			Col:      node.Column,
+		}}
+	}
+	ref := node.Value[at+1:]
+	if isMutableRef(ref) {
+		return []finding.Finding{{
+			RuleID:   "GL003",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("component include %q uses mutable ref %q — pin to a tag or commit SHA", node.Value, ref),
+			File:     file,
+			Line:     node.Line,
+			Col:      node.Column,
+		}}
+	}
+	return nil
+}
+
+// isMutableRef returns true if the ref is a known mutable branch name.
+// SHA-like strings are considered pinned; everything else (tags) is allowed.
+func isMutableRef(ref string) bool {
+	if shaPattern.MatchString(ref) {
+		return false
+	}
+	return mutableRefs[ref]
+}

--- a/rules/gl003_test.go
+++ b/rules/gl003_test.go
@@ -1,0 +1,164 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings003(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL003.Check(doc.Root, "test.yml")
+}
+
+func TestGL003_LocalInclude(t *testing.T) {
+	f := findings003(t, `
+include:
+  - local: '/templates/security.yml'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for local include, got %d", len(f))
+	}
+}
+
+func TestGL003_TemplateInclude(t *testing.T) {
+	f := findings003(t, `
+include:
+  - template: 'Security/SAST.gitlab-ci.yml'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for template include, got %d", len(f))
+	}
+}
+
+func TestGL003_ScalarShorthand(t *testing.T) {
+	f := findings003(t, `
+include: '/templates/security.yml'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for scalar shorthand include, got %d", len(f))
+	}
+}
+
+func TestGL003_RemoteInclude(t *testing.T) {
+	f := findings003(t, `
+include:
+  - remote: 'https://example.com/templates/security.yml'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for remote include, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL003_ProjectMissingRef(t *testing.T) {
+	f := findings003(t, `
+include:
+  - project: 'company/ci-templates'
+    file: '/jobs/deploy.yml'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for missing ref, got %d", len(f))
+	}
+}
+
+func TestGL003_ProjectMutableRef(t *testing.T) {
+	f := findings003(t, `
+include:
+  - project: 'company/ci-templates'
+    file: '/jobs/deploy.yml'
+    ref: main
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for mutable ref, got %d", len(f))
+	}
+}
+
+func TestGL003_ProjectPinnedTag(t *testing.T) {
+	f := findings003(t, `
+include:
+  - project: 'company/ci-templates'
+    file: '/jobs/deploy.yml'
+    ref: v1.2.3
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for pinned tag, got %d", len(f))
+	}
+}
+
+func TestGL003_ProjectPinnedSHA(t *testing.T) {
+	f := findings003(t, `
+include:
+  - project: 'company/ci-templates'
+    file: '/jobs/deploy.yml'
+    ref: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for SHA-pinned ref, got %d", len(f))
+	}
+}
+
+func TestGL003_ComponentMutableRef(t *testing.T) {
+	f := findings003(t, `
+include:
+  - component: 'gitlab.com/my-org/my-component/build@main'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for component with mutable ref, got %d", len(f))
+	}
+}
+
+func TestGL003_ComponentPinnedVersion(t *testing.T) {
+	f := findings003(t, `
+include:
+  - component: 'gitlab.com/my-org/my-component/build@1.0.0'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for versioned component, got %d", len(f))
+	}
+}
+
+func TestGL003_ComponentMissingRef(t *testing.T) {
+	f := findings003(t, `
+include:
+  - component: 'gitlab.com/my-org/my-component/build'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for component missing version, got %d", len(f))
+	}
+}
+
+func TestGL003_Mixed(t *testing.T) {
+	f := findings003(t, `
+include:
+  - local: '/safe.yml'
+  - project: 'company/templates'
+    file: '/deploy.yml'
+    ref: main
+  - remote: 'https://example.com/template.yml'
+  - template: 'SAST.gitlab-ci.yml'
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (mutable ref + remote), got %d", len(f))
+	}
+}
+
+func TestGL003_LineNumbers(t *testing.T) {
+	f := findings003(t, `
+include:
+  - remote: 'https://example.com/template.yml'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}


### PR DESCRIPTION
Closes #5

## What
Detects \`include:\` entries that reference mutable sources — a supply chain attack vector where a compromised template repo silently affects all downstream pipelines.

## Include types and their treatment

| Type | Treatment |
|------|-----------|
| \`local:\` | Safe — pinned to current commit |
| \`template:\` | Safe — GitLab-managed, tied to instance version |
| \`remote:\` | Always ERROR — URL content is unversioned and unverifiable |
| \`project:\` | Check \`ref:\` — missing or mutable branch → ERROR; tag or SHA → OK |
| \`component:\` | Check version after \`@\` — missing or mutable → ERROR; semver/SHA → OK |

## Ref classification
- SHA (8–40 hex chars) → pinned, no finding
- Known mutable branches (\`main\`, \`master\`, \`dev\`, \`develop\`, \`staging\`, \`production\`, \`latest\`, \`HEAD\`, \`nightly\`, \`canary\`, \`edge\`) → ERROR
- Anything else (tags like \`v1.2.3\`) → trusted, no finding

## Test plan
- [x] \`go test ./...\` passes (13 test cases)
- [x] Covers: local, template, scalar shorthand, remote, project missing ref, project mutable ref, project pinned tag, project SHA, component mutable, component versioned, component missing version, mixed file, line numbers