### PR TITLE
feat: GL010 – trigger: forward: pipeline_variables: true leaks secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL007](docs/rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
 | [GL008](docs/rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
 | [GL009](docs/rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
+| [GL010](docs/rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL010.md
+++ b/docs/rules/GL010.md
@@ -1,0 +1,50 @@
+# GL010 — Secrets forwarded to downstream pipeline
+
+**Severity:** warn  
+**Minimum GitLab version:** 14.9 (`trigger: forward:` was introduced in 14.9)  
+**OWASP:** [CICD-SEC-5 – Insufficient PBAC (Pipeline-Based Access Controls)](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)
+
+## What glsec checks
+
+glsec flags `trigger:` jobs that set `forward: pipeline_variables: true`, which forwards all parent pipeline variables — including masked secrets set in CI/CD Settings — to the downstream project's pipeline.
+
+## Trigger example
+
+```yaml
+trigger-downstream:
+  trigger:
+    project: org/downstream-project
+    forward:
+      pipeline_variables: true   # all variables forwarded, including secrets
+```
+
+## Safe alternative
+
+Pass only the variables the downstream pipeline needs, and disable implicit variable inheritance:
+
+```yaml
+trigger-downstream:
+  trigger:
+    project: org/downstream-project
+  variables:
+    DEPLOY_ENV: production        # explicit, minimal variable passing
+  inherit:
+    variables: false              # do not inherit parent pipeline variables
+```
+
+## Why this matters
+
+GitLab's own documentation explicitly warns:
+
+> "Do not use this method to pass masked variables to a multi-project pipeline. The CI/CD masking configuration is not passed to the downstream pipeline and the variable could be unmasked in job logs."
+
+When `pipeline_variables: true` is set:
+
+- Every CI/CD variable from the parent pipeline is forwarded, including secrets marked as masked or protected
+- Masking is not applied in the downstream pipeline — secrets can appear in plain text in job logs
+- The downstream project may have a broader set of maintainers and less strict access controls
+- A malicious job in the downstream project can trivially exfiltrate all forwarded secrets
+
+## zizmor analogue
+
+`secrets-inherit` (GitHub Actions) — same class of vulnerability, different mechanism.

--- a/rules/all.go
+++ b/rules/all.go
@@ -13,5 +13,6 @@ func All() []rule.Rule {
 		GL007,
 		GL008,
 		GL009,
+		GL010,
 	}
 }

--- a/rules/gl010.go
+++ b/rules/gl010.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl010 struct{}
+
+var GL010 = &gl010{}
+
+func (r *gl010) ID() string { return "GL010" }
+
+func (r *gl010) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		trigger := parser.FindKey(job, "trigger")
+		if trigger == nil || trigger.Kind != yaml.MappingNode {
+			return
+		}
+		forward := parser.FindKey(trigger, "forward")
+		if forward == nil || forward.Kind != yaml.MappingNode {
+			return
+		}
+		pv := parser.FindKey(forward, "pipeline_variables")
+		if pv == nil || pv.Kind != yaml.ScalarNode || pv.Value != "true" {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL010",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"trigger job %q forwards all pipeline variables to the downstream pipeline — masked variables are not re-masked and may be exposed in downstream job logs",
+				name.Value,
+			),
+			File: file,
+			Line: pv.Line,
+			Col:  pv.Column,
+		})
+	})
+
+	return findings
+}

--- a/rules/gl010_test.go
+++ b/rules/gl010_test.go
@@ -1,0 +1,120 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings010(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL010.Check(doc.Root, "test.yml")
+}
+
+func TestGL010_ForwardPipelineVariables(t *testing.T) {
+	f := findings010(t, `
+trigger-downstream:
+  trigger:
+    project: org/downstream
+    forward:
+      pipeline_variables: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL010_ForwardFalse_NoFinding(t *testing.T) {
+	f := findings010(t, `
+trigger-downstream:
+  trigger:
+    project: org/downstream
+    forward:
+      pipeline_variables: false
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when pipeline_variables: false, got %d", len(f))
+	}
+}
+
+func TestGL010_NoForward_NoFinding(t *testing.T) {
+	f := findings010(t, `
+trigger-downstream:
+  trigger:
+    project: org/downstream
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding without forward:, got %d", len(f))
+	}
+}
+
+func TestGL010_ScalarTrigger_NoFinding(t *testing.T) {
+	// Simple trigger form — no forward: key possible
+	f := findings010(t, `
+trigger-downstream:
+  trigger: org/downstream
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for scalar trigger, got %d", len(f))
+	}
+}
+
+func TestGL010_YamlVariablesOnly_NoFinding(t *testing.T) {
+	// Forwarding yaml_variables (YAML-defined vars) is less risky than pipeline_variables
+	f := findings010(t, `
+trigger-downstream:
+  trigger:
+    project: org/downstream
+    forward:
+      yaml_variables: true
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for yaml_variables only, got %d", len(f))
+	}
+}
+
+func TestGL010_MultipleJobs(t *testing.T) {
+	f := findings010(t, `
+trigger-a:
+  trigger:
+    project: org/a
+    forward:
+      pipeline_variables: true
+
+trigger-b:
+  trigger:
+    project: org/b
+    forward:
+      pipeline_variables: true
+
+build:
+  script: [make]
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL010_LineNumber(t *testing.T) {
+	f := findings010(t, `
+trigger-downstream:
+  trigger:
+    project: org/downstream
+    forward:
+      pipeline_variables: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl010-trigger-forward-secrets.yml
+++ b/testdata/fixtures/gl010-trigger-forward-secrets.yml
@@ -1,0 +1,17 @@
+stages:
+  - build
+  - trigger
+
+build:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build
+
+trigger-downstream:
+  stage: trigger
+  trigger:
+    project: org/downstream-project
+    forward:
+      pipeline_variables: true


### PR DESCRIPTION
## What

Implements GL010, which detects `trigger:` jobs that set `forward: pipeline_variables: true`. GitLab explicitly warns against this in its documentation: masked variables are not re-masked in downstream pipelines and can appear in plain text in job logs.

## Detection logic

For each `trigger:` job, check if:
- `trigger.forward.pipeline_variables` exists and is the scalar `true`

Not flagged:
- `forward: pipeline_variables: false` (safe)
- `forward: yaml_variables: true` (forwards only YAML-defined vars, not CI/CD secrets)
- Simple scalar trigger form (`trigger: org/project`)

## Version gating

GL010 is already in `rules/versions.go` as requiring GitLab ≥ 14.9 (`trigger: forward:` was introduced then). Running with `--gitlab-version 14.8` or lower skips this rule automatically.

## zizmor analogue

`secrets-inherit` — same vulnerability class on GitHub Actions.

Closes #44