### PR TITLE
feat: GL013 – production deploy job without branch restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL010](docs/rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |
 | [GL011](docs/rules/GL011.md) | `error` | Download-and-execute pattern in script (`curl \| bash`, `wget \| sh`) |
 | [GL012](docs/rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
+| [GL013](docs/rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL013.md
+++ b/docs/rules/GL013.md
@@ -1,0 +1,56 @@
+# GL013 — Production deploy job without branch restriction
+
+**Severity:** warn  
+**OWASP:** [CICD-SEC-5 – Insufficient PBAC (Pipeline-Based Access Controls)](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)
+
+## What glsec checks
+
+glsec flags jobs that deploy to a production-like environment but have no `rules:` or `only:` clause to restrict which branches or conditions can trigger the deployment.
+
+A job is considered production-like if its `environment:` name contains (case-insensitive): `production`, `prod`, `live`, or `staging`. Both the scalar form and the `{name: ..., url: ...}` mapping form are checked.
+
+## Trigger example
+
+```yaml
+deploy-prod:
+  stage: deploy
+  environment: production   # no rules: — any branch can deploy
+  script: ./deploy-to-prod.sh
+```
+
+## Safe alternative
+
+Restrict the job to the default protected branch:
+
+```yaml
+deploy-prod:
+  stage: deploy
+  environment: production
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_REF_PROTECTED == "true"'
+  script: ./deploy-to-prod.sh
+```
+
+Or with the legacy `only:` syntax:
+
+```yaml
+deploy-prod:
+  stage: deploy
+  environment: production
+  only:
+    - main
+  script: ./deploy-to-prod.sh
+```
+
+## Why this matters
+
+Without a branch restriction:
+
+- Any developer with pipeline trigger access can deploy to production from any branch
+- Hotfix or feature branches can accidentally deploy untested code
+- Manual pipeline runs from the GitLab UI can bypass normal review workflows
+- GitLab's environment protection rules (defined in Settings → CI/CD → Environments) are a second line of defence, not a substitute for restricting which pipelines can target the environment
+
+## zizmor analogue
+
+`secrets-outside-env` — same class of missing access control on GitHub Actions.

--- a/rules/all.go
+++ b/rules/all.go
@@ -16,5 +16,6 @@ func All() []rule.Rule {
 		GL010,
 		GL011,
 		GL012,
+		GL013,
 	}
 }

--- a/rules/gl013.go
+++ b/rules/gl013.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl013 struct{}
+
+var GL013 = &gl013{}
+
+func (r *gl013) ID() string { return "GL013" }
+
+// prodKeywords identifies environment names that represent production-like targets.
+var prodKeywords = []string{
+	"production", "prod", "live", "staging",
+}
+
+func (r *gl013) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		envNode := parser.FindKey(job, "environment")
+		if envNode == nil {
+			return
+		}
+		envName := extractEnvName(envNode)
+		if envName == "" || !isProdEnv(envName) {
+			return
+		}
+		if hasExecutionRestriction(job) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL013",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"job %q deploys to %q but has no rules: or only: clause — any branch can trigger this deployment",
+				name.Value, envName,
+			),
+			File: file,
+			Line: envNode.Line,
+			Col:  envNode.Column,
+		})
+	})
+
+	return findings
+}
+
+func extractEnvName(node *yaml.Node) string {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node.Value
+	case yaml.MappingNode:
+		if v := parser.FindKey(node, "name"); v != nil && v.Kind == yaml.ScalarNode {
+			return v.Value
+		}
+	}
+	return ""
+}
+
+func isProdEnv(name string) bool {
+	lower := strings.ToLower(name)
+	for _, kw := range prodKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasExecutionRestriction returns true if the job has a rules: or only: clause
+// that can limit which branches or conditions trigger it.
+func hasExecutionRestriction(job *yaml.Node) bool {
+	return parser.FindKey(job, "rules") != nil || parser.FindKey(job, "only") != nil
+}

--- a/rules/gl013_test.go
+++ b/rules/gl013_test.go
@@ -1,0 +1,164 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings013(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL013.Check(doc.Root, "test.yml")
+}
+
+func TestGL013_ProdNoRules(t *testing.T) {
+	f := findings013(t, `
+deploy-prod:
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL013_ProdWithRules_NoFinding(t *testing.T) {
+	f := findings013(t, `
+deploy-prod:
+  environment: production
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when rules: is present, got %d", len(f))
+	}
+}
+
+func TestGL013_ProdWithOnly_NoFinding(t *testing.T) {
+	f := findings013(t, `
+deploy-prod:
+  environment: production
+  only:
+    - main
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when only: is present, got %d", len(f))
+	}
+}
+
+func TestGL013_EnvNameProdSubstring(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment: prod-eu-west
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 'prod-eu-west', got %d", len(f))
+	}
+}
+
+func TestGL013_EnvNameLive(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment: live
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 'live', got %d", len(f))
+	}
+}
+
+func TestGL013_EnvNameStaging(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment: staging
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 'staging', got %d", len(f))
+	}
+}
+
+func TestGL013_EnvNameDev_NoFinding(t *testing.T) {
+	f := findings013(t, `
+deploy-dev:
+  environment: development
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for dev environment, got %d", len(f))
+	}
+}
+
+func TestGL013_MappingFormEnv(t *testing.T) {
+	f := findings013(t, `
+deploy-prod:
+  environment:
+    name: production
+    url: https://example.com
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for mapping environment form, got %d", len(f))
+	}
+}
+
+func TestGL013_MappingFormWithRules_NoFinding(t *testing.T) {
+	f := findings013(t, `
+deploy-prod:
+  environment:
+    name: production
+    url: https://example.com
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for mapping env with rules:, got %d", len(f))
+	}
+}
+
+func TestGL013_NoEnvironment_NoFinding(t *testing.T) {
+	f := findings013(t, `
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for job without environment:, got %d", len(f))
+	}
+}
+
+func TestGL013_CaseInsensitive(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment: PRODUCTION
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for uppercase PRODUCTION, got %d", len(f))
+	}
+}
+
+func TestGL013_LineNumber(t *testing.T) {
+	f := findings013(t, `
+deploy-prod:
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl013-prod-deploy-no-restriction.yml
+++ b/testdata/fixtures/gl013-prod-deploy-no-restriction.yml
@@ -1,0 +1,17 @@
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build
+
+deploy-production:
+  stage: deploy
+  image: alpine:3.19
+  environment: production
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
## What

Implements GL013, which flags jobs that deploy to a production-like environment without a `rules:` or `only:` clause. Without such a restriction, any branch can trigger the deployment.

## Detection logic

A job is flagged when:
1. It has an `environment:` key (scalar or `{name: ..., url: ...}` mapping form)
2. The environment name contains a production-like keyword (case-insensitive): `production`, `prod`, `live`, `staging`
3. The job has neither `rules:` nor `only:`

## Examples detected

- `environment: production` — exact match
- `environment: prod-eu-west` — substring match
- `environment: PRODUCTION` — case-insensitive
- `environment: {name: production, url: ...}` — mapping form

## Severity

`warn` — the deployment still works, but branch access controls are absent.

## zizmor analogue

`secrets-outside-env` on GitHub Actions.

Closes #47