### PR TITLE
feat: .glsec.yml config file with rule overrides and min-severity

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/glsec/glsec/internal/config"
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/output"
 	"github.com/glsec/glsec/internal/parser"
@@ -21,9 +22,10 @@ var (
 
 func main() {
 	formatFlag := flag.String("format", "text", "output format: text, json, sarif")
+	configFlag := flag.String("config", config.DefaultFile, "path to .glsec.yml config file")
 	versionFlag := flag.Bool("version", false, "print version and exit")
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] <file>")
+		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] [--config .glsec.yml] <file>")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -41,6 +43,12 @@ func main() {
 	format, ok := output.ParseFormat(*formatFlag)
 	if !ok {
 		fmt.Fprintf(os.Stderr, "unknown format %q — use text, json, or sarif\n", *formatFlag)
+		os.Exit(2)
+	}
+
+	cfg, err := config.Load(*configFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(2)
 	}
 
@@ -62,7 +70,15 @@ func main() {
 
 	var findings []finding.Finding
 	for _, rule := range rules.All() {
-		findings = append(findings, rule.Check(doc.Root, file)...)
+		if !cfg.RuleEnabled(rule.ID()) {
+			continue
+		}
+		for _, f := range rule.Check(doc.Root, file) {
+			f = cfg.ApplySeverity(f)
+			if cfg.AboveMinSeverity(f) {
+				findings = append(findings, f)
+			}
+		}
 	}
 
 	if err := output.Write(os.Stdout, format, findings); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+const DefaultFile = ".glsec.yml"
+
+// Config holds the parsed contents of a .glsec.yml file.
+type Config struct {
+	// Rules maps rule ID to a severity override or "off".
+	Rules map[string]string `yaml:"rules"`
+	// MinSeverity filters out findings below this level.
+	MinSeverity string `yaml:"min-severity"`
+}
+
+// Default returns a Config with no overrides.
+func Default() *Config {
+	return &Config{
+		Rules:       map[string]string{},
+		MinSeverity: "",
+	}
+}
+
+// Load reads and parses a config file. Returns Default() if the file does not
+// exist and path is the default filename.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: user-supplied config path
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && path == DefaultFile {
+			return Default(), nil
+		}
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	return parse(data, path)
+}
+
+func parse(data []byte, path string) (*Config, error) {
+	// Decode into a raw node first so we can detect unknown keys.
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if root.Kind == 0 {
+		return Default(), nil
+	}
+
+	mapping := &root
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		mapping = root.Content[0]
+	}
+	if mapping.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("%s: config must be a YAML mapping", path)
+	}
+
+	if err := checkUnknownKeys(mapping, path); err != nil {
+		return nil, err
+	}
+
+	var cfg Config
+	if err := root.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if cfg.Rules == nil {
+		cfg.Rules = map[string]string{}
+	}
+
+	if err := cfg.validate(path); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+var allowedTopLevelKeys = map[string]bool{
+	"rules":        true,
+	"min-severity": true,
+}
+
+func checkUnknownKeys(mapping *yaml.Node, path string) error {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := mapping.Content[i].Value
+		if !allowedTopLevelKeys[key] {
+			return fmt.Errorf("%s:%d: unknown config key %q", path, mapping.Content[i].Line, key)
+		}
+	}
+	return nil
+}
+
+var validSeverities = map[string]bool{
+	"error": true,
+	"warn":  true,
+	"info":  true,
+	"off":   true,
+}
+
+func (c *Config) validate(path string) error {
+	for id, sev := range c.Rules {
+		if !strings.HasPrefix(id, "GL") {
+			return fmt.Errorf("%s: rules: invalid rule ID %q (must start with GL)", path, id)
+		}
+		if !validSeverities[sev] {
+			return fmt.Errorf("%s: rules.%s: invalid severity %q (use error, warn, info, or off)", path, id, sev)
+		}
+	}
+	if c.MinSeverity != "" {
+		if !validSeverities[c.MinSeverity] || c.MinSeverity == "off" {
+			return fmt.Errorf("%s: min-severity: invalid value %q (use error, warn, or info)", path, c.MinSeverity)
+		}
+	}
+	return nil
+}
+
+// RuleEnabled returns false if the rule is set to "off" in the config.
+func (c *Config) RuleEnabled(id string) bool {
+	sev, ok := c.Rules[id]
+	return !ok || sev != "off"
+}
+
+// ApplySeverity returns the effective severity for a finding, applying any
+// rule-level override from the config.
+func (c *Config) ApplySeverity(f finding.Finding) finding.Finding {
+	sev, ok := c.Rules[f.RuleID]
+	if !ok || sev == "off" {
+		return f
+	}
+	f.Severity = finding.Severity(sev)
+	return f
+}
+
+// severityLevel maps severity to a comparable integer (higher = more severe).
+var severityLevel = map[finding.Severity]int{
+	finding.Error: 3,
+	finding.Warn:  2,
+	finding.Info:  1,
+}
+
+// AboveMinSeverity returns true if f meets or exceeds the configured
+// min-severity. If min-severity is unset, all findings pass.
+func (c *Config) AboveMinSeverity(f finding.Finding) bool {
+	if c.MinSeverity == "" {
+		return true
+	}
+	min := severityLevel[finding.Severity(c.MinSeverity)]
+	return severityLevel[f.Severity] >= min
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+)
+
+func parseStr(t *testing.T, src string) *Config {
+	t.Helper()
+	cfg, err := parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	return cfg
+}
+
+func TestDefault(t *testing.T) {
+	cfg := Default()
+	if !cfg.RuleEnabled("GL001") {
+		t.Error("GL001 should be enabled by default")
+	}
+	if !cfg.AboveMinSeverity(finding.Finding{Severity: finding.Info}) {
+		t.Error("info should pass with no min-severity set")
+	}
+}
+
+func TestLoad_MissingDefaultFile(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	_ = os.Chdir(dir)
+	defer func() { _ = os.Chdir(orig) }()
+
+	cfg, err := Load(DefaultFile)
+	if err != nil {
+		t.Fatalf("expected no error for missing default config: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+}
+
+func TestLoad_ExplicitMissing(t *testing.T) {
+	_, err := Load("/nonexistent/.glsec.yml")
+	if err == nil {
+		t.Error("expected error for missing explicit config path")
+	}
+}
+
+func TestParse_RuleOff(t *testing.T) {
+	cfg := parseStr(t, `
+rules:
+  GL001: off
+  GL002: warn
+`)
+	if cfg.RuleEnabled("GL001") {
+		t.Error("GL001 should be disabled")
+	}
+	if !cfg.RuleEnabled("GL002") {
+		t.Error("GL002 should be enabled")
+	}
+	if !cfg.RuleEnabled("GL003") {
+		t.Error("GL003 not in config — should be enabled")
+	}
+}
+
+func TestParse_SeverityOverride(t *testing.T) {
+	cfg := parseStr(t, `rules:
+  GL001: warn
+`)
+	f := finding.Finding{RuleID: "GL001", Severity: finding.Error}
+	got := cfg.ApplySeverity(f)
+	if got.Severity != finding.Warn {
+		t.Errorf("expected warn, got %s", got.Severity)
+	}
+}
+
+func TestParse_MinSeverity(t *testing.T) {
+	cfg := parseStr(t, `min-severity: error`)
+	if cfg.AboveMinSeverity(finding.Finding{Severity: finding.Warn}) {
+		t.Error("warn should be filtered by min-severity: error")
+	}
+	if !cfg.AboveMinSeverity(finding.Finding{Severity: finding.Error}) {
+		t.Error("error should pass min-severity: error")
+	}
+}
+
+func TestParse_UnknownKey(t *testing.T) {
+	_, err := parse([]byte("unknown-key: value\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for unknown top-level key")
+	}
+}
+
+func TestParse_InvalidRuleID(t *testing.T) {
+	_, err := parse([]byte("rules:\n  BADID: off\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for invalid rule ID")
+	}
+}
+
+func TestParse_InvalidSeverity(t *testing.T) {
+	_, err := parse([]byte("rules:\n  GL001: critical\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for invalid severity")
+	}
+}
+
+func TestParse_InvalidMinSeverity(t *testing.T) {
+	_, err := parse([]byte("min-severity: off\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for min-severity: off")
+	}
+}
+
+func TestParse_Empty(t *testing.T) {
+	cfg, err := parse([]byte(""), "test.yml")
+	if err != nil {
+		t.Fatalf("empty config should be valid: %v", err)
+	}
+	if !cfg.RuleEnabled("GL001") {
+		t.Error("empty config should enable all rules")
+	}
+}
+
+func TestLoad_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("rules:\n  GL001: off\nmin-severity: warn\n")
+	path := filepath.Join(dir, ".glsec.yml")
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RuleEnabled("GL001") {
+		t.Error("GL001 should be off")
+	}
+	if cfg.MinSeverity != "warn" {
+		t.Errorf("expected min-severity warn, got %q", cfg.MinSeverity)
+	}
+}


### PR DESCRIPTION
Closes #36, closes #38

## What changed

New `internal/config` package and `--config` flag.

### Config file lookup

1. `--config path/to/.glsec.yml` (explicit)
2. `.glsec.yml` in the current directory (automatic)
3. Neither found → defaults apply (all rules on, no severity filter)

### Schema

```yaml
# .glsec.yml
rules:
  GL001: off        # disable entirely
  GL004: warn       # downgrade from error to warn

min-severity: warn  # filter out info findings
```

**Severities:** `error`, `warn`, `info`, `off`  
**`min-severity`** accepts `error`, `warn`, `info` (not `off`)

Unknown top-level keys and invalid rule IDs/severities are rejected with a clear error message and exit 2.

### Integration in main.go

- Rules set to `off` are skipped before `Check()` is called
- Severity overrides are applied per-finding after `Check()`
- `min-severity` filters findings after overrides are applied

## How to test

```sh
# Disable GL001
echo "rules:\n  GL001: off" > .glsec.yml
glsec testdata/fixtures/gl001-mutable-images.yml   # → exit 0, no findings

# Only show errors
echo "min-severity: error" > .glsec.yml
glsec testdata/fixtures/gl002-variable-injection.yml  # GL002 is warn → filtered out

# Unknown key
echo "unknown: true" > .glsec.yml
glsec .gitlab-ci.yml   # → error: unknown config key "unknown"
```