### PR TITLE
fix: golangci-lint v2 config format + bump action to v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 linters:
   enable:
     - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,10 +8,6 @@ linters:
     - revive
     - gosec
     - misspell
-  settings:
-    gosec:
-      excludes:
-        - G304 # file path from variable — intentional, we read user-supplied .gitlab-ci.yml files
 
 run:
   timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,15 +5,13 @@ linters:
     - errcheck
     - govet
     - staticcheck
-    - unused
     - revive
     - gosec
     - misspell
-
-linters-settings:
-  gosec:
-    excludes:
-      - G304 # file path from variable — intentional, we read user-supplied .gitlab-ci.yml files
+  settings:
+    gosec:
+      excludes:
+        - G304 # file path from variable — intentional, we read user-supplied .gitlab-ci.yml files
 
 run:
   timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,13 @@ linters:
     - revive
     - gosec
     - misspell
+  settings:
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
 
 run:
   timeout: 5m

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -13,7 +13,7 @@ type Document struct {
 }
 
 func ParseFile(path string) (*Document, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // G304: intentional, reads user-supplied files
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}


### PR DESCRIPTION
golangci-lint-action v9 uses golangci-lint v2 which requires `version: "2"` in `.golangci.yml`. Also closes Dependabot PR #25.