### PR TITLE
feat: GL008 – allow_failure: true on security scan jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL005](docs/rules/GL005.md) | `warn`  | Sensitive file patterns in `artifacts:` or missing `expire_in` |
 | [GL006](docs/rules/GL006.md) | `error` | Hardcoded secret in `variables:` block |
 | [GL007](docs/rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
+| [GL008](docs/rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL008.md
+++ b/docs/rules/GL008.md
@@ -1,0 +1,57 @@
+# GL008 — `allow_failure: true` on security scan jobs
+
+**Severity:** warn  
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
+
+## What glsec checks
+
+glsec flags any of GitLab's predefined security scan jobs that have `allow_failure: true` set:
+
+| Job name | Template |
+|----------|----------|
+| `sast` | `Security/SAST.gitlab-ci.yml` |
+| `sast-iac` | `Security/SAST-IaC.gitlab-ci.yml` |
+| `secret_detection` | `Security/Secret-Detection.gitlab-ci.yml` |
+| `dast` | `Security/DAST.gitlab-ci.yml` |
+| `dast_api` | `Security/DAST-API.gitlab-ci.yml` |
+| `container_scanning` | `Security/Container-Scanning.gitlab-ci.yml` |
+| `dependency_scanning` | `Security/Dependency-Scanning.gitlab-ci.yml` |
+| `coverage_fuzzing` | `Security/Coverage-Fuzzing.gitlab-ci.yml` |
+| `api_fuzzing` | `Security/API-Fuzzing.gitlab-ci.yml` |
+| `license_scanning` | `Security/License-Scanning.gitlab-ci.yml` |
+
+The `allow_failure: {exit_codes: [...]}` form (exit-code-specific) is not flagged — that is a deliberate choice, not a blanket suppression.
+
+## Trigger example
+
+```yaml
+include:
+  - template: Security/SAST.gitlab-ci.yml
+
+sast:
+  allow_failure: true   # scan failures are silently ignored
+```
+
+## Safe alternative
+
+Remove `allow_failure: true` so the pipeline fails when the security scan fails:
+
+```yaml
+include:
+  - template: Security/SAST.gitlab-ci.yml
+
+# No allow_failure override — pipeline fails if SAST finds issues
+```
+
+If you need the pipeline to pass during a transition period, use a [GitLab security policy](https://docs.gitlab.com/user/application_security/policies/) to enforce scan requirements separately from pipeline status, rather than silencing failures.
+
+## Why this matters
+
+When a GitLab security scan job has `allow_failure: true`:
+
+- The pipeline passes even if the scan exits with an error
+- GitLab's security dashboard may not ingest scan results from a failed job
+- Vulnerabilities are not surfaced in merge request widgets or approval rules
+- The security gate is effectively disabled, defeating the purpose of including the scan
+
+This is especially dangerous when the job fails due to a misconfiguration (wrong image, expired token) rather than an actual scan finding — the failure is invisible.

--- a/rules/all.go
+++ b/rules/all.go
@@ -11,5 +11,6 @@ func All() []rule.Rule {
 		GL005,
 		GL006,
 		GL007,
+		GL008,
 	}
 }

--- a/rules/gl008.go
+++ b/rules/gl008.go
@@ -1,0 +1,62 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl008 struct{}
+
+var GL008 = &gl008{}
+
+func (r *gl008) ID() string { return "GL008" }
+
+// securityScanJobs are the GitLab-defined job names created when security
+// scan templates are included. Failing these jobs with allow_failure: true
+// causes GitLab to silently skip security result ingestion.
+var securityScanJobs = map[string]bool{
+	"sast":                  true,
+	"sast-iac":              true,
+	"secret_detection":      true,
+	"dast":                  true,
+	"dast_api":              true,
+	"container_scanning":    true,
+	"dependency_scanning":   true,
+	"coverage_fuzzing":      true,
+	"api_fuzzing":           true,
+	"license_scanning":      true,
+	"license_management":    true,
+}
+
+func (r *gl008) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if !securityScanJobs[name.Value] {
+			return
+		}
+		af := parser.FindKey(job, "allow_failure")
+		if af == nil {
+			return
+		}
+		// Only flag scalar `true`; allow_failure: {exit_codes: [...]} is intentional.
+		if af.Kind == yaml.ScalarNode && af.Value == "true" {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL008",
+				Severity: finding.Warn,
+				Message: fmt.Sprintf(
+					"security scan job %q has allow_failure: true — scan failures are silently ignored and security results may not be ingested by GitLab",
+					name.Value,
+				),
+				File: file,
+				Line: af.Line,
+				Col:  af.Column,
+			})
+		}
+	})
+
+	return findings
+}

