### PR TITLE
feat: GL009 – overly broad OIDC id_tokens audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL006](docs/rules/GL006.md) | `error` | Hardcoded secret in `variables:` block |
 | [GL007](docs/rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
 | [GL008](docs/rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
+| [GL009](docs/rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL009.md
+++ b/docs/rules/GL009.md
@@ -1,0 +1,53 @@
+# GL009 — Overly broad OIDC `id_tokens` audience
+
+**Severity:** warn  
+**Minimum GitLab version:** 15.7 (`id_tokens:` was introduced in 15.7)  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags `id_tokens:` entries whose `aud:` value is a GitLab instance URL (hostname contains `gitlab`). Such an audience is accepted by any service configured with that GitLab instance as an OIDC issuer, rather than being scoped to a specific cloud service.
+
+## Trigger example
+
+```yaml
+deploy-aws:
+  id_tokens:
+    AWS_OIDC_TOKEN:
+      aud: "https://gitlab.example.com"   # instance root — too broad
+```
+
+## Safe alternative
+
+Use the specific audience required by each cloud provider:
+
+```yaml
+deploy-aws:
+  id_tokens:
+    AWS_OIDC_TOKEN:
+      aud: "https://sts.amazonaws.com"    # AWS STS
+
+deploy-gcp:
+  id_tokens:
+    GCP_TOKEN:
+      aud: "https://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
+
+deploy-vault:
+  id_tokens:
+    VAULT_TOKEN:
+      aud: "https://vault.example.com"
+```
+
+## Why this matters
+
+When `aud:` is the GitLab instance root URL:
+
+- Any cloud service that trusts that GitLab instance as an OIDC issuer will accept the token
+- If an attacker obtains the token from one job, they can reuse it against other services that share the same audience
+- A compromised or misconfigured job in any project on the same instance could obtain tokens accepted by your cloud provider
+
+Service-specific audiences (e.g. `https://sts.amazonaws.com`) limit the token's usefulness to exactly one service, dramatically reducing the blast radius of a token leak.
+
+## GitLab documentation
+
+[Connect to cloud services using OpenID Connect](https://docs.gitlab.com/ci/cloud_services/)

--- a/rules/all.go
+++ b/rules/all.go
@@ -12,5 +12,6 @@ func All() []rule.Rule {
 		GL006,
 		GL007,
 		GL008,
+		GL009,
 	}
 }

--- a/rules/gl009.go
+++ b/rules/gl009.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl009 struct{}
+
+var GL009 = &gl009{}
+
+func (r *gl009) ID() string { return "GL009" }
+
+func (r *gl009) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		idTokens := parser.FindKey(job, "id_tokens")
+		if idTokens == nil || idTokens.Kind != yaml.MappingNode {
+			return
+		}
+		// Each key is a token name, each value is a mapping with an aud: key.
+		for i := 0; i+1 < len(idTokens.Content); i += 2 {
+			tokenDef := idTokens.Content[i+1]
+			if tokenDef.Kind != yaml.MappingNode {
+				continue
+			}
+			audNode := parser.FindKey(tokenDef, "aud")
+			if audNode == nil {
+				continue
+			}
+			findings = append(findings, checkAudNode(audNode, file)...)
+		}
+	})
+
+	return findings
+}
+
+func checkAudNode(node *yaml.Node, file string) []finding.Finding {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if isOverbroad(node.Value) {
+			return []finding.Finding{overbroad(node.Value, node.Line, node.Column, file)}
+		}
+	case yaml.SequenceNode:
+		var findings []finding.Finding
+		for _, item := range node.Content {
+			if item.Kind == yaml.ScalarNode && isOverbroad(item.Value) {
+				findings = append(findings, overbroad(item.Value, item.Line, item.Column, file))
+			}
+		}
+		return findings
+	}
+	return nil
+}
+
+// isOverbroad returns true when the audience is a GitLab instance root URL.
+// Such an audience accepts OIDC tokens from any project on that instance,
+// rather than being scoped to a specific cloud service.
+func isOverbroad(aud string) bool {
+	u, err := url.Parse(aud)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(u.Hostname()), "gitlab")
+}
+
+func overbroad(aud string, line, col int, file string) finding.Finding {
+	return finding.Finding{
+		RuleID:   "GL009",
+		Severity: finding.Warn,
+		Message: fmt.Sprintf(
+			"id_token audience %q is a GitLab instance URL — use a service-specific audience (e.g. https://sts.amazonaws.com) to limit token acceptance to the intended cloud service",
+			aud,
+		),
+		File: file,
+		Line: line,
+		Col:  col,
+	}
+}

