### PR TITLE
feat: GL005 sensitive artifacts + working CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-glsec
+/glsec
 dist/
 
 # Test output

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"github.com/glsec/glsec/rules"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: glsec <file>")
+		os.Exit(2)
+	}
+
+	file := os.Args[1]
+	doc, err := parser.ParseFile(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
+	var findings []finding.Finding
+	for _, rule := range rules.All() {
+		findings = append(findings, rule.Check(doc.Root, file)...)
+	}
+
+	for _, f := range findings {
+		fmt.Printf("%-6s %s:%d  %s  %s\n",
+			strings.ToUpper(string(f.Severity)),
+			f.File, f.Line,
+			f.RuleID,
+			f.Message,
+		)
+	}
+
+	if len(findings) > 0 {
+		os.Exit(1)
+	}
+}

--- a/rules/all.go
+++ b/rules/all.go
@@ -8,5 +8,6 @@ func All() []rule.Rule {
 		GL002,
 		GL003,
 		GL004,
+		GL005,
 	}
 }

--- a/rules/gl005.go
+++ b/rules/gl005.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl005 struct{}
+
+var GL005 = &gl005{}
+
+func (r *gl005) ID() string { return "GL005" }
+
+// sensitivePatterns are glob patterns matching files that commonly contain secrets.
+var sensitivePatterns = []string{
+	".env", ".env.*",
+	"*.pem", "*.key", "*.p12", "*.pfx", "*.der",
+	"*.keystore", "*.jks",
+	"id_rsa", "id_ecdsa", "id_ed25519", "id_dsa",
+	"*.secret", "*secret*",
+	"*credential*", "*credentials*",
+	"*password*", "*passwd*",
+	"*.token",
+	"kubeconfig", "*.kubeconfig",
+	"*.tfstate", "*.tfvars",
+}
+
+func (r *gl005) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		artifactsNode := parser.FindKey(job, "artifacts")
+		if artifactsNode == nil {
+			return
+		}
+		findings = append(findings, checkArtifacts(artifactsNode, file)...)
+	})
+
+	return findings
+}
+
+func checkArtifacts(node *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	pathsNode := parser.FindKey(node, "paths")
+	if pathsNode != nil && pathsNode.Kind == yaml.SequenceNode {
+		for _, item := range pathsNode.Content {
+			if item.Kind != yaml.ScalarNode {
+				continue
+			}
+			if pat := matchesSensitivePattern(item.Value); pat != "" {
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL005",
+					Severity: finding.Error,
+					Message:  fmt.Sprintf("artifact path %q matches sensitive file pattern %q — exclude secrets from artifacts", item.Value, pat),
+					File:     file,
+					Line:     item.Line,
+					Col:      item.Column,
+				})
+			}
+		}
+	}
+
+	_, expireNode := parser.FindKeyNode(node, "expire_in")
+	if expireNode == nil {
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL005",
+			Severity: finding.Warn,
+			Message:  "artifacts block has no \"expire_in\" — artifacts are stored indefinitely, increasing the exposure window for any sensitive content",
+			File:     file,
+			Line:     node.Line,
+			Col:      node.Column,
+		})
+	}
+
+	return findings
+}
+
+func matchesSensitivePattern(path string) string {
+	base := filepath.Base(path)
+	// also check the full path for patterns like "*secret*"
+	targets := []string{base, strings.ToLower(base), strings.ToLower(path)}
+
+	for _, pat := range sensitivePatterns {
+		for _, target := range targets {
+			if ok, _ := filepath.Match(pat, target); ok {
+				return pat
+			}
+		}
+	}
+	return ""
+}

--- a/rules/gl005_test.go
+++ b/rules/gl005_test.go
@@ -1,0 +1,163 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings005(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL005.Check(doc.Root, "test.yml")
+}
+
+func TestGL005_EnvFile(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - .env.production
+    expire_in: 1 week
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for .env file, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL005_PemFile(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - deploy-key.pem
+    expire_in: 1 week
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for .pem file, got %d", len(f))
+	}
+}
+
+func TestGL005_NoExpiry(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - dist/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for missing expire_in, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity for missing expiry")
+	}
+}
+
+func TestGL005_SensitiveAndNoExpiry(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - .env.production
+      - dist/
+`)
+	// .env finding (Error) + no expire_in (Warn)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL005_SafeArtifactWithExpiry(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - dist/
+      - coverage.xml
+    expire_in: 7 days
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for safe artifact with expiry, got %d", len(f))
+	}
+}
+
+func TestGL005_KeyFile(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - secrets/api.key
+    expire_in: 1 day
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for .key file, got %d", len(f))
+	}
+}
+
+func TestGL005_SecretInPath(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - output/db_password.txt
+    expire_in: 1 day
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for password in filename, got %d", len(f))
+	}
+}
+
+func TestGL005_TerraformState(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - terraform.tfstate
+    expire_in: 1 day
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for tfstate, got %d", len(f))
+	}
+}
+
+func TestGL005_NoArtifacts(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings when no artifacts block, got %d", len(f))
+	}
+}
+
+func TestGL005_LineNumbers(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - .env.production
+    expire_in: 1 week
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}


### PR DESCRIPTION
Closes #7, closes #8 (partial — text output and exit codes)

## GL005: Sensitive artifact paths and missing expiry

Two distinct findings per artifacts block:

**Sensitive paths (ERROR):** artifact paths matching patterns like `.env*`, `*.pem`, `*.key`, `*password*`, `*.tfstate`, `kubeconfig`, etc.

**Missing expire_in (WARN):** any artifacts block without an `expire_in` key — artifacts stored indefinitely increase the exposure window.

Sensitive pattern matching uses `filepath.Match` against both the full path and the basename (lowercased), so `secrets/DB_PASSWORD.txt` and `deploy-key.pem` both trigger.

## Working CLI

`cmd/glsec/main.go` is now wired up with all five rules:

```
ERROR  file.yml:7   GL001  image "ubuntu:latest" uses mutable tag "latest" ...
WARN   file.yml:17  GL002  unquoted user-controlled variable $CI_COMMIT_REF_NAME ...
ERROR  file.yml:4   GL003  remote include "https://..." — URL content is mutable ...
WARN   file.yml:31  GL004  CI_JOB_TOKEN sent to non-GitLab host "external-service.com" ...
ERROR  file.yml:24  GL005  artifact path ".env.production" matches sensitive pattern ...
```

Exit codes: `0` = no findings, `1` = findings found, `2` = parse/usage error.

Also fixes `.gitignore`: `glsec` → `/glsec` so the pattern only matches the root binary, not the `cmd/glsec/` source directory.

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./cmd/glsec` succeeds
- [x] Demo run against a deliberately broken `.gitlab-ci.yml` produces 11 findings across all 5 rules