--- a/rules/gl008_test.go
+++ b/rules/gl008_test.go
@@ -1,0 +1,126 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings008(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL008.Check(doc.Root, "test.yml")
+}
+
+func TestGL008_SAST_AllowFailure(t *testing.T) {
+	f := findings008(t, `
+sast:
+  allow_failure: true
+  variables:
+    SAST_EXCLUDED_PATHS: "spec"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL008_SecretDetection_AllowFailure(t *testing.T) {
+	f := findings008(t, `
+secret_detection:
+  allow_failure: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for secret_detection, got %d", len(f))
+	}
+}
+
+func TestGL008_ContainerScanning_AllowFailure(t *testing.T) {
+	f := findings008(t, `
+container_scanning:
+  allow_failure: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for container_scanning, got %d", len(f))
+	}
+}
+
+func TestGL008_AllowFailureFalse_NoFinding(t *testing.T) {
+	f := findings008(t, `
+sast:
+  allow_failure: false
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when allow_failure: false, got %d", len(f))
+	}
+}
+
+func TestGL008_NoAllowFailure_NoFinding(t *testing.T) {
+	f := findings008(t, `
+sast:
+  variables:
+    SAST_EXCLUDED_PATHS: "spec"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when allow_failure is absent, got %d", len(f))
+	}
+}
+
+func TestGL008_NonSecurityJob_NoFinding(t *testing.T) {
+	f := findings008(t, `
+build:
+  allow_failure: true
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-security job, got %d", len(f))
+	}
+}
+
+func TestGL008_AllowFailureExitCodes_NoFinding(t *testing.T) {
+	// allow_failure: {exit_codes: [...]} is intentional and not the same as allow_failure: true
+	f := findings008(t, `
+sast:
+  allow_failure:
+    exit_codes: [1]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for exit_codes form, got %d", len(f))
+	}
+}
+
+func TestGL008_MultipleJobs(t *testing.T) {
+	f := findings008(t, `
+sast:
+  allow_failure: true
+
+dependency_scanning:
+  allow_failure: true
+
+build:
+  allow_failure: true
+  script: [make]
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (sast + dependency_scanning), got %d", len(f))
+	}
+}
+
+func TestGL008_LineNumber(t *testing.T) {
+	f := findings008(t, `
+sast:
+  allow_failure: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl008-allow-failure-security-jobs.yml
+++ b/testdata/fixtures/gl008-allow-failure-security-jobs.yml
@@ -1,0 +1,20 @@
+include:
+  - template: Security/SAST.gitlab-ci.yml
+  - template: Security/Secret-Detection.gitlab-ci.yml
+
+stages:
+  - test
+  - security
+
+build:
+  stage: test
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm test
+
+sast:
+  allow_failure: true
+
+secret_detection:
+  allow_failure: true


### PR DESCRIPTION
## What

Implements GL008, which detects GitLab security scan jobs configured with `allow_failure: true`. This silently swallows scan failures and prevents GitLab from ingesting security results into the dashboard.

## Detection logic

- Checks all jobs whose name matches a known GitLab security scan job name (`sast`, `secret_detection`, `container_scanning`, `dependency_scanning`, `dast`, `dast_api`, `sast-iac`, `coverage_fuzzing`, `api_fuzzing`, `license_scanning`, `license_management`)
- Flags `allow_failure: true` (scalar) — not the `exit_codes:` mapping form, which is intentional

## Severity

`warn` — the pipeline structure is not broken, but security findings are silently swallowed.

## Notes

This is one of glsec's GitLab-specific differentiators: zizmor has no equivalent check because GitHub Actions doesn't have a built-in security scan job concept. The README rules table is updated in this PR.

Closes #42