### PR TITLE
feat: release automation with GoReleaser and --version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,49 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./cmd/glsec
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+      - "Merge pull request"
+      - "Merge branch"
+
+release:
+  draft: false
+  prerelease: auto

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -11,13 +11,26 @@ import (
 	"github.com/glsec/glsec/rules"
 )
 
+// Set via ldflags at build time by GoReleaser.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	formatFlag := flag.String("format", "text", "output format: text, json, sarif")
+	versionFlag := flag.Bool("version", false, "print version and exit")
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] <file>")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Printf("glsec %s (commit %s, built %s)\n", version, commit, date)
+		return
+	}
 
 	if flag.NArg() < 1 {
 		flag.Usage()


### PR DESCRIPTION
Closes #32, closes #33

## What changed

### `.goreleaser.yml`
- Builds for Linux, macOS, Windows × amd64 + arm64 (6 binaries per release)
- `CGO_ENABLED=0` — fully static binaries, no libc dependency
- ldflags inject `version`, `commit` (short SHA), `date` at build time
- Archives: `.tar.gz` for Unix, `.zip` for Windows
- SHA256 `checksums.txt` included in every release
- Changelog auto-generated from commits, filtered to feat/fix/perf (excludes docs/chore/test)
- `prerelease: auto` — tags like `v1.0.0-rc.1` become pre-releases automatically

### `.github/workflows/release.yml`
- Triggered on `v*` tag pushes
- `permissions: contents: write` (minimum needed for release creation)
- All actions pinned to commit SHAs (zizmor clean)
- `cache: false` on setup-go — avoids cache-poisoning in release context (zizmor `cache-poisoning` finding)
- `fetch-depth: 0` — GoReleaser needs full git history for changelog generation

### `cmd/glsec/main.go`
- Added `var version, commit, date` package-level vars (set to `dev`/`none`/`unknown` when built without ldflags)
- Added `--version` flag: `glsec dev (commit none, built unknown)` locally, real values in releases

## How to release

```sh
git tag v0.1.0
git push origin v0.1.0
```

The release workflow runs automatically and publishes binaries + checksums to GitHub Releases.

## How to test locally

```sh
go run ./cmd/glsec --version
# glsec dev (commit none, built unknown)

goreleaser release --snapshot --clean   # local dry-run, no GitHub publish
```