### PR TITLE
feat: input validation for file structure and GitLab CI content

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/output"
 	"github.com/glsec/glsec/internal/parser"
+	"github.com/glsec/glsec/internal/validate"
 	"github.com/glsec/glsec/rules"
 )
 
@@ -47,6 +48,15 @@ func main() {
 	doc, err := parser.ParseFile(file)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
+	warns, valErr := validate.File(file, doc)
+	for _, w := range warns {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+	if valErr != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", valErr)
 		os.Exit(2)
 	}
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,71 @@
+package validate
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+// File validates that path is a plausible GitLab CI file.
+// It returns any warnings (non-fatal) and a fatal error if the file
+// cannot be linted meaningfully.
+func File(path string, doc *parser.Document) (warnings []string, err error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".yml" && ext != ".yaml" {
+		warnings = append(warnings, fmt.Sprintf("%s: file does not have a .yml or .yaml extension", path))
+	}
+
+	mapping := doc.MappingNode()
+	if mapping.Kind != yaml.MappingNode {
+		return warnings, fmt.Errorf("%s: not a valid GitLab CI file: expected a top-level mapping", path)
+	}
+
+	if !hasGitLabContent(mapping) {
+		return warnings, fmt.Errorf("%s: not a valid GitLab CI file: no recognisable GitLab CI content", path)
+	}
+
+	return warnings, nil
+}
+
+// knownKeys are GitLab CI reserved top-level keys that are not job definitions.
+var knownKeys = map[string]bool{
+	"stages":        true,
+	"variables":     true,
+	"default":       true,
+	"workflow":      true,
+	"include":       true,
+	"image":         true,
+	"services":      true,
+	"cache":         true,
+	"before_script": true,
+	"after_script":  true,
+}
+
+// hasGitLabContent returns true if the mapping contains at least one known
+// top-level GitLab CI key or at least one job-like entry (mapping with a
+// "script" key).
+func hasGitLabContent(mapping *yaml.Node) bool {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := mapping.Content[i].Value
+		val := mapping.Content[i+1]
+		if knownKeys[key] {
+			return true
+		}
+		if val.Kind == yaml.MappingNode && hasKey(val, "script") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasKey(mapping *yaml.Node, key string) bool {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,102 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func parse(t *testing.T, src string) *parser.Document {
+	t.Helper()
+	doc, err := parser.Parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return doc
+}
+
+func TestFile_ValidGitLabCI(t *testing.T) {
+	doc := parse(t, `
+stages: [build]
+build:
+  script: [make]
+`)
+	warns, err := File("test.yml", doc)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("unexpected warnings: %v", warns)
+	}
+}
+
+func TestFile_ExtensionWarning(t *testing.T) {
+	doc := parse(t, `
+stages: [build]
+build:
+  script: [make]
+`)
+	warns, err := File("pipeline", doc)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warns) == 0 {
+		t.Error("expected extension warning")
+	}
+}
+
+func TestFile_YamlExtension(t *testing.T) {
+	doc := parse(t, `stages: [build]`)
+	warns, err := File("ci.yaml", doc)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("unexpected warnings for .yaml extension: %v", warns)
+	}
+}
+
+func TestFile_NotAMapping(t *testing.T) {
+	// A YAML list at the top level is not a valid GitLab CI file.
+	doc, err := parser.Parse([]byte("- item1\n- item2\n"), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	_, valErr := File("test.yml", doc)
+	if valErr == nil {
+		t.Error("expected error for non-mapping top-level")
+	}
+}
+
+func TestFile_NoGitLabContent(t *testing.T) {
+	doc := parse(t, `
+foo: bar
+baz: qux
+`)
+	_, err := File("test.yml", doc)
+	if err == nil {
+		t.Error("expected error for file with no GitLab CI content")
+	}
+}
+
+func TestFile_KnownKeyIsEnough(t *testing.T) {
+	for _, key := range []string{"stages", "variables", "include", "default", "workflow"} {
+		doc := parse(t, key+": []\n")
+		_, err := File("test.yml", doc)
+		if err != nil {
+			t.Errorf("key %q should be recognised as GitLab CI content: %v", key, err)
+		}
+	}
+}
+
+func TestFile_JobWithScriptIsEnough(t *testing.T) {
+	doc := parse(t, `
+my-job:
+  script:
+    - echo hello
+`)
+	_, err := File("test.yml", doc)
+	if err != nil {
+		t.Errorf("job with script should be recognised: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #35

## What changed

New `internal/validate` package with `File(path, doc)` that runs before security rules and exits 2 on fatal problems.

**Checks in order:**

| Check | Behaviour |
|-------|-----------|
| Extension not `.yml`/`.yaml` | warning to stderr, continues |
| Top-level node is not a YAML mapping | error → exit 2 |
| No recognisable GitLab CI content | error → exit 2 |

"Recognisable content" means at least one known top-level key (`stages`, `variables`, `include`, `default`, `workflow`, `image`, `services`, `cache`, `before_script`, `after_script`) OR at least one job-like entry (mapping value containing a `script:` key).

Empty files and invalid YAML were already caught by the parser and remain unchanged.

## Example output

```
$ glsec notayaml.txt
warning: notayaml.txt: file does not have a .yml or .yaml extension
error: notayaml.txt: not a valid GitLab CI file: no recognisable GitLab CI content

$ echo "- item" | glsec /dev/stdin
error: /dev/stdin: not a valid GitLab CI file: expected a top-level mapping
```