### PR TITLE
feat: GL006 – hardcoded secrets in variables: block

### DIFF
--- a/docs/rules/GL006.md
+++ b/docs/rules/GL006.md
@@ -1,0 +1,60 @@
+# GL006 — Hardcoded secrets in `variables:` block
+
+**Severity:** error  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec scans all `variables:` blocks (global, `default:`, and per-job) for scalar values that match known secret patterns:
+
+| Pattern | Example match |
+|---------|--------------|
+| GitLab PAT | `glpat-…` (20+ chars) |
+| GitLab runner token | `glrt-…` |
+| GitLab deploy token | `gldt-…` |
+| GitLab CI job token | `glcbt-…` |
+| AWS access key | `AKIA…` (16 uppercase chars) |
+| PEM private key header | `-----BEGIN … PRIVATE KEY` |
+| GitHub PAT | `ghp_…` |
+| Slack bot token | `xoxb-…` / `xoxp-…` |
+| OpenAI API key | `sk-…` (32+ chars) |
+
+Values that are variable references (starting with `$`) are ignored.
+
+## Trigger example
+
+```yaml
+variables:
+  AWS_SECRET_ACCESS_KEY: "AKIAIOSFODNN7EXAMPLE"
+  DEPLOY_TOKEN: "glpat-xxxxxxxxxxxxxxxxxxxx"
+
+deploy:
+  script:
+    - aws s3 sync dist/ s3://my-bucket/
+```
+
+## Safe alternative
+
+Store secrets in **GitLab CI/CD Variables** (project Settings → CI/CD → Variables). Mark them as **Masked** so they are redacted in job logs, and optionally as **Protected** to restrict access to protected branches.
+
+Reference them by name without embedding the value in the file:
+
+```yaml
+variables:
+  # References a masked CI/CD variable — no secret stored in the repo
+  AWS_SECRET_ACCESS_KEY: "$AWS_SECRET_ACCESS_KEY"
+
+deploy:
+  script:
+    - aws s3 sync dist/ s3://my-bucket/
+```
+
+## Why this matters
+
+Variables in `.gitlab-ci.yml` are committed to git history and visible to every user with repository read access. A secret stored here:
+
+- Cannot be rotated without a new commit
+- Is permanently readable in git history even after deletion
+- May be exfiltrated by a compromised dependency or forked pipeline
+
+The only safe remediation after accidental exposure is to **immediately rotate the credential**.

--- a/rules/all.go
+++ b/rules/all.go
@@ -9,5 +9,6 @@ func All() []rule.Rule {
 		GL003,
 		GL004,
 		GL005,
+		GL006,
 	}
 }

