### PR TITLE
feat: GL011 – download-and-execute pattern (curl | bash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL008](docs/rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
 | [GL009](docs/rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL010](docs/rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |
+| [GL011](docs/rules/GL011.md) | `error` | Download-and-execute pattern in script (`curl \| bash`, `wget \| sh`) |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL011.md
+++ b/docs/rules/GL011.md
@@ -1,0 +1,49 @@
+# GL011 — Download-and-execute pattern in script (`curl | bash`)
+
+**Severity:** error  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags script lines that download content with `curl` or `wget` and pipe it directly into a shell interpreter, including via bash process substitution:
+
+| Pattern | Example |
+|---------|---------|
+| Pipe to shell | `curl URL \| bash` |
+| Pipe to sh | `wget -qO- URL \| sh` |
+| Pipe to Python | `curl URL \| python3` |
+| Pipe to Ruby/Perl/Node | `curl URL \| ruby` |
+| Process substitution | `python3 <(curl URL)` |
+| Multi-stage pipe | `curl URL \| base64 -d \| bash` |
+
+## Trigger example
+
+```yaml
+setup:
+  script:
+    - curl -sSL https://install.example.com/setup.sh | bash
+    - wget -qO- https://raw.githubusercontent.com/org/repo/main/install.sh | sh
+    - python3 <(curl -s https://example.com/bootstrap.py)
+```
+
+## Safe alternative
+
+Download the script first, verify its checksum, then execute:
+
+```yaml
+setup:
+  script:
+    - curl -sSLO https://install.example.com/setup.sh
+    - echo "a3b4c5d6…  setup.sh" | sha256sum --check
+    - bash setup.sh
+```
+
+Or better: commit the script to the repository and reference it locally, removing the runtime network dependency entirely.
+
+## Why this matters
+
+HTTPS provides transport-level security but no content integrity guarantee. If the script host is compromised, the pipeline will silently execute malicious code in the CI environment with access to all secrets, tokens, and build artifacts. Unlike a committed dependency, the executed code is unversioned and cannot be audited in pull request reviews or git history.
+
+## zizmor analogue
+
+`unpinned-tools` — same supply chain risk on GitHub Actions.

--- a/rules/all.go
+++ b/rules/all.go
@@ -14,5 +14,6 @@ func All() []rule.Rule {
 		GL008,
 		GL009,
 		GL010,
+		GL011,
 	}
 }

--- a/rules/gl011.go
+++ b/rules/gl011.go
@@ -1,0 +1,90 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl011 struct{}
+
+var GL011 = &gl011{}
+
+func (r *gl011) ID() string { return "GL011" }
+
+var (
+	// downloadToolRe matches curl or wget anywhere in a script line.
+	downloadToolRe = regexp.MustCompile(`\b(?:curl|wget)\b`)
+	// pipeToShellRe matches a pipe directly into a shell interpreter.
+	pipeToShellRe = regexp.MustCompile(`\|\s*(?:bash|sh|python[23]?|ruby|perl|node)\b`)
+	// processSubstRe matches bash process substitution: <(curl ...) or <(wget ...).
+	processSubstRe = regexp.MustCompile(`<\s*\(\s*(?:curl|wget)\b`)
+)
+
+func (r *gl011) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkScriptDownloadExecute(node, file)...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkScriptDownloadExecute(node, file)...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkScriptDownloadExecute(node, file)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkScriptDownloadExecute(node *yaml.Node, file string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if isDownloadExecute(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL011",
+				Severity: finding.Error,
+				Message:  fmt.Sprintf("script line downloads and executes remote code without integrity verification: %q", truncate(item.Value, 80)),
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}
+
+func isDownloadExecute(line string) bool {
+	if processSubstRe.MatchString(line) {
+		return true
+	}
+	return downloadToolRe.MatchString(line) && pipeToShellRe.MatchString(line)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/rules/gl011_test.go
+++ b/rules/gl011_test.go
@@ -1,0 +1,149 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings011(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL011.Check(doc.Root, "test.yml")
+}
+
+func TestGL011_CurlPipeBash(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -sSL https://install.example.com/setup.sh | bash
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL011_WgetPipeSh(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - wget -qO- https://example.com/install.sh | sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for wget | sh, got %d", len(f))
+	}
+}
+
+func TestGL011_CurlPipePython(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -s https://bootstrap.example.com | python3
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for curl | python3, got %d", len(f))
+	}
+}
+
+func TestGL011_ProcessSubstitution(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - python3 <(curl -s https://example.com/bootstrap.py)
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for process substitution, got %d", len(f))
+	}
+}
+
+func TestGL011_CurlPipeBase64Bash(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -s https://example.com/script | base64 -d | bash
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for curl | base64 | bash, got %d", len(f))
+	}
+}
+
+func TestGL011_CurlDownloadOnly_NoFinding(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -sSLO https://install.example.com/setup.sh
+    - bash setup.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when curl downloads without pipe, got %d", len(f))
+	}
+}
+
+func TestGL011_CurlPipeJq_NoFinding(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -s https://api.example.com/data | jq '.version'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for curl | jq, got %d", len(f))
+	}
+}
+
+func TestGL011_CurlPipeGrep_NoFinding(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -s https://example.com/check | grep "version"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for curl | grep, got %d", len(f))
+	}
+}
+
+func TestGL011_BeforeScript(t *testing.T) {
+	f := findings011(t, `
+setup:
+  before_script:
+    - curl -sSL https://example.com/setup.sh | bash
+  script:
+    - make
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in before_script, got %d", len(f))
+	}
+}
+
+func TestGL011_TopLevelBeforeScript(t *testing.T) {
+	f := findings011(t, `
+before_script:
+  - curl -sSL https://example.com/setup.sh | bash
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in top-level before_script, got %d", len(f))
+	}
+}
+
+func TestGL011_LineNumber(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -sSL https://example.com/setup.sh | bash
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl011-curl-pipe-bash.yml
+++ b/testdata/fixtures/gl011-curl-pipe-bash.yml
@@ -1,0 +1,17 @@
+stages:
+  - setup
+  - build
+
+setup:
+  stage: setup
+  image: ubuntu:22.04
+  script:
+    - curl -sSL https://install.example.com/setup.sh | bash
+    - wget -qO- https://raw.example.com/install.sh | sh
+
+build:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build


### PR DESCRIPTION
## What

Implements GL011, which detects script lines that download content with `curl` or `wget` and pipe it directly into a shell interpreter without checksum verification.

## Detection patterns

| Pattern | Example |
|---------|---------|
| Pipe to shell | `curl URL \| bash` / `wget URL \| sh` |
| Pipe to interpreter | `curl URL \| python3` / `\| ruby` / `\| node` |
| Multi-stage pipe | `curl URL \| base64 -d \| bash` |
| Process substitution | `python3 <(curl URL)` |

Not flagged: `curl URL | jq`, `curl URL | grep`, `curl -O URL && bash script.sh`

## Scope

`script`, `before_script`, `after_script` — top-level, `default:`, and per-job.

## Bug fixed during implementation

The initial regex used `ba?sh` which matches `bash` and `bsh` but not plain `sh`. Fixed to `(?:bash|sh|...)` so `wget ... | sh` is correctly detected.

Closes #45