### PR TITLE
feat: GitLab version awareness (#50)

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/glsec/glsec/internal/parser"
 	"github.com/glsec/glsec/internal/suppress"
 	"github.com/glsec/glsec/internal/validate"
+	gitlabver "github.com/glsec/glsec/internal/version"
 	"github.com/glsec/glsec/rules"
 )
 
@@ -25,8 +26,9 @@ func main() {
 	formatFlag := flag.String("format", "text", "output format: text, json, sarif")
 	configFlag := flag.String("config", config.DefaultFile, "path to .glsec.yml config file")
 	versionFlag := flag.Bool("version", false, "print version and exit")
+	gitlabVersionFlag := flag.String("gitlab-version", "", "target GitLab version, e.g. 16.0 (skips rules not available in that version)")
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] [--config .glsec.yml] [file]")
+		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] [--config .glsec.yml] [--gitlab-version 16.0] [file]")
 		fmt.Fprintln(os.Stderr, "       If no file is given, glsec looks for .gitlab-ci.yml in the current directory.")
 		flag.PrintDefaults()
 	}
@@ -52,6 +54,20 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(2)
+	}
+
+	// --gitlab-version flag overrides the config file value.
+	gitlabVersionStr := cfg.GitLabVersion
+	if *gitlabVersionFlag != "" {
+		gitlabVersionStr = *gitlabVersionFlag
+	}
+	gitlabVersion, err := gitlabver.Parse(gitlabVersionStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: --gitlab-version: %v\n", err)
+		os.Exit(2)
+	}
+	if !gitlabVersion.IsZero() && !gitlabVersion.AtLeast(gitlabver.Minimum) {
+		fmt.Fprintf(os.Stderr, "warning: gitlab-version %s is below the minimum supported version %s\n", gitlabVersion, gitlabver.Minimum)
 	}
 
 	file := flag.Arg(0)
