### PR TITLE
feat: GL016 – HTTP instead of HTTPS in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL013](docs/rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |
 | [GL014](docs/rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 | [GL015](docs/rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
+| [GL016](docs/rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -56,6 +56,8 @@ func main() {
 		os.Exit(2)
 	}
 
+	rules.GL016.SetTrustedHosts(cfg.TrustedHosts)
+
 	// --gitlab-version flag overrides the config file value.
 	gitlabVersionStr := cfg.GitLabVersion
 	if *gitlabVersionFlag != "" {

--- a/docs/rules/GL016.md
+++ b/docs/rules/GL016.md
@@ -1,0 +1,65 @@
+# GL016 — HTTP instead of HTTPS in URLs
+
+**Severity:** varies by context (see below)  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags HTTP URLs in security-sensitive locations. Severity depends on context:
+
+| Location | Severity | Risk |
+|----------|----------|------|
+| `include: remote: http://...` | `error` | MITM attacker injects arbitrary pipeline configuration |
+| `curl http://...` / `wget http://...` in scripts | `warn` | MITM attacker serves malicious content |
+| `variables:` value with `http://` | `warn` (public) / `info` (private) | Credential or data interception |
+
+## Host classification
+
+| Host type | Behavior |
+|-----------|----------|
+| `localhost`, `127.0.0.1`, `::1` | Always ignored |
+| Configured in `trusted-hosts:` | Always ignored |
+| RFC 1918 IPs (`10.x`, `172.16–31.x`, `192.168.x`) | Downgraded to `info` |
+| `.local`, `.internal`, `.corp`, `.lan` TLDs | Downgraded to `info` |
+| All other public hosts | Full severity per table above |
+
+## Trigger example
+
+```yaml
+include:
+  - remote: "http://templates.example.com/ci.yml"   # error
+
+build:
+  script:
+    - curl http://install.example.com/tool.sh -o tool.sh   # warn
+
+variables:
+  REGISTRY: "http://nexus.internal/repo"   # info — internal host
+```
+
+## Safe alternative
+
+```yaml
+include:
+  - remote: "https://templates.example.com/ci.yml"
+
+build:
+  script:
+    - curl https://install.example.com/tool.sh -o tool.sh
+    - echo "abc123…  tool.sh" | sha256sum --check
+    - bash tool.sh
+```
+
+## Enterprise allowlist
+
+In corporate environments, internal registries or Artifactory instances may intentionally use HTTP. Add them to `.glsec.yml` to suppress findings:
+
+```yaml
+trusted-hosts:
+  - nexus.internal
+  - registry.corp.example.com
+  - 10.0.0.0/8          # RFC 1918 — private network CIDR
+  - 192.168.0.0/16
+```
+
+Hosts and CIDRs on the allowlist are never flagged regardless of protocol.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	// GitLabVersion is the target GitLab version (e.g. "16.0").
 	// Rules requiring a higher version are skipped.
 	GitLabVersion string `yaml:"gitlab-version"`
+	// TrustedHosts is a list of hostnames or CIDRs whose HTTP URLs are never flagged.
+	TrustedHosts []string `yaml:"trusted-hosts"`
 }
 
 // Default returns a Config with no overrides.
@@ -85,6 +87,7 @@ var allowedTopLevelKeys = map[string]bool{
 	"rules":          true,
 	"min-severity":   true,
 	"gitlab-version": true,
+	"trusted-hosts":  true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {

--- a/rules/all.go
+++ b/rules/all.go
@@ -19,5 +19,6 @@ func All() []rule.Rule {
 		GL013,
 		GL014,
 		GL015,
+		GL016,
 	}
 }

--- a/rules/gl016.go
+++ b/rules/gl016.go
@@ -1,0 +1,234 @@
+package rules
+
+import (
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl016 struct {
+	trustedHosts []string
+}
+
+var GL016 = &gl016{}
+
+func (r *gl016) ID() string { return "GL016" }
+
+// SetTrustedHosts configures the allowlist of hosts/CIDRs that are never flagged.
+func (r *gl016) SetTrustedHosts(hosts []string) {
+	r.trustedHosts = hosts
+}
+
+var (
+	httpURLRe     = regexp.MustCompile(`https?://[^\s'"]+`)
+	curlWgetHTTPRe = regexp.MustCompile(`\b(?:curl|wget)\b[^|]*\bhttp://`)
+	privateRanges  []*net.IPNet
+	internalTLDs   = []string{".local", ".internal", ".corp", ".lan"}
+)
+
+func init() {
+	for _, cidr := range []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"} {
+		_, network, _ := net.ParseCIDR(cidr)
+		privateRanges = append(privateRanges, network)
+	}
+}
+
+func (r *gl016) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	// include: remote: http://...
+	findings = append(findings, r.checkIncludes(parser.FindKey(mapping, "include"), file)...)
+
+	// variables: values
+	findings = append(findings, r.checkVariablesHTTP(parser.FindKey(mapping, "variables"), file)...)
+
+	// per-job
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		findings = append(findings, r.checkVariablesHTTP(parser.FindKey(job, "variables"), file)...)
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, r.checkScriptHTTP(node, file)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func (r *gl016) checkIncludes(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		remote := parser.FindKey(item, "remote")
+		if remote == nil || remote.Kind != yaml.ScalarNode {
+			continue
+		}
+		if !strings.HasPrefix(remote.Value, "http://") {
+			continue
+		}
+		host := hostOf(remote.Value)
+		if r.skip(host) {
+			continue
+		}
+		sev := finding.Error
+		msg := "include: remote: uses HTTP — a MITM attacker can inject arbitrary pipeline configuration"
+		if isPrivateOrInternal(host) {
+			sev = finding.Info
+			msg = "include: remote: uses HTTP to a private/internal host — consider HTTPS even on internal networks"
+		}
+		findings = append(findings, finding.Finding{
+			RuleID: "GL016", Severity: sev, Message: msg,
+			File: file, Line: remote.Line, Col: remote.Column,
+		})
+	}
+	return findings
+}
+
+func (r *gl016) checkVariablesHTTP(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		val := node.Content[i+1]
+		var scalar *yaml.Node
+		switch val.Kind {
+		case yaml.ScalarNode:
+			scalar = val
+		case yaml.MappingNode:
+			if v := parser.FindKey(val, "value"); v != nil && v.Kind == yaml.ScalarNode {
+				scalar = v
+			}
+		}
+		if scalar == nil || !strings.Contains(scalar.Value, "http://") {
+			continue
+		}
+		host := hostOf(scalar.Value)
+		if r.skip(host) {
+			continue
+		}
+		sev := finding.Info
+		msg := "variable value uses HTTP — consider HTTPS to protect data in transit"
+		if !isPrivateOrInternal(host) {
+			sev = finding.Warn
+			msg = "variable value uses HTTP to a public host — a MITM attacker can read or modify traffic"
+		}
+		findings = append(findings, finding.Finding{
+			RuleID: "GL016", Severity: sev, Message: msg,
+			File: file, Line: scalar.Line, Col: scalar.Column,
+		})
+	}
+	return findings
+}
+
+func (r *gl016) checkScriptHTTP(node *yaml.Node, file string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if !curlWgetHTTPRe.MatchString(item.Value) {
+			continue
+		}
+		// Extract the http:// URL from the line to get the host.
+		m := httpURLRe.FindString(item.Value)
+		if m == "" || !strings.HasPrefix(m, "http://") {
+			continue
+		}
+		host := hostOf(m)
+		if r.skip(host) {
+			continue
+		}
+		sev := finding.Warn
+		msg := "script downloads over HTTP — a MITM attacker can serve malicious content"
+		if isPrivateOrInternal(host) {
+			sev = finding.Info
+			msg = "script downloads over HTTP from a private/internal host — consider HTTPS"
+		}
+		findings = append(findings, finding.Finding{
+			RuleID: "GL016", Severity: sev, Message: msg,
+			File: file, Line: item.Line, Col: item.Column,
+		})
+	}
+	return findings
+}
+
+// skip returns true if the host should never be flagged (loopback or trusted).
+func (r *gl016) skip(host string) bool {
+	if isLoopback(host) {
+		return true
+	}
+	for _, entry := range r.trustedHosts {
+		if strings.Contains(entry, "/") {
+			// CIDR entry
+			if hostInCIDR(host, entry) {
+				return true
+			}
+		} else if strings.EqualFold(host, entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLoopback(host string) bool {
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+func isPrivateOrInternal(host string) bool {
+	if ip := net.ParseIP(host); ip != nil {
+		for _, r := range privateRanges {
+			if r.Contains(ip) {
+				return true
+			}
+		}
+		return false
+	}
+	lower := strings.ToLower(host)
+	for _, tld := range internalTLDs {
+		if strings.HasSuffix(lower, tld) {
+			return true
+		}
+	}
+	return false
+}
+
+func hostInCIDR(host, cidr string) bool {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+	return network.Contains(ip)
+}
+
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}

--- a/rules/gl016_test.go
+++ b/rules/gl016_test.go
@@ -1,0 +1,215 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings016(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	r := &gl016{}
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return r.Check(doc.Root, "test.yml")
+}
+
+func findings016trusted(t *testing.T, yaml string, trusted []string) []finding.Finding {
+	t.Helper()
+	r := &gl016{trustedHosts: trusted}
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return r.Check(doc.Root, "test.yml")
+}
+
+func TestGL016_IncludeRemoteHTTP_Error(t *testing.T) {
+	f := findings016(t, `
+include:
+  - remote: "http://templates.example.com/ci.yml"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity for include:remote, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_IncludeRemoteHTTPS_NoFinding(t *testing.T) {
+	f := findings016(t, `
+include:
+  - remote: "https://templates.example.com/ci.yml"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for HTTPS include, got %d", len(f))
+	}
+}
+
+func TestGL016_IncludeRemoteLocalhost_NoFinding(t *testing.T) {
+	f := findings016(t, `
+include:
+  - remote: "http://localhost/ci.yml"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for localhost, got %d", len(f))
+	}
+}
+
+func TestGL016_IncludeRemotePrivateIP_Info(t *testing.T) {
+	f := findings016(t, `
+include:
+  - remote: "http://10.0.1.5/ci.yml"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for private IP, got %d", len(f))
+	}
+	if f[0].Severity != finding.Info {
+		t.Errorf("expected Info severity for private IP, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_IncludeRemoteInternalTLD_Info(t *testing.T) {
+	f := findings016(t, `
+include:
+  - remote: "http://templates.internal/ci.yml"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for .internal host, got %d", len(f))
+	}
+	if f[0].Severity != finding.Info {
+		t.Errorf("expected Info severity for .internal TLD, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_ScriptCurlHTTP_Warn(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - curl http://install.example.com/tool.sh -o tool.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for curl http://, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity for script curl, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_ScriptWgetHTTP_Warn(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - wget http://install.example.com/tool.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for wget http://, got %d", len(f))
+	}
+}
+
+func TestGL016_ScriptCurlHTTPS_NoFinding(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - curl https://install.example.com/tool.sh -o tool.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for curl https://, got %d", len(f))
+	}
+}
+
+func TestGL016_ScriptCurlLocalhost_NoFinding(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - curl http://localhost:8080/health
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for localhost, got %d", len(f))
+	}
+}
+
+func TestGL016_ScriptCurlPrivate_Info(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - curl http://192.168.1.10/artifact.tar.gz -o artifact.tar.gz
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for private IP in script, got %d", len(f))
+	}
+	if f[0].Severity != finding.Info {
+		t.Errorf("expected Info for private IP, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_VariableHTTP_Warn(t *testing.T) {
+	f := findings016(t, `
+variables:
+  REGISTRY: "http://registry.example.com"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for variable with http://, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn for public host in variable, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_VariableHTTPInternal_Info(t *testing.T) {
+	f := findings016(t, `
+variables:
+  NEXUS: "http://nexus.internal/repo"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for .internal variable, got %d", len(f))
+	}
+	if f[0].Severity != finding.Info {
+		t.Errorf("expected Info for .internal variable, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_TrustedHost_NoFinding(t *testing.T) {
+	f := findings016trusted(t, `
+variables:
+  NEXUS: "http://nexus.corp.example.com/repo"
+build:
+  script:
+    - curl http://nexus.corp.example.com/tool.sh -o tool.sh
+`, []string{"nexus.corp.example.com"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for trusted host, got %d", len(f))
+	}
+}
+
+func TestGL016_TrustedCIDR_NoFinding(t *testing.T) {
+	f := findings016trusted(t, `
+build:
+  script:
+    - curl http://10.5.2.3/artifact.tar.gz -o artifact.tar.gz
+`, []string{"10.0.0.0/8"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for host in trusted CIDR, got %d", len(f))
+	}
+}
+
+func TestGL016_LineNumber(t *testing.T) {
+	f := findings016(t, `
+include:
+  - remote: "http://templates.example.com/ci.yml"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl016-http-urls.yml
+++ b/testdata/fixtures/gl016-http-urls.yml
@@ -1,0 +1,16 @@
+include:
+  - remote: "https://templates.example.com/ci.yml"
+
+stages:
+  - build
+
+variables:
+  REGISTRY_URL: "http://registry.example.com"
+
+build:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - curl http://install.example.com/tool.sh -o tool.sh
+    - bash tool.sh


### PR DESCRIPTION
## What

Implements GL016, which detects HTTP URLs in security-sensitive pipeline locations. Severity varies by context and host type.

## Severity matrix

| Location | Public host | Private/internal host | Trusted/loopback |
|----------|-------------|----------------------|------------------|
| `include: remote: http://...` | `error` | `info` | ignored |
| `curl`/`wget http://...` in scripts | `warn` | `info` | ignored |
| `variables:` value with `http://` | `warn` | `info` | ignored |

## Host classification

- **Always ignored:** `localhost`, `127.0.0.1`, `::1`
- **Trusted (config):** entries in `trusted-hosts:` (hostname or CIDR) — always ignored
- **Private/internal:** RFC 1918 IP ranges, `.local`/`.internal`/`.corp`/`.lan` TLDs → downgraded to `info`
- **Public:** full severity

## Config extension

Adds `trusted-hosts:` to `.glsec.yml` for enterprise allowlists:

```yaml
trusted-hosts:
  - nexus.internal
  - registry.corp.example.com
  - 10.0.0.0/8
```

`GL016.SetTrustedHosts()` is called from `main.go` after config load. The `trusted-hosts` key is validated as an unknown-key check pass-through (list of strings — format validated at use time in the rule).

## Notes

- `include: remote: https://...` is **not** flagged (GL003 handles mutable remote includes separately)
- HTTP in `image:` values is not checked — Docker image refs don't include the protocol in practice
- Overlaps with GL011 (curl|bash) intentionally: orthogonal concerns (transport security vs. execution without verification)

Closes #51