### PR TITLE
feat: GL012 – when: always on deploy-stage job

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL009](docs/rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL010](docs/rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |
 | [GL011](docs/rules/GL011.md) | `error` | Download-and-execute pattern in script (`curl \| bash`, `wget \| sh`) |
+| [GL012](docs/rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL012.md
+++ b/docs/rules/GL012.md
@@ -1,0 +1,57 @@
+# GL012 — `when: always` on deploy-stage job
+
+**Severity:** warn  
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
+
+## What glsec checks
+
+glsec flags jobs that have `when: always` AND are identified as deployment jobs by either:
+
+- Having an `environment:` key (unambiguous deploy context), or
+- Having a `stage:` whose name contains a deploy-related keyword: `deploy`, `release`, `publish`, `ship`, `prod`, `production`, `staging`
+
+Jobs in `test`, `build`, `lint`, or `security` stages are excluded — `when: always` there is sometimes intentional for cleanup or reporting tasks.
+
+## Trigger example
+
+```yaml
+stages: [test, deploy]
+
+sast:
+  stage: test
+  script: run-sast
+
+deploy-production:
+  stage: deploy
+  when: always          # runs even if sast failed
+  environment: production
+  script: ./deploy.sh
+```
+
+## Safe alternative
+
+Remove `when: always` and rely on the default `when: on_success`, which only runs the job if all prior jobs in the pipeline passed:
+
+```yaml
+deploy-production:
+  stage: deploy
+  # when: on_success is the default — no need to specify
+  environment: production
+  script: ./deploy.sh
+```
+
+If you need to deploy after a partial failure (e.g. only one test suite failed), use a dependency-based approach with `needs:` instead of bypassing all gates.
+
+## Why this matters
+
+`when: always` tells GitLab to run the job regardless of the outcome of all preceding jobs. On a deployment job this means:
+
+- A failed SAST scan does not prevent deployment
+- Failed unit tests do not prevent deployment
+- A failed `secret_detection` job does not prevent deployment
+
+The security and quality gates in earlier stages are effectively disabled for the downstream deployment.
+
+## zizmor analogue
+
+`unsound-condition` — same class of flow control bypass on GitHub Actions.

--- a/rules/all.go
+++ b/rules/all.go
@@ -15,5 +15,6 @@ func All() []rule.Rule {
 		GL009,
 		GL010,
 		GL011,
+		GL012,
 	}
 }

--- a/rules/gl012.go
+++ b/rules/gl012.go
@@ -1,0 +1,84 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl012 struct{}
+
+var GL012 = &gl012{}
+
+func (r *gl012) ID() string { return "GL012" }
+
+// deployKeywords identifies stages that represent deployment or release work.
+var deployKeywords = []string{
+	"deploy", "release", "publish", "ship", "prod", "production", "staging",
+}
+
+// excludedStages are stages where when: always can be intentional (e.g. cleanup jobs).
+var excludedStages = map[string]bool{
+	"test":     true,
+	"build":    true,
+	"lint":     true,
+	"security": true,
+}
+
+func (r *gl012) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		when := parser.FindKey(job, "when")
+		if when == nil || when.Kind != yaml.ScalarNode || when.Value != "always" {
+			return
+		}
+
+		stage := ""
+		if s := parser.FindKey(job, "stage"); s != nil && s.Kind == yaml.ScalarNode {
+			stage = s.Value
+		}
+		hasEnvironment := parser.FindKey(job, "environment") != nil
+
+		if !isDeployJob(stage, hasEnvironment) {
+			return
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL012",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"deploy job %q has when: always — it will run even if upstream tests or security scans failed, bypassing quality gates",
+				name.Value,
+			),
+			File: file,
+			Line: when.Line,
+			Col:  when.Column,
+		})
+	})
+
+	return findings
+}
+
+// isDeployJob returns true if the job is a deployment context based on its
+// stage name or the presence of an environment: key.
+func isDeployJob(stage string, hasEnvironment bool) bool {
+	// environment: is unambiguous — always a deploy job.
+	if hasEnvironment {
+		return true
+	}
+	lower := strings.ToLower(stage)
+	// Exclude stages where when: always is sometimes intentional.
+	if excludedStages[lower] {
+		return false
+	}
+	for _, kw := range deployKeywords {
+		if lower == kw || strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/rules/gl012_test.go
+++ b/rules/gl012_test.go
@@ -1,0 +1,143 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings012(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL012.Check(doc.Root, "test.yml")
+}
+
+func TestGL012_DeployStageWhenAlways(t *testing.T) {
+	f := findings012(t, `
+deploy-production:
+  stage: deploy
+  when: always
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL012_EnvironmentWhenAlways(t *testing.T) {
+	f := findings012(t, `
+release:
+  when: always
+  environment: production
+  script: [./release.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for job with environment:, got %d", len(f))
+	}
+}
+
+func TestGL012_ReleaseStage(t *testing.T) {
+	f := findings012(t, `
+publish-npm:
+  stage: release
+  when: always
+  script: [npm publish]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for release stage, got %d", len(f))
+	}
+}
+
+func TestGL012_DeploySubstring(t *testing.T) {
+	f := findings012(t, `
+job:
+  stage: deploy-production
+  when: always
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for stage containing 'deploy', got %d", len(f))
+	}
+}
+
+func TestGL012_WhenOnSuccess_NoFinding(t *testing.T) {
+	f := findings012(t, `
+deploy-production:
+  stage: deploy
+  when: on_success
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for when: on_success, got %d", len(f))
+	}
+}
+
+func TestGL012_NoWhen_NoFinding(t *testing.T) {
+	f := findings012(t, `
+deploy-production:
+  stage: deploy
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when when: is absent, got %d", len(f))
+	}
+}
+
+func TestGL012_TestStageExcluded_NoFinding(t *testing.T) {
+	// when: always in test stage is sometimes intentional (e.g. report upload)
+	f := findings012(t, `
+upload-report:
+  stage: test
+  when: always
+  script: [./upload.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for test stage, got %d", len(f))
+	}
+}
+
+func TestGL012_BuildStageExcluded_NoFinding(t *testing.T) {
+	f := findings012(t, `
+cleanup:
+  stage: build
+  when: always
+  script: [./cleanup.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for build stage, got %d", len(f))
+	}
+}
+
+func TestGL012_UnknownStageNoEnvironment_NoFinding(t *testing.T) {
+	f := findings012(t, `
+notify:
+  stage: notify
+  when: always
+  script: [./notify.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-deploy stage without environment:, got %d", len(f))
+	}
+}
+
+func TestGL012_LineNumber(t *testing.T) {
+	f := findings012(t, `
+deploy-production:
+  stage: deploy
+  when: always
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl012-when-always-deploy.yml
+++ b/testdata/fixtures/gl012-when-always-deploy.yml
@@ -1,0 +1,17 @@
+stages:
+  - test
+  - deploy
+
+sast:
+  stage: test
+  image: node:20.11.0
+  script:
+    - npm audit
+
+deploy-production:
+  stage: deploy
+  when: always
+  environment: production
+  image: alpine:3.19
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
## What

Implements GL012, which flags deploy/release jobs that use `when: always`. This bypasses all upstream quality and security gates — a failed SAST, broken tests, or failed dependency scan will not prevent deployment.

## Detection logic

A job is flagged when:
1. It has `when: always`, AND
2. It is a deployment context, defined as:
   - Has an `environment:` key (unambiguous), OR
   - Its `stage:` contains a deploy-related keyword: `deploy`, `release`, `publish`, `ship`, `prod`, `production`, `staging`

Jobs in `test`, `build`, `lint`, `security` stages are excluded — `when: always` there is sometimes intentional for cleanup or artifact upload.

## Severity

`warn` — the pipeline still runs, but all upstream gates are bypassed.

## zizmor analogue

`unsound-condition` on GitHub Actions.

Closes #46