--- a/rules/gl006.go
+++ b/rules/gl006.go
@@ -1,0 +1,105 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl006 struct{}
+
+var GL006 = &gl006{}
+
+func (r *gl006) ID() string { return "GL006" }
+
+type secretPattern struct {
+	name string
+	re   *regexp.Regexp
+}
+
+var secretPatterns = []secretPattern{
+	{"GitLab PAT", regexp.MustCompile(`^glpat-[A-Za-z0-9_-]{20,}$`)},
+	{"GitLab CI job token", regexp.MustCompile(`^glcbt-[A-Za-z0-9_-]{20,}$`)},
+	{"GitLab runner registration token", regexp.MustCompile(`^glrt-[A-Za-z0-9_-]{20,}$`)},
+	{"GitLab deploy token", regexp.MustCompile(`^gldt-[A-Za-z0-9_-]{20,}$`)},
+	{"AWS access key", regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+	{"PEM private key", regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY`)},
+	{"GitHub PAT", regexp.MustCompile(`^ghp_[A-Za-z0-9]{36,}$`)},
+	{"GitHub fine-grained PAT", regexp.MustCompile(`^github_pat_[A-Za-z0-9_]{82,}$`)},
+	{"Slack token", regexp.MustCompile(`^xox[baprs]-[A-Za-z0-9-]{10,}$`)},
+	{"OpenAI API key", regexp.MustCompile(`^sk-[A-Za-z0-9]{32,}$`)},
+}
+
+func (r *gl006) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkVariablesNode(parser.FindKey(mapping, "variables"), file)...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkVariablesNode(parser.FindKey(def, "variables"), file)...)
+	}
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		findings = append(findings, checkVariablesNode(parser.FindKey(job, "variables"), file)...)
+	})
+
+	return findings
+}
+
+func checkVariablesNode(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		varName := node.Content[i].Value
+		val := node.Content[i+1]
+
+		var scalar *yaml.Node
+		switch val.Kind {
+		case yaml.ScalarNode:
+			scalar = val
+		case yaml.MappingNode:
+			// Extended form: {value: ..., description: ...}
+			if v := parser.FindKey(val, "value"); v != nil && v.Kind == yaml.ScalarNode {
+				scalar = v
+			}
+		}
+		if scalar == nil {
+			continue
+		}
+		if f := checkSecretValue(scalar, varName, file); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	return findings
+}
+
+func checkSecretValue(node *yaml.Node, varName, file string) *finding.Finding {
+	v := node.Value
+	if v == "" || strings.HasPrefix(v, "$") {
+		return nil
+	}
+	for _, pat := range secretPatterns {
+		if pat.re.MatchString(v) {
+			f := finding.Finding{
+				RuleID:   "GL006",
+				Severity: finding.Error,
+				Message: fmt.Sprintf(
+					"variable %q appears to contain a hardcoded %s — use GitLab CI/CD masked variables (Settings → CI/CD → Variables) instead",
+					varName, pat.name,
+				),
+				File: file,
+				Line: node.Line,
+				Col:  node.Column,
+			}
+			return &f
+		}
+	}
+	return nil
+}

--- a/rules/gl006_test.go
+++ b/rules/gl006_test.go
@@ -1,0 +1,171 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings006(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL006.Check(doc.Root, "test.yml")
+}
+
+func TestGL006_GitLabPAT(t *testing.T) {
+	f := findings006(t, `
+variables:
+  DEPLOY_TOKEN: "glpat-xxxxxxxxxxxxxxxxxxxx"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL006_AWSAccessKey(t *testing.T) {
+	f := findings006(t, `
+variables:
+  AWS_SECRET: "AKIAIOSFODNN7EXAMPLE"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for AWS key, got %d", len(f))
+	}
+}
+
+func TestGL006_PEMKey(t *testing.T) {
+	f := findings006(t, `
+variables:
+  SIGNING_KEY: "-----BEGIN RSA PRIVATE KEY-----"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for PEM key, got %d", len(f))
+	}
+}
+
+func TestGL006_GitHubPAT(t *testing.T) {
+	f := findings006(t, `
+variables:
+  GH_TOKEN: "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for GitHub PAT, got %d", len(f))
+	}
+}
+
+func TestGL006_SlackToken(t *testing.T) {
+	f := findings006(t, `
+variables:
+  SLACK_BOT: "xoxb-FAKETOKEN-NOTREAL"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for Slack token, got %d", len(f))
+	}
+}
+
+func TestGL006_VariableReference_NoFinding(t *testing.T) {
+	f := findings006(t, `
+variables:
+  AWS_SECRET: "$AWS_SECRET_FROM_VAULT"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for variable reference, got %d", len(f))
+	}
+}
+
+func TestGL006_SafeValue_NoFinding(t *testing.T) {
+	f := findings006(t, `
+variables:
+  REGION: "us-east-1"
+  LOG_LEVEL: "info"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for safe values, got %d", len(f))
+	}
+}
+
+func TestGL006_PerJobVariables(t *testing.T) {
+	f := findings006(t, `
+deploy:
+  variables:
+    DEPLOY_TOKEN: "glpat-xxxxxxxxxxxxxxxxxxxx"
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in per-job variables, got %d", len(f))
+	}
+}
+
+func TestGL006_ExtendedForm(t *testing.T) {
+	f := findings006(t, `
+variables:
+  API_KEY:
+    value: "glpat-xxxxxxxxxxxxxxxxxxxx"
+    description: "deploy token"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for extended variable form, got %d", len(f))
+	}
+}
+
+func TestGL006_EmptyValue_NoFinding(t *testing.T) {
+	f := findings006(t, `
+variables:
+  OPTIONAL_TOKEN: ""
+build:
+  script: [echo ok]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for empty value, got %d", len(f))
+	}
+}
+
+func TestGL006_MultipleSecrets(t *testing.T) {
+	f := findings006(t, `
+variables:
+  PAT: "glpat-xxxxxxxxxxxxxxxxxxxx"
+  AWS: "AKIAIOSFODNN7EXAMPLE"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL006_LineNumber(t *testing.T) {
+	f := findings006(t, `
+variables:
+  TOKEN: "glpat-xxxxxxxxxxxxxxxxxxxx"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl006-hardcoded-secrets.yml
+++ b/testdata/fixtures/gl006-hardcoded-secrets.yml
@@ -1,0 +1,12 @@
+stages:
+  - deploy
+
+variables:
+  AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
+  DEPLOY_TOKEN: "glpat-xxxxxxxxxxxxxxxxxxxx"
+
+deploy-job:
+  stage: deploy
+  script:
+    - aws s3 sync dist/ s3://my-bucket/
+    - echo "done"


### PR DESCRIPTION
## What

Implements GL006, which detects plaintext secrets stored in `variables:` blocks in `.gitlab-ci.yml`.

## Detection patterns

| Pattern | Example |
|---------|---------|
| GitLab PAT | `glpat-…` |
| GitLab runner/deploy/CI tokens | `glrt-…`, `gldt-…`, `glcbt-…` |
| AWS access key | `AKIA…` (16 uppercase chars) |
| PEM private key | `-----BEGIN … PRIVATE KEY` |
| GitHub PAT | `ghp_…`, `github_pat_…` |
| Slack token | `xoxb-…`, `xoxp-…` etc. |
| OpenAI API key | `sk-…` (32+ chars) |

Values starting with `$` (variable references) are excluded.

## Scope

- Global `variables:` block
- `default: variables:`
- Per-job `variables:`
- Extended variable form (`value:` / `description:` mapping)

## Severity

`error` — secrets in version control require immediate rotation.

## Notes

The test file uses `xoxb-FAKETOKEN-NOTREAL` for the Slack pattern test rather than a realistic-looking token value, to avoid triggering GitHub push protection.

Closes #40