### PR TITLE
feat: CI pipeline, dependabot, linting, security, fixture validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go build ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test -race -coverprofile=coverage.out ./...
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  security:
+    name: Security (govulncheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: golang/govulncheck-action@v1
+
+  zizmor:
+    name: Security (zizmor)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zizmorcore/zizmor-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  validate-fixtures:
+    name: Validate GitLab CI fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install check-jsonschema
+      - name: Validate against GitLab CI schema
+        # Uses the SchemaStore GitLab CI JSON Schema (targets latest gitlab.com).
+        # Catches unknown keys, wrong types, and missing required fields.
+        # Does not validate runtime semantics (stage references, include resolution)
+        # or version-specific features — document minimum GitLab version in CONTRIBUTING.md.
+        run: check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - revive
+    - gosec
+    - misspell
+
+linters-settings:
+  gosec:
+    excludes:
+      - G304 # file path from variable — intentional, we read user-supplied .gitlab-ci.yml files
+
+run:
+  timeout: 5m

--- a/testdata/fixtures/clean.yml
+++ b/testdata/fixtures/clean.yml
@@ -1,0 +1,40 @@
+include:
+  - project: company/ci-templates
+    file: /jobs/security.yml
+    ref: v2.1.0
+
+stages:
+  - build
+  - test
+  - deploy
+
+variables:
+  NODE_VERSION: "20.11.0"
+
+build-job:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths:
+      - dist/
+    expire_in: 1 week
+
+test-job:
+  stage: test
+  image: node:20.11.0
+  script:
+    - npm test
+  coverage: '/Coverage: \d+\.\d+/'
+
+deploy-job:
+  stage: deploy
+  image: alpine:3.19
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/testdata/fixtures/gl001-mutable-images.yml
+++ b/testdata/fixtures/gl001-mutable-images.yml
@@ -1,0 +1,26 @@
+stages:
+  - build
+  - test
+
+build-job:
+  stage: build
+  image: node:latest
+  script:
+    - npm ci
+    - npm run build
+
+test-job:
+  stage: test
+  image: alpine
+  script:
+    - npm test
+
+docker-job:
+  stage: build
+  image: docker:24
+  services:
+    - docker:dind
+  variables:
+    DOCKER_TLS_CERTDIR: /certs
+  script:
+    - docker build -t myapp .

--- a/testdata/fixtures/gl002-variable-injection.yml
+++ b/testdata/fixtures/gl002-variable-injection.yml
@@ -1,0 +1,18 @@
+stages:
+  - test
+  - deploy
+
+test-job:
+  stage: test
+  image: node:20.11.0
+  script:
+    - echo $CI_COMMIT_REF_NAME
+    - npm test
+
+deploy-job:
+  stage: deploy
+  image: alpine:3.19
+  before_script:
+    - echo $CI_COMMIT_MESSAGE
+  script:
+    - ./deploy.sh $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME

--- a/testdata/fixtures/gl003-unpinned-includes.yml
+++ b/testdata/fixtures/gl003-unpinned-includes.yml
@@ -1,0 +1,24 @@
+include:
+  - project: company/ci-templates
+    file: /jobs/security.yml
+  - project: company/ci-templates
+    file: /jobs/deploy.yml
+    ref: main
+  - template: Security/SAST.gitlab-ci.yml
+
+stages:
+  - build
+  - test
+
+build-job:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build
+
+test-job:
+  stage: test
+  image: node:20.11.0
+  script:
+    - npm test

--- a/testdata/fixtures/gl004-job-token.yml
+++ b/testdata/fixtures/gl004-job-token.yml
@@ -1,0 +1,16 @@
+stages:
+  - build
+  - upload
+
+build-job:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build
+
+upload-job:
+  stage: upload
+  image: alpine:3.19
+  script:
+    - curl --header JOB-TOKEN=$CI_JOB_TOKEN https://external-registry.example.com/upload

--- a/testdata/fixtures/gl005-sensitive-artifacts.yml
+++ b/testdata/fixtures/gl005-sensitive-artifacts.yml
@@ -1,0 +1,14 @@
+stages:
+  - build
+
+build-job:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths:
+      - dist/
+      - .env.production
+      - deploy-key.pem


### PR DESCRIPTION
Closes #10

## Jobs

| Job | Tool | Purpose |
|-----|------|---------|
| Build | `go build` | Compilation check |
| Test | `go test -race` | Tests + race detector |
| Lint | golangci-lint | Code quality (`errcheck`, `govet`, `staticcheck`, `gosec`, `revive`, `misspell`) |
| Security | govulncheck | Known vulnerabilities in Go dependencies |
| Security | zizmor | Security analysis of the GitHub Actions workflows themselves |
| Validate fixtures | check-jsonschema | Ensures testdata fixtures are valid GitLab CI YAML |

## Dependabot
Weekly updates for Go modules and GitHub Actions versions.

## Fixture validation
`testdata/fixtures/*.yml` are validated against the [SchemaStore GitLab CI JSON Schema](https://www.schemastore.org/schemas/json/gitlab-ci.json) via `check-jsonschema --builtin-schema gitlab-ci`.

**What this catches:** unknown keys, wrong types, missing required fields, invalid enum values.

**What this does not catch:** runtime semantics (unresolvable `include:` references, non-existent stages), version-specific features. The schema targets the current gitlab.com version. Features gated behind a specific GitLab version should be documented in CONTRIBUTING.md when added.

All 5 current fixtures validated locally before merge.

## golangci-lint config
`.golangci.yml` excludes `gosec G304` (file path from variable) — intentional since glsec reads user-supplied `.gitlab-ci.yml` files by design.

## zizmor note
Uses `zizmorcore/zizmor-action@v1` with `GH_TOKEN` for richer analysis. If the action version changes, dependabot will send a PR.