### PR TITLE
feat: GL014 – dotenv artifact capturing all environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL011](docs/rules/GL011.md) | `error` | Download-and-execute pattern in script (`curl \| bash`, `wget \| sh`) |
 | [GL012](docs/rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
 | [GL013](docs/rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |
+| [GL014](docs/rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL014.md
+++ b/docs/rules/GL014.md
@@ -1,0 +1,55 @@
+# GL014 — `dotenv` artifact capturing all environment variables
+
+**Severity:** warn  
+**Minimum GitLab version:** 12.9 (`artifacts: reports: dotenv:` was introduced in 12.9)  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags jobs that combine two things:
+
+1. A script line that dumps **all** environment variables to a file (`env >` or `printenv >`)
+2. An `artifacts: reports: dotenv:` entry that uploads that file as a pipeline artifact
+
+This makes `CI_JOB_TOKEN`, masked CI/CD variables, and any other secrets present in the job environment downloadable by any project member who can access pipeline artifacts.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - make build
+    - env > build.env          # captures CI_JOB_TOKEN, AWS_SECRET_ACCESS_KEY, etc.
+  artifacts:
+    reports:
+      dotenv: build.env        # downloadable by any pipeline viewer
+```
+
+## Safe alternative
+
+Export only the specific variables that downstream jobs need:
+
+```yaml
+build:
+  script:
+    - make build
+    - echo "BUILD_VERSION=$BUILD_VERSION" > build.env
+    - echo "IMAGE_TAG=$CI_COMMIT_SHORT_SHA" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+```
+
+## Why this matters
+
+GitLab's `dotenv` report artifact is designed to pass a small set of computed values (e.g. a generated version string) to downstream jobs. When `env >` is used instead, the artifact contains every variable in the job environment, including:
+
+- `CI_JOB_TOKEN` — a scoped GitLab API token
+- All CI/CD variables, even those marked as masked (masking only applies to logs, not artifact files)
+- Cloud provider credentials, deploy keys, and any other secret injected into the job
+
+Any project member with the Reporter role or above can download pipeline artifacts through the GitLab UI or API.
+
+## zizmor analogue
+
+`artipacked` — same credential-in-artifact risk on GitHub Actions.

--- a/rules/all.go
+++ b/rules/all.go
@@ -17,5 +17,6 @@ func All() []rule.Rule {
 		GL011,
 		GL012,
 		GL013,
+		GL014,
 	}
 }

--- a/rules/gl014.go
+++ b/rules/gl014.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl014 struct{}
+
+var GL014 = &gl014{}
+
+func (r *gl014) ID() string { return "GL014" }
+
+// envDumpRe matches script lines that redirect the full environment to a file:
+// "env > file", "env > file", "printenv > file".
+// Does not match "printenv VAR > file" (single-var export) or "env | grep ... > file".
+var envDumpRe = regexp.MustCompile(`\benv\s*>|\bprintenv\s*>`)
+
+func (r *gl014) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		dotenvNode := dotenvArtifactNode(job)
+		if dotenvNode == nil {
+			return
+		}
+		// Check all script blocks for an env dump line.
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			scriptNode := parser.FindKey(job, key)
+			if scriptNode == nil || scriptNode.Kind != yaml.SequenceNode {
+				continue
+			}
+			for _, item := range scriptNode.Content {
+				if item.Kind != yaml.ScalarNode {
+					continue
+				}
+				if envDumpRe.MatchString(item.Value) {
+					findings = append(findings, finding.Finding{
+						RuleID:   "GL014",
+						Severity: finding.Warn,
+						Message: fmt.Sprintf(
+							"job %q dumps all environment variables to a dotenv artifact — CI_JOB_TOKEN and masked secrets are included and downloadable by any pipeline viewer",
+							name.Value,
+						),
+						File: file,
+						Line: item.Line,
+						Col:  item.Column,
+					})
+					return // one finding per job is enough
+				}
+			}
+		}
+	})
+
+	return findings
+}
+
+// dotenvArtifactNode returns the dotenv value node if the job has
+// artifacts.reports.dotenv set, otherwise nil.
+func dotenvArtifactNode(job *yaml.Node) *yaml.Node {
+	artifacts := parser.FindKey(job, "artifacts")
+	if artifacts == nil {
+		return nil
+	}
+	reports := parser.FindKey(artifacts, "reports")
+	if reports == nil {
+		return nil
+	}
+	return parser.FindKey(reports, "dotenv")
+}

--- a/rules/gl014_test.go
+++ b/rules/gl014_test.go
@@ -1,0 +1,148 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings014(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL014.Check(doc.Root, "test.yml")
+}
+
+func TestGL014_EnvDumpWithDotenv(t *testing.T) {
+	f := findings014(t, `
+build:
+  script:
+    - make build
+    - env > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL014_PrintenvDumpWithDotenv(t *testing.T) {
+	f := findings014(t, `
+build:
+  script:
+    - printenv > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for printenv >, got %d", len(f))
+	}
+}
+
+func TestGL014_EnvDumpNoDotenv_NoFinding(t *testing.T) {
+	// env > file without dotenv artifact is not our concern
+	f := findings014(t, `
+build:
+  script:
+    - env > build.env
+    - make build
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when no dotenv artifact, got %d", len(f))
+	}
+}
+
+func TestGL014_DotenvNoEnvDump_NoFinding(t *testing.T) {
+	// dotenv artifact with specific vars is safe
+	f := findings014(t, `
+build:
+  script:
+    - echo "BUILD_VERSION=$BUILD_VERSION" > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for specific var export, got %d", len(f))
+	}
+}
+
+func TestGL014_BeforeScript(t *testing.T) {
+	f := findings014(t, `
+build:
+  before_script:
+    - env > vars.env
+  script:
+    - make
+  artifacts:
+    reports:
+      dotenv: vars.env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for env dump in before_script, got %d", len(f))
+	}
+}
+
+func TestGL014_OneFindingPerJob(t *testing.T) {
+	// Both script lines match but only one finding should be emitted per job
+	f := findings014(t, `
+build:
+  script:
+    - env > build.env
+    - printenv > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding per job, got %d", len(f))
+	}
+}
+
+func TestGL014_MultipleJobs(t *testing.T) {
+	f := findings014(t, `
+build:
+  script:
+    - env > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+test:
+  script:
+    - env > test.env
+  artifacts:
+    reports:
+      dotenv: test.env
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings for two jobs, got %d", len(f))
+	}
+}
+
+func TestGL014_LineNumber(t *testing.T) {
+	f := findings014(t, `
+build:
+  script:
+    - make build
+    - env > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl014-dotenv-all-vars.yml
+++ b/testdata/fixtures/gl014-dotenv-all-vars.yml
@@ -1,0 +1,20 @@
+stages:
+  - build
+  - test
+
+build:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build
+    - env > build.env
+  artifacts:
+    reports:
+      dotenv: build.env
+
+test:
+  stage: test
+  image: node:20.11.0
+  script:
+    - npm test


### PR DESCRIPTION
## What

Implements GL014, which detects jobs that dump all environment variables to a file and upload it as a `dotenv` report artifact. This makes `CI_JOB_TOKEN`, masked CI/CD variables, and any other secrets in the job environment downloadable by any project member with Reporter access.

## Detection logic

A job is flagged when it has **both**:
1. A script line matching `env >` or `printenv >` (full env dump, not a single-var export)
2. `artifacts: reports: dotenv:` set

Single-var exports like `echo "X=$X" > file.env` are **not** flagged.

## Version gating

GL014 is already in `rules/versions.go` as requiring GitLab ≥ 12.9 (when `dotenv` artifacts were introduced).

## Note on the fixture

The fixture also triggers GL005 (no `expire_in`) — that's expected and correct. Two separate rules, two separate problems.

## zizmor analogue

`artipacked` on GitHub Actions.

Closes #48