--- a/rules/gl009_test.go
+++ b/rules/gl009_test.go
@@ -1,0 +1,128 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings009(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL009.Check(doc.Root, "test.yml")
+}
+
+func TestGL009_GitLabInstanceAud(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    AWS_TOKEN:
+      aud: "https://gitlab.example.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL009_GitLabCom(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    TOKEN:
+      aud: "https://gitlab.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for gitlab.com, got %d", len(f))
+	}
+}
+
+func TestGL009_ServiceSpecificAud_NoFinding(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    AWS_TOKEN:
+      aud: "https://sts.amazonaws.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for service-specific audience, got %d", len(f))
+	}
+}
+
+func TestGL009_GCPAud_NoFinding(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    GCP_TOKEN:
+      aud: "https://accounts.google.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for GCP audience, got %d", len(f))
+	}
+}
+
+func TestGL009_ListAud_OneOverbroad(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    TOKEN:
+      aud:
+        - "https://gitlab.example.com"
+        - "https://sts.amazonaws.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for list aud with one overbroad entry, got %d", len(f))
+	}
+}
+
+func TestGL009_MultipleTokens(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    AWS_TOKEN:
+      aud: "https://gitlab.example.com"
+    GCP_TOKEN:
+      aud: "https://gitlab.example.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings for two overbroad tokens, got %d", len(f))
+	}
+}
+
+func TestGL009_NoIdTokens_NoFinding(t *testing.T) {
+	f := findings009(t, `
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings when no id_tokens, got %d", len(f))
+	}
+}
+
+func TestGL009_LineNumber(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    TOKEN:
+      aud: "https://gitlab.example.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl009-oidc-overbroad-audience.yml
+++ b/testdata/fixtures/gl009-oidc-overbroad-audience.yml
@@ -1,0 +1,12 @@
+stages:
+  - deploy
+
+deploy-aws:
+  stage: deploy
+  id_tokens:
+    AWS_OIDC_TOKEN:
+      aud: "https://gitlab.example.com"
+  script:
+    - aws sts assume-role-with-web-identity
+        --role-arn arn:aws:iam::123456789:role/my-role
+        --web-identity-token "$AWS_OIDC_TOKEN"


### PR DESCRIPTION
## What

Implements GL009, which detects `id_tokens:` entries whose `aud:` is a GitLab instance URL rather than a service-specific audience. This is a GitLab-specific rule with no zizmor analogue — one of glsec's key differentiators.

## Detection logic

An audience is considered too broad if its hostname contains `gitlab` (case-insensitive). This catches:
- `https://gitlab.com`
- `https://gitlab.example.com`
- `https://mygitlab.corp.com`

Service-specific audiences like `https://sts.amazonaws.com`, `https://accounts.google.com`, or `https://vault.example.com` are not flagged.

Both scalar (`aud: "..."`) and list (`aud: [...]`) forms are handled.

## Version gating

GL009 is already registered in `rules/versions.go` as requiring GitLab ≥ 15.7 (when `id_tokens:` was introduced). Running with `--gitlab-version 15.6` or lower will skip this rule automatically.

## Severity

`warn` — the token still works, but the blast radius on compromise is larger than necessary.

Closes #43