### PR TITLE
feat: GL007 – variable interpolation in image reference

### DIFF
--- a/docs/rules/GL007.md
+++ b/docs/rules/GL007.md
@@ -1,0 +1,61 @@
+# GL007 — Variable interpolation in image reference
+
+**Severity:** error  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution (PPE)](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+
+## What glsec checks
+
+glsec flags `image:` values (and `services:` entries) that use CI variable interpolation in two ways:
+
+1. **Entirely a variable** — the whole image reference is a single `$VAR` or `${VAR}`, meaning anyone who can set that variable controls which container runs.
+
+2. **User-controlled variable in the tag** — the image reference embeds a GitLab predefined variable whose value is supplied by external actors (commit authors, MR creators):
+
+   | Variable | Controlled by |
+   |----------|---------------|
+   | `CI_COMMIT_REF_NAME` | branch / tag name |
+   | `CI_COMMIT_REF_SLUG` | URL-safe branch name |
+   | `CI_COMMIT_BRANCH` | branch name |
+   | `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | MR source branch |
+   | `CI_PIPELINE_NAME` | pipeline trigger |
+
+## Trigger example
+
+```yaml
+build:
+  image: $BUILD_IMAGE               # entirely attacker-controlled
+
+deploy:
+  image: registry.example.com/app:$CI_COMMIT_REF_SLUG  # branch name controls tag
+  script: ./deploy.sh
+```
+
+## Safe alternative
+
+Pin images to a specific version or digest:
+
+```yaml
+build:
+  image: node:20.11.0               # explicit version
+
+deploy:
+  image: registry.example.com/app:a1b2c3d4  # specific tag, not from user input
+  script: ./deploy.sh
+```
+
+If different branches genuinely need different images, use a fixed lookup in `.gitlab-ci.yml` rather than embedding the branch name directly:
+
+```yaml
+build:
+  image: registry.example.com/app:main  # fixed tag for main pipeline
+```
+
+## Why this matters
+
+When an attacker can choose which container image runs in a job they can:
+
+- Exfiltrate CI secrets and tokens available in the job environment
+- Tamper with build artifacts before they reach production
+- Pivot to other systems using credentials from the compromised job
+
+This is a GitLab-specific variant of the Poisoned Pipeline Execution (PPE) attack class.

--- a/rules/all.go
+++ b/rules/all.go
@@ -10,5 +10,6 @@ func All() []rule.Rule {
 		GL004,
 		GL005,
 		GL006,
+		GL007,
 	}
 }

--- a/rules/gl007.go
+++ b/rules/gl007.go
@@ -1,0 +1,105 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl007 struct{}
+
+var GL007 = &gl007{}
+
+func (r *gl007) ID() string { return "GL007" }
+
+// entireVarRe matches an image ref that is entirely a single variable reference.
+var entireVarRe = regexp.MustCompile(`^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$`)
+
+// userControlledImageVars are GitLab predefined variables whose values are set
+// by external actors (commit authors, MR creators) and can contain arbitrary strings.
+var userControlledImageVars = []string{
+	"CI_COMMIT_REF_NAME",
+	"CI_COMMIT_REF_SLUG",
+	"CI_COMMIT_BRANCH",
+	"CI_MERGE_REQUEST_SOURCE_BRANCH_NAME",
+	"CI_PIPELINE_NAME",
+}
+
+func (r *gl007) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkImageVarInjection(parser.FindKey(mapping, "image"), file)...)
+	findings = append(findings, checkServicesVarInjection(parser.FindKey(mapping, "services"), file)...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkImageVarInjection(parser.FindKey(def, "image"), file)...)
+		findings = append(findings, checkServicesVarInjection(parser.FindKey(def, "services"), file)...)
+	}
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		findings = append(findings, checkImageVarInjection(parser.FindKey(job, "image"), file)...)
+		findings = append(findings, checkServicesVarInjection(parser.FindKey(job, "services"), file)...)
+	})
+
+	return findings
+}
+
+func checkImageVarInjection(node *yaml.Node, file string) []finding.Finding {
+	if node == nil {
+		return nil
+	}
+	ref, line, col := imageRef(node)
+	if ref == "" {
+		return nil
+	}
+	return imageVarFindings(ref, line, col, file)
+}
+
+func checkServicesVarInjection(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		ref, line, col := imageRef(item)
+		if ref == "" {
+			continue
+		}
+		findings = append(findings, imageVarFindings(ref, line, col, file)...)
+	}
+	return findings
+}
+
+func imageVarFindings(ref string, line, col int, file string) []finding.Finding {
+	if entireVarRe.MatchString(ref) {
+		return []finding.Finding{{
+			RuleID:   "GL007",
+			Severity: finding.Error,
+			Message: fmt.Sprintf(
+				"image %q is controlled entirely by a CI variable — anyone who can set this variable can execute code in an arbitrary container",
+				ref,
+			),
+			File: file, Line: line, Col: col,
+		}}
+	}
+
+	for _, v := range userControlledImageVars {
+		if strings.Contains(ref, "$"+v) || strings.Contains(ref, "${"+v+"}") {
+			return []finding.Finding{{
+				RuleID:   "GL007",
+				Severity: finding.Error,
+				Message: fmt.Sprintf(
+					"image %q uses user-controlled variable $%s — a commit author can redirect job execution to an arbitrary container tag",
+					ref, v,
+				),
+				File: file, Line: line, Col: col,
+			}}
+		}
+	}
+	return nil
+}

--- a/rules/gl007_test.go
+++ b/rules/gl007_test.go
@@ -1,0 +1,151 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings007(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL007.Check(doc.Root, "test.yml")
+}
+
+func TestGL007_EntirelyVariable(t *testing.T) {
+	f := findings007(t, `
+build:
+  image: $BUILD_IMAGE
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for fully-variable image, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL007_BraceForm(t *testing.T) {
+	f := findings007(t, `
+build:
+  image: ${BUILD_IMAGE}
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for brace-form variable image, got %d", len(f))
+	}
+}
+
+func TestGL007_UserControlledTag(t *testing.T) {
+	f := findings007(t, `
+deploy:
+  image: registry.example.com/app:$CI_COMMIT_REF_SLUG
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for user-controlled variable in tag, got %d", len(f))
+	}
+}
+
+func TestGL007_UserControlledRefName(t *testing.T) {
+	f := findings007(t, `
+build:
+  image: myrepo/app:$CI_COMMIT_REF_NAME
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_REF_NAME in image, got %d", len(f))
+	}
+}
+
+func TestGL007_SafeImage_NoFinding(t *testing.T) {
+	f := findings007(t, `
+build:
+  image: node:20.11.0
+  script: [npm ci]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for pinned image, got %d", len(f))
+	}
+}
+
+func TestGL007_SafeDigest_NoFinding(t *testing.T) {
+	f := findings007(t, `
+build:
+  image: node@sha256:abc123
+  script: [npm ci]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for digest-pinned image, got %d", len(f))
+	}
+}
+
+func TestGL007_SafeRegistryVar_NoFinding(t *testing.T) {
+	// CI_REGISTRY_IMAGE is set by GitLab, not by external actors
+	f := findings007(t, `
+build:
+  image: $CI_REGISTRY_IMAGE:1.2.3
+  script: [make]
+`)
+	// Not entirely a variable, and CI_REGISTRY_IMAGE is not in userControlledImageVars
+	if len(f) != 0 {
+		t.Errorf("expected no finding for $CI_REGISTRY_IMAGE with pinned tag, got %d", len(f))
+	}
+}
+
+func TestGL007_GlobalImage(t *testing.T) {
+	f := findings007(t, `
+image: $BUILD_IMAGE
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for global variable image, got %d", len(f))
+	}
+}
+
+func TestGL007_DefaultImage(t *testing.T) {
+	f := findings007(t, `
+default:
+  image: $BUILD_IMAGE
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in default: image, got %d", len(f))
+	}
+}
+
+func TestGL007_ServiceVariable(t *testing.T) {
+	f := findings007(t, `
+build:
+  image: node:20.11.0
+  services:
+    - $DB_IMAGE
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for variable in services, got %d", len(f))
+	}
+}
+
+func TestGL007_LineNumber(t *testing.T) {
+	f := findings007(t, `
+build:
+  image: $BUILD_IMAGE
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl007-image-variable-injection.yml
+++ b/testdata/fixtures/gl007-image-variable-injection.yml
@@ -1,0 +1,15 @@
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  image: $BUILD_IMAGE
+  script:
+    - make
+
+deploy:
+  stage: deploy
+  image: registry.example.com/app:$CI_COMMIT_REF_SLUG
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
## What

Implements GL007, which detects CI variable interpolation in `image:` and `services:` entries that allows an attacker to redirect job execution to an arbitrary container.

## Two detection cases

**1. Image is entirely a variable reference**
```yaml
image: $BUILD_IMAGE   # anyone who can set this variable controls the container
```

**2. User-controlled predefined variable used in the image reference**
```yaml
image: registry.example.com/app:$CI_COMMIT_REF_SLUG  # branch name controls tag
```

Flagged user-controlled variables: `CI_COMMIT_REF_NAME`, `CI_COMMIT_REF_SLUG`, `CI_COMMIT_BRANCH`, `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`, `CI_PIPELINE_NAME`.

## Scope

- Global `image:` / `services:`
- `default: image:` / `default: services:`
- Per-job `image:` / `services:`
- Both scalar and `{name: ...}` service forms (reuses `imageRef` from GL001)

## Notes

- `$CI_REGISTRY_IMAGE:1.2.3` is **not** flagged — `CI_REGISTRY_IMAGE` is a safe GitLab-controlled variable, and the tag is a literal.
- GL001 may also fire on fully-variable images (no tag); that's intentional — different rules, different remediation advice.

Closes #41