### PR TITLE
fix: CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: zizmorcore/zizmor-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install zizmor
+        run: pip install zizmor
+      - name: Run zizmor
+        run: zizmor --gh-token "${{ secrets.GITHUB_TOKEN }}" .github/workflows/
 
   validate-fixtures:
     name: Validate GitLab CI fixtures

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -86,7 +86,7 @@ func TestEachJob(t *testing.T) {
 	doc, _ := Parse(sampleCI, "test.yml")
 
 	var jobs []string
-	EachJob(doc.Root, func(name *yaml.Node, job *yaml.Node) {
+	EachJob(doc.Root, func(name *yaml.Node, _ *yaml.Node) {
 		jobs = append(jobs, name.Value)
 	})
 
@@ -111,7 +111,7 @@ func TestEachJob_SkipsReservedKeys(t *testing.T) {
 func TestEachJob_LineNumbers(t *testing.T) {
 	doc, _ := Parse(sampleCI, "test.yml")
 
-	EachJob(doc.Root, func(name *yaml.Node, job *yaml.Node) {
+	EachJob(doc.Root, func(name *yaml.Node, _ *yaml.Node) {
 		if name.Line == 0 {
 			t.Errorf("job %q has zero line number", name.Value)
 		}


### PR DESCRIPTION
- Replace `zizmorcore/zizmor-action@v1` (tag doesn't exist) with `pip install zizmor`
- Rename unused `job` parameters to `_` in parser tests (revive lint)