### PR TITLE
feat: add --format flag with text, JSON, and SARIF output

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -1,22 +1,36 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/output"
 	"github.com/glsec/glsec/internal/parser"
 	"github.com/glsec/glsec/rules"
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: glsec <file>")
+	formatFlag := flag.String("format", "text", "output format: text, json, sarif")
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] <file>")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		flag.Usage()
 		os.Exit(2)
 	}
 
-	file := os.Args[1]
+	format, ok := output.ParseFormat(*formatFlag)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "unknown format %q — use text, json, or sarif\n", *formatFlag)
+		os.Exit(2)
+	}
+
+	file := flag.Arg(0)
 	doc, err := parser.ParseFile(file)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -28,13 +42,9 @@ func main() {
 		findings = append(findings, rule.Check(doc.Root, file)...)
 	}
 
-	for _, f := range findings {
-		fmt.Printf("%-6s %s:%d  %s  %s\n",
-			strings.ToUpper(string(f.Severity)),
-			f.File, f.Line,
-			f.RuleID,
-			f.Message,
-		)
+	if err := output.Write(os.Stdout, format, findings); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
 	}
 
 	if len(findings) > 0 {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,172 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+)
+
+type Format string
+
+const (
+	FormatText Format = "text"
+	FormatJSON Format = "json"
+	FormatSARIF Format = "sarif"
+)
+
+func ParseFormat(s string) (Format, bool) {
+	switch Format(s) {
+	case FormatText, FormatJSON, FormatSARIF:
+		return Format(s), true
+	default:
+		return "", false
+	}
+}
+
+func Write(w io.Writer, format Format, findings []finding.Finding) error {
+	switch format {
+	case FormatJSON:
+		return writeJSON(w, findings)
+	case FormatSARIF:
+		return writeSARIF(w, findings)
+	default:
+		return writeText(w, findings)
+	}
+}
+
+func writeText(w io.Writer, findings []finding.Finding) error {
+	for _, f := range findings {
+		_, err := fmt.Fprintf(w, "%-6s %s:%d  %s  %s\n",
+			strings.ToUpper(string(f.Severity)),
+			f.File, f.Line,
+			f.RuleID,
+			f.Message,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type jsonFinding struct {
+	Rule     string `json:"rule"`
+	Severity string `json:"severity"`
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Message  string `json:"message"`
+}
+
+type jsonOutput struct {
+	Findings []jsonFinding `json:"findings"`
+}
+
+func writeJSON(w io.Writer, findings []finding.Finding) error {
+	out := jsonOutput{Findings: make([]jsonFinding, 0, len(findings))}
+	for _, f := range findings {
+		out.Findings = append(out.Findings, jsonFinding{
+			Rule:     f.RuleID,
+			Severity: string(f.Severity),
+			File:     f.File,
+			Line:     f.Line,
+			Message:  f.Message,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// SARIF 2.1.0 types — minimal subset for Code Scanning / GitLab SAST.
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string `json:"name"`
+	InformationURI string `json:"informationUri"`
+}
+
+type sarifResult struct {
+	RuleID    string          `json:"ruleId"`
+	Level     string          `json:"level"`
+	Message   sarifMessage    `json:"message"`
+	Locations []sarifLocation `json:"locations"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           sarifRegion           `json:"region"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
+}
+
+func severityToSARIFLevel(s finding.Severity) string {
+	switch s {
+	case finding.Error:
+		return "error"
+	case finding.Warn:
+		return "warning"
+	default:
+		return "note"
+	}
+}
+
+func writeSARIF(w io.Writer, findings []finding.Finding) error {
+	results := make([]sarifResult, 0, len(findings))
+	for _, f := range findings {
+		results = append(results, sarifResult{
+			RuleID:  f.RuleID,
+			Level:   severityToSARIFLevel(f.Severity),
+			Message: sarifMessage{Text: f.Message},
+			Locations: []sarifLocation{{
+				PhysicalLocation: sarifPhysicalLocation{
+					ArtifactLocation: sarifArtifactLocation{URI: f.File},
+					Region:           sarifRegion{StartLine: f.Line},
+				},
+			}},
+		})
+	}
+	log := sarifLog{
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Version: "2.1.0",
+		Runs: []sarifRun{{
+			Tool: sarifTool{Driver: sarifDriver{
+				Name:           "glsec",
+				InformationURI: "https://github.com/glsec/glsec",
+			}},
+			Results: results,
+		}},
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(log)
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,124 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+)
+
+var testFindings = []finding.Finding{
+	{RuleID: "GL001", Severity: finding.Error, File: "ci.yml", Line: 4, Message: `Mutable image tag "node:latest"`},
+	{RuleID: "GL002", Severity: finding.Warn, File: "ci.yml", Line: 12, Message: "Unquoted variable $CI_COMMIT_REF_NAME"},
+}
+
+func TestWriteText(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatText, testFindings); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "ERROR") || !strings.Contains(got, "WARN") {
+		t.Errorf("missing severity labels: %q", got)
+	}
+	if !strings.Contains(got, "GL001") || !strings.Contains(got, "GL002") {
+		t.Errorf("missing rule IDs: %q", got)
+	}
+	if !strings.Contains(got, "ci.yml:4") {
+		t.Errorf("missing file:line: %q", got)
+	}
+}
+
+func TestWriteText_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatText, nil); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for no findings, got %q", buf.String())
+	}
+}
+
+func TestWriteJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatJSON, testFindings); err != nil {
+		t.Fatal(err)
+	}
+	var out jsonOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(out.Findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(out.Findings))
+	}
+	f := out.Findings[0]
+	if f.Rule != "GL001" || f.Severity != "error" || f.File != "ci.yml" || f.Line != 4 {
+		t.Errorf("unexpected first finding: %+v", f)
+	}
+}
+
+func TestWriteJSON_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatJSON, nil); err != nil {
+		t.Fatal(err)
+	}
+	var out jsonOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(out.Findings) != 0 {
+		t.Errorf("expected empty findings array, got %d", len(out.Findings))
+	}
+}
+
+func TestWriteSARIF(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatSARIF, testFindings); err != nil {
+		t.Fatal(err)
+	}
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid SARIF JSON: %v", err)
+	}
+	if log.Version != "2.1.0" {
+		t.Errorf("expected SARIF version 2.1.0, got %q", log.Version)
+	}
+	if len(log.Runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(log.Runs))
+	}
+	results := log.Runs[0].Results
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].RuleID != "GL001" || results[0].Level != "error" {
+		t.Errorf("unexpected first result: %+v", results[0])
+	}
+	if results[1].Level != "warning" {
+		t.Errorf("expected warning level for WARN, got %q", results[1].Level)
+	}
+	loc := results[0].Locations[0].PhysicalLocation
+	if loc.ArtifactLocation.URI != "ci.yml" || loc.Region.StartLine != 4 {
+		t.Errorf("unexpected location: %+v", loc)
+	}
+}
+
+func TestParseFormat(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want Format
+		ok   bool
+	}{
+		{"text", FormatText, true},
+		{"json", FormatJSON, true},
+		{"sarif", FormatSARIF, true},
+		{"xml", "", false},
+		{"", "", false},
+	} {
+		got, ok := ParseFormat(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("ParseFormat(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}


### PR DESCRIPTION
Closes #9

## What changed

Adds `--format` flag to `glsec` supporting three output modes:

- **`text`** (default) — existing human-readable output, unchanged
- **`json`** — machine-readable `{"findings": [...]}` object, each finding has `rule`, `severity`, `file`, `line`, `message`
- **`sarif`** — SARIF 2.1.0 format for GitHub Code Scanning and GitLab SAST integration; severity maps `error→error`, `warn→warning`, `info→note`

## Structure

- `internal/output/output.go` — `Write(w, format, findings)` + `ParseFormat(s)` for validation
- `cmd/glsec/main.go` — wired up via `flag.String("format", "text", ...)`; invalid format exits 2

## How to test

```sh
glsec testdata/fixtures/gl001-mutable-images.yml
glsec --format json testdata/fixtures/gl001-mutable-images.yml
glsec --format sarif testdata/fixtures/gl001-mutable-images.yml
glsec --format invalid testdata/fixtures/gl001-mutable-images.yml  # → exit 2 + error message
```

Unit tests in `internal/output/output_test.go` cover all three formats, empty findings, and `ParseFormat` validation.