### PR TITLE
feat: GL015 – user-controlled variable as Docker image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL012](docs/rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
 | [GL013](docs/rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |
 | [GL014](docs/rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
+| [GL015](docs/rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL015.md
+++ b/docs/rules/GL015.md
@@ -1,0 +1,54 @@
+# GL015 — User-controlled variable used as Docker image tag
+
+**Severity:** warn  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution (PPE)](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+
+## What glsec checks
+
+glsec flags `docker build`, `docker push`, `docker tag`, and `podman` commands in scripts that use a user-controlled predefined variable as the image tag (the part after `:`):
+
+| Variable | Controlled by |
+|----------|---------------|
+| `CI_COMMIT_REF_SLUG` | branch / tag name (URL-safe) |
+| `CI_COMMIT_REF_NAME` | branch / tag name |
+| `CI_COMMIT_BRANCH` | branch name |
+| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | MR source branch |
+
+`CI_COMMIT_SHA`, `CI_COMMIT_SHORT_SHA`, and `CI_PIPELINE_ID` are **not** flagged — they are set by GitLab and are not user-controllable.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+    # A developer can create a branch named "latest" or "main" and
+    # overwrite the production image tag
+```
+
+## Safe alternative
+
+Use the commit SHA as the tag — it is unique, immutable, and not influenced by the branch name:
+
+```yaml
+build:
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+    # Optionally also tag as "latest" in a separate step gated to the default branch
+```
+
+## Why this matters
+
+Branch names are set by developers with push access. By creating a branch with a strategically chosen name:
+
+- A branch named `latest` causes the job to overwrite the `latest` production image tag
+- A branch named `main` or `master` overwrites the tag pulled in production deployments
+- The resulting image may be pulled by other pipelines or production systems expecting a stable tag
+
+Unlike a SHA-based tag, a branch-name tag is mutable and can be overwritten repeatedly from any branch.
+
+## Distinct from GL007
+
+GL007 checks the `image:` YAML field for variable interpolation. GL015 specifically checks Docker CLI commands in scripts — a job may use a safe `image:` but still build and push with a dangerous tag.

--- a/rules/all.go
+++ b/rules/all.go
@@ -18,5 +18,6 @@ func All() []rule.Rule {
 		GL012,
 		GL013,
 		GL014,
+		GL015,
 	}
 }

--- a/rules/gl015.go
+++ b/rules/gl015.go
@@ -1,0 +1,87 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl015 struct{}
+
+var GL015 = &gl015{}
+
+func (r *gl015) ID() string { return "GL015" }
+
+var (
+	// dockerCmdRe matches docker or podman build/push/tag/buildx commands.
+	dockerCmdRe = regexp.MustCompile(`\b(?:docker|podman)\s+(?:build|push|tag|buildx)\b`)
+
+	// userControlledTagRe matches an image tag that uses a user-controlled variable,
+	// i.e. a colon (tag separator) followed by a user-controlled predefined variable.
+	// CI_COMMIT_SHA, CI_PIPELINE_ID, and CI_COMMIT_SHORT_SHA are safe — not listed here.
+	userControlledTagRe = regexp.MustCompile(
+		`:\$\{?(?:CI_COMMIT_REF_NAME|CI_COMMIT_REF_SLUG|CI_COMMIT_BRANCH|CI_MERGE_REQUEST_SOURCE_BRANCH_NAME)\}?`,
+	)
+)
+
+func (r *gl015) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkScriptDockerTags(node, file)...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkScriptDockerTags(node, file)...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkScriptDockerTags(node, file)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkScriptDockerTags(node *yaml.Node, file string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if dockerCmdRe.MatchString(item.Value) && userControlledTagRe.MatchString(item.Value) {
+			m := userControlledTagRe.FindString(item.Value)
+			varName := m[2:] // strip ":$"
+			if len(varName) > 0 && varName[0] == '{' {
+				varName = varName[1 : len(varName)-1] // strip braces
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL015",
+				Severity: finding.Warn,
+				Message: fmt.Sprintf(
+					"Docker image tag uses user-controlled variable $%s — a branch named \"latest\" or \"main\" overwrites the production tag; use $CI_COMMIT_SHA instead",
+					varName,
+				),
+				File: file,
+				Line: item.Line,
+				Col:  item.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl015_test.go
+++ b/rules/gl015_test.go
@@ -1,0 +1,135 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings015(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL015.Check(doc.Root, "test.yml")
+}
+
+func TestGL015_DockerBuildRefSlug(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL015_DockerPushRefName(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for docker push with ref name, got %d", len(f))
+	}
+}
+
+func TestGL015_DockerBuildBranch(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - docker build -t registry.example.com/app:$CI_COMMIT_BRANCH .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_BRANCH, got %d", len(f))
+	}
+}
+
+func TestGL015_PodmanBuild(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - podman build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for podman build, got %d", len(f))
+	}
+}
+
+func TestGL015_BraceForm(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - docker push $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_SLUG}
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for brace form, got %d", len(f))
+	}
+}
+
+func TestGL015_SafeSHA_NoFinding(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for SHA tag, got %d", len(f))
+	}
+}
+
+func TestGL015_SafeShortSHA_NoFinding(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA .
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for short SHA tag, got %d", len(f))
+	}
+}
+
+func TestGL015_BuildArgOnly_NoFinding(t *testing.T) {
+	// Using user-controlled var as a build arg, not as a tag — not flagged
+	f := findings015(t, `
+build:
+  script:
+    - docker build --build-arg BRANCH=$CI_COMMIT_REF_NAME .
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for build arg usage, got %d", len(f))
+	}
+}
+
+func TestGL015_NonDockerCommand_NoFinding(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - echo "Branch is $CI_COMMIT_REF_SLUG"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-docker command, got %d", len(f))
+	}
+}
+
+func TestGL015_LineNumber(t *testing.T) {
+	f := findings015(t, `
+build:
+  script:
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl015-docker-tag-user-var.yml
+++ b/testdata/fixtures/gl015-docker-tag-user-var.yml
@@ -1,0 +1,19 @@
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  image: docker:24.0
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+
+deploy:
+  stage: deploy
+  image: alpine:3.19
+  environment: production
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
## What

Implements GL015, which detects Docker/Podman CLI commands in scripts that use user-controlled predefined variables as the image tag. A developer who creates a branch named `latest` or `main` causes the job to overwrite that production tag.

## Detection logic

Flags script lines where **both** conditions are true:
1. Line contains a `docker`/`podman` build/push/tag/buildx command
2. Line contains `:<USER_CONTROLLED_VAR>` — the variable appears as the tag portion (after `:`)

Flagged variables: `CI_COMMIT_REF_SLUG`, `CI_COMMIT_REF_NAME`, `CI_COMMIT_BRANCH`, `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`

Not flagged: `CI_COMMIT_SHA`, `CI_COMMIT_SHORT_SHA`, `CI_PIPELINE_ID` (not user-controllable), `--build-arg VAR=$CI_COMMIT_REF_NAME` (not a tag context)

## Distinct from GL007

GL007 checks the `image:` YAML field. GL015 specifically checks Docker CLI commands in scripts — a different code path with a different risk (tag collision/overwrite vs. arbitrary image execution).

Closes #49