### PR TITLE
feat: inline rule suppression with optional reason

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/output"
 	"github.com/glsec/glsec/internal/parser"
+	"github.com/glsec/glsec/internal/suppress"
 	"github.com/glsec/glsec/internal/validate"
 	"github.com/glsec/glsec/rules"
 )
@@ -78,12 +79,17 @@ func main() {
 		os.Exit(2)
 	}
 
+	suppressMap := suppress.Build(doc.Root)
+
 	var findings []finding.Finding
 	for _, rule := range rules.All() {
 		if !cfg.RuleEnabled(rule.ID()) {
 			continue
 		}
 		for _, f := range rule.Check(doc.Root, file) {
+			if suppressMap.IsSuppressed(f.Line, f.RuleID) {
+				continue
+			}
 			f = cfg.ApplySeverity(f)
 			if cfg.AboveMinSeverity(f) {
 				findings = append(findings, f)

--- a/internal/suppress/suppress.go
+++ b/internal/suppress/suppress.go
@@ -1,0 +1,75 @@
+package suppress
+
+import (
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// pattern matches:  # glsec:ignore GL001
+//                   # glsec:ignore GL001 -- approved, updated monthly
+var pattern = regexp.MustCompile(`glsec:ignore\s+(GL\d{3})(?:\s+--\s+(.+))?`)
+
+// Suppression records a single inline suppression parsed from a YAML comment.
+type Suppression struct {
+	RuleID string
+	Reason string // empty when no reason was given
+	Line   int
+}
+
+// FromNode extracts all suppressions declared in the comments attached to node.
+// yaml.v3 attaches inline comments (# …) to the node as LineComment.
+func FromNode(node *yaml.Node) []Suppression {
+	return fromComment(node.LineComment, node.Line)
+}
+
+func fromComment(comment string, line int) []Suppression {
+	if comment == "" {
+		return nil
+	}
+	var out []Suppression
+	for _, match := range pattern.FindAllStringSubmatch(comment, -1) {
+		s := Suppression{RuleID: match[1], Line: line}
+		if len(match) > 2 {
+			s.Reason = strings.TrimSpace(match[2])
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// Map builds a lookup from (line → set of suppressed rule IDs) for an entire
+// YAML document tree. Call this once per document, then use IsSuppressed.
+type Map map[int]map[string]string // line → ruleID → reason
+
+// Build walks the node tree and collects all inline suppressions.
+func Build(root *yaml.Node) Map {
+	m := make(Map)
+	walk(root, m)
+	return m
+}
+
+func walk(node *yaml.Node, m Map) {
+	if node == nil {
+		return
+	}
+	for _, s := range fromComment(node.LineComment, node.Line) {
+		if m[s.Line] == nil {
+			m[s.Line] = make(map[string]string)
+		}
+		m[s.Line][s.RuleID] = s.Reason
+	}
+	for _, child := range node.Content {
+		walk(child, m)
+	}
+}
+
+// IsSuppressed returns true when ruleID is suppressed on the given line.
+func (m Map) IsSuppressed(line int, ruleID string) bool {
+	if rules, ok := m[line]; ok {
+		_, suppressed := rules[ruleID]
+		return suppressed
+	}
+	return false
+}

--- a/internal/suppress/suppress_test.go
+++ b/internal/suppress/suppress_test.go
@@ -1,0 +1,94 @@
+package suppress
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func parseNode(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &root); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return &root
+}
+
+func TestFromComment_Basic(t *testing.T) {
+	sups := fromComment("# glsec:ignore GL001", 5)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if sups[0].RuleID != "GL001" {
+		t.Errorf("expected GL001, got %q", sups[0].RuleID)
+	}
+	if sups[0].Reason != "" {
+		t.Errorf("expected no reason, got %q", sups[0].Reason)
+	}
+}
+
+func TestFromComment_WithReason(t *testing.T) {
+	sups := fromComment("# glsec:ignore GL002 -- approved by security team", 10)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if sups[0].Reason != "approved by security team" {
+		t.Errorf("unexpected reason: %q", sups[0].Reason)
+	}
+}
+
+func TestFromComment_Empty(t *testing.T) {
+	if sups := fromComment("", 1); len(sups) != 0 {
+		t.Errorf("expected no suppressions from empty comment")
+	}
+}
+
+func TestFromComment_NoMatch(t *testing.T) {
+	if sups := fromComment("# just a regular comment", 1); len(sups) != 0 {
+		t.Errorf("expected no suppressions")
+	}
+}
+
+func TestBuild_IsSuppressed(t *testing.T) {
+	src := `
+build:
+  image: node:latest  # glsec:ignore GL001 -- updated monthly via Renovate
+  script:
+    - npm ci
+`
+	root := parseNode(t, src)
+	m := Build(root)
+
+	// Find the line with the image node — it should have the suppression
+	found := false
+	for line, rules := range m {
+		if _, ok := rules["GL001"]; ok {
+			found = true
+			if !m.IsSuppressed(line, "GL001") {
+				t.Errorf("GL001 should be suppressed on line %d", line)
+			}
+			if m.IsSuppressed(line, "GL002") {
+				t.Errorf("GL002 should NOT be suppressed on line %d", line)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected GL001 suppression to be found in document")
+	}
+}
+
+func TestBuild_EmptyDocument(t *testing.T) {
+	root := parseNode(t, "stages: [build]\n")
+	m := Build(root)
+	if m.IsSuppressed(1, "GL001") {
+		t.Error("nothing should be suppressed in a document without ignore comments")
+	}
+}
+
+func TestIsSuppressed_MissingLine(t *testing.T) {
+	m := Map{}
+	if m.IsSuppressed(99, "GL001") {
+		t.Error("should not be suppressed on a line not in the map")
+	}
+}


### PR DESCRIPTION
Closes #37

## What changed

New `internal/suppress` package. Findings on a line with a `# glsec:ignore GLNNN` comment are silently dropped before output.

### Syntax

```yaml
image: node:latest  # glsec:ignore GL001
script:
  - echo $CI_COMMIT_REF_NAME  # glsec:ignore GL002 -- quoted in downstream script
```

- Format: `# glsec:ignore <RULE-ID> [-- <reason>]`
- Reason is optional, free-form text, no validation
- Multiple suppressions on one line are supported (multiple `glsec:ignore` tokens)
- Only suppresses the specific rule on that specific line — other rules and other lines are unaffected

### Implementation

`suppress.Build(root)` walks the YAML node tree once and builds a `map[line → map[ruleID → reason]]` from all `LineComment` fields. `suppress.Map.IsSuppressed(line, ruleID)` is then used in the main loop to skip matching findings. The reason is parsed and stored but currently only used internally (groundwork for a future `--show-suppressed` flag).

### How to test

```sh
# With suppression comment → exit 0
echo 'stages: [build]\nbuild:\n  image: node:latest  # glsec:ignore GL001\n  script: [npm ci]' > /tmp/t.yml
glsec /tmp/t.yml

# Without comment → exit 1, finding reported
glsec testdata/fixtures/gl001-mutable-images.yml
```