@@ -84,6 +100,9 @@ func main() {
 	var findings []finding.Finding
 	for _, rule := range rules.All() {
 		if !cfg.RuleEnabled(rule.ID()) {
+			continue
+		}
+		if !rules.EnabledFor(rule.ID(), gitlabVersion) {
 			continue
 		}
 		for _, f := range rule.Check(doc.Root, file) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/version"
 	"gopkg.in/yaml.v3"
 )
 
@@ -18,6 +19,9 @@ type Config struct {
 	Rules map[string]string `yaml:"rules"`
 	// MinSeverity filters out findings below this level.
 	MinSeverity string `yaml:"min-severity"`
+	// GitLabVersion is the target GitLab version (e.g. "16.0").
+	// Rules requiring a higher version are skipped.
+	GitLabVersion string `yaml:"gitlab-version"`
 }
 
 // Default returns a Config with no overrides.
@@ -78,8 +82,9 @@ func parse(data []byte, path string) (*Config, error) {
 }
 
 var allowedTopLevelKeys = map[string]bool{
-	"rules":        true,
-	"min-severity": true,
+	"rules":          true,
+	"min-severity":   true,
+	"gitlab-version": true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {
@@ -111,6 +116,11 @@ func (c *Config) validate(path string) error {
 	if c.MinSeverity != "" {
 		if !validSeverities[c.MinSeverity] || c.MinSeverity == "off" {
 			return fmt.Errorf("%s: min-severity: invalid value %q (use error, warn, or info)", path, c.MinSeverity)
+		}
+	}
+	if c.GitLabVersion != "" {
+		if _, err := version.Parse(c.GitLabVersion); err != nil {
+			return fmt.Errorf("%s: gitlab-version: %w", path, err)
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -125,6 +125,27 @@ func TestParse_Empty(t *testing.T) {
 	}
 }
 
+func TestParse_GitLabVersion_Valid(t *testing.T) {
+	cfg := parseStr(t, `gitlab-version: "16.0"`)
+	if cfg.GitLabVersion != "16.0" {
+		t.Errorf("expected 16.0, got %q", cfg.GitLabVersion)
+	}
+}
+
+func TestParse_GitLabVersion_Invalid(t *testing.T) {
+	_, err := parse([]byte("gitlab-version: abc\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for invalid gitlab-version")
+	}
+}
+
+func TestParse_GitLabVersion_Absent(t *testing.T) {
+	cfg := parseStr(t, `min-severity: warn`)
+	if cfg.GitLabVersion != "" {
+		t.Errorf("expected empty gitlab-version, got %q", cfg.GitLabVersion)
+	}
+}
+
 func TestLoad_FromFile(t *testing.T) {
 	dir := t.TempDir()
 	content := []byte("rules:\n  GL001: off\nmin-severity: warn\n")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,54 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version represents a GitLab major.minor version.
+// The zero value means "unset / latest" — no version gating.
+type Version struct {
+	Major int
+	Minor int
+}
+
+// Minimum is the lowest GitLab version glsec officially supports.
+var Minimum = Version{Major: 15, Minor: 0}
+
+// IsZero returns true for the zero value (unset / latest).
+func (v Version) IsZero() bool { return v.Major == 0 && v.Minor == 0 }
+
+// AtLeast returns true if v is greater than or equal to other.
+func (v Version) AtLeast(other Version) bool {
+	if v.Major != other.Major {
+		return v.Major > other.Major
+	}
+	return v.Minor >= other.Minor
+}
+
+// String returns "MAJOR.MINOR".
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+// Parse parses a version string like "16.0", "15.7", or "16" (minor defaults to 0).
+func Parse(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return Version{}, nil
+	}
+	parts := strings.SplitN(s, ".", 2)
+	major, err := strconv.Atoi(parts[0])
+	if err != nil || major < 1 {
+		return Version{}, fmt.Errorf("invalid GitLab version %q: major must be a positive integer", s)
+	}
+	minor := 0
+	if len(parts) == 2 {
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil || minor < 0 {
+			return Version{}, fmt.Errorf("invalid GitLab version %q: minor must be a non-negative integer", s)
+		}
+	}
+	return Version{Major: major, Minor: minor}, nil
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,59 @@
+package version
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    Version
+		wantErr bool
+	}{
+		{"16.0", Version{16, 0}, false},
+		{"15.7", Version{15, 7}, false},
+		{"16", Version{16, 0}, false},
+		{"", Version{}, false},
+		{"abc", Version{}, true},
+		{"16.x", Version{}, true},
+		{"0.1", Version{}, true},
+		{"-1.0", Version{}, true},
+	}
+	for _, tc := range cases {
+		got, err := Parse(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("Parse(%q) error = %v, wantErr %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if !tc.wantErr && got != tc.want {
+			t.Errorf("Parse(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestAtLeast(t *testing.T) {
+	cases := []struct {
+		v, other Version
+		want     bool
+	}{
+		{Version{16, 0}, Version{15, 7}, true},
+		{Version{15, 7}, Version{15, 7}, true},
+		{Version{15, 6}, Version{15, 7}, false},
+		{Version{14, 9}, Version{15, 0}, false},
+		{Version{17, 0}, Version{16, 11}, true},
+	}
+	for _, tc := range cases {
+		got := tc.v.AtLeast(tc.other)
+		if got != tc.want {
+			t.Errorf("%v.AtLeast(%v) = %v, want %v", tc.v, tc.other, got, tc.want)
+		}
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	zero := Version{}
+	if !zero.IsZero() {
+		t.Error("zero value should be zero")
+	}
+	if (Version{15, 0}).IsZero() {
+		t.Error("15.0 should not be zero")
+	}
+}

--- a/rules/versions.go
+++ b/rules/versions.go
@@ -1,0 +1,24 @@
+package rules
+
+import "github.com/glsec/glsec/internal/version"
+
+// minVersions maps rule IDs to the minimum GitLab version that introduced
+// the feature the rule checks. Rules not listed here have no version gate.
+var minVersions = map[string]version.Version{
+	"GL009": {Major: 15, Minor: 7}, // id_tokens:
+	"GL010": {Major: 14, Minor: 9}, // trigger: forward:
+	"GL014": {Major: 12, Minor: 9}, // artifacts: reports: dotenv:
+}
+
+// EnabledFor returns true if rule id should run against the given GitLab
+// version. A zero version (unset) always returns true.
+func EnabledFor(id string, v version.Version) bool {
+	if v.IsZero() {
+		return true
+	}
+	min, ok := minVersions[id]
+	if !ok {
+		return true
+	}
+	return v.AtLeast(min)
+}

--- a/rules/versions_test.go
+++ b/rules/versions_test.go
@@ -1,0 +1,31 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/version"
+)
+
+func TestEnabledFor(t *testing.T) {
+	cases := []struct {
+		id   string
+		v    version.Version
+		want bool
+	}{
+		// zero version always passes
+		{"GL009", version.Version{}, true},
+		// GL009 requires 15.7
+		{"GL009", version.Version{Major: 15, Minor: 7}, true},
+		{"GL009", version.Version{Major: 15, Minor: 6}, false},
+		{"GL009", version.Version{Major: 16, Minor: 0}, true},
+		// GL001 has no version gate
+		{"GL001", version.Version{Major: 15, Minor: 0}, true},
+		{"GL001", version.Version{Major: 1, Minor: 0}, true},
+	}
+	for _, tc := range cases {
+		got := EnabledFor(tc.id, tc.v)
+		if got != tc.want {
+			t.Errorf("EnabledFor(%q, %s) = %v, want %v", tc.id, tc.v, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds GitLab version awareness so glsec can skip rules that require GitLab features not available in older self-hosted instances.

## Changes

### New packages
- **`internal/version`** — `Version{Major, Minor}` type with `Parse()`, `AtLeast()`, `IsZero()`, `String()`. Zero value means "unset / always run". `Minimum = 15.0` is the oldest version glsec officially supports.
- **`rules/versions.go`** — `minVersions` map (GL009→15.7, GL010→14.9, GL014→12.9) and `EnabledFor(id, v)` predicate.

### Config file
`gitlab-version` is now a valid top-level key in `.glsec.yml`:
```yaml
gitlab-version: "15.7"
```
Format is validated on load (must parse as `MAJOR.MINOR` or `MAJOR`). Invalid format → hard error. Below `Minimum` → warning at runtime.

### CLI flag
```
--gitlab-version 15.7
```
The flag takes precedence over the config value. If the version is below 15.0, a warning is printed to stderr but linting continues.

### Rule loop
Each rule is now checked against `rules.EnabledFor(id, version)` before running. Rules with no entry in `minVersions` always run.

## How to test

```bash
# Rules requiring 15.7 (GL009) are skipped on 15.6:
glsec --gitlab-version 15.6 .gitlab-ci.yml

# Warning emitted for below-minimum version:
glsec --gitlab-version 14.0 .gitlab-ci.yml

# Via config:
echo 'gitlab-version: "15.7"' >> .glsec.yml
glsec .gitlab-ci.yml
```

Closes #50