### PR TITLE
feat: Docker image published to GHCR on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,5 +41,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@a0c73a10bb6782f082cd6714666c87911e4fc7d3 # v3.10.0
+
+      - uses: docker/login-action@9f4a8ea54ed9055d5f86c993e1f2ffa674f98344 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@4f5b5234679dfa19837d4942067c97d7df43b7b3 # v5.7.0
+        id: meta
+        with:
+          images: ghcr.io/glsec/glsec
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@789f68658055d3ca993799b232b5c46dfe3f114d # v6.16.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o glsec ./cmd/glsec
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /build/glsec /usr/local/bin/glsec
+ENTRYPOINT ["glsec"]

--- a/README.md
+++ b/README.md
@@ -91,15 +91,42 @@ Each rule page contains the full risk description, trigger examples, safe altern
 
 ## CI integration
 
-### GitLab CI
+### GitLab CI — Docker image (recommended)
+
+The fastest way: use the pre-built image from GHCR. No Go toolchain needed.
 
 ```yaml
 glsec:
   stage: test
-  image: golang:1.24-alpine
+  image: ghcr.io/glsec/glsec:latest
   script:
-    - go install github.com/glsec/glsec@latest
     - glsec .gitlab-ci.yml
+```
+
+Pin to a specific release for reproducible pipelines:
+
+```yaml
+glsec:
+  stage: test
+  image: ghcr.io/glsec/glsec:0.1.0
+  script:
+    - glsec .gitlab-ci.yml
+```
+
+### GitLab CI — binary download
+
+For pipelines that cannot pull from GHCR:
+
+```yaml
+glsec:
+  stage: test
+  image: alpine:3.19
+  script:
+    - |
+      curl -sSLO https://github.com/glsec/glsec/releases/latest/download/glsec_linux_amd64.tar.gz
+      echo "$(curl -sSL https://github.com/glsec/glsec/releases/latest/download/checksums.txt | grep glsec_linux_amd64.tar.gz)" | sha256sum -c
+      tar xzf glsec_linux_amd64.tar.gz
+    - ./glsec .gitlab-ci.yml
 ```
 
 ### GitHub Actions
@@ -107,8 +134,9 @@ glsec:
 ```yaml
 - name: Run glsec
   run: |
-    go install github.com/glsec/glsec@latest
-    glsec .gitlab-ci.yml
+    curl -sSLO https://github.com/glsec/glsec/releases/latest/download/glsec_linux_amd64.tar.gz
+    tar xzf glsec_linux_amd64.tar.gz
+    ./glsec .gitlab-ci.yml
 ```
 
 ### SARIF upload to GitHub Code Scanning
@@ -116,8 +144,9 @@ glsec:
 ```yaml
 - name: Run glsec (SARIF)
   run: |
-    go install github.com/glsec/glsec@latest
-    glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
+    curl -sSLO https://github.com/glsec/glsec/releases/latest/download/glsec_linux_amd64.tar.gz
+    tar xzf glsec_linux_amd64.tar.gz
+    ./glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
 - uses: github/codeql-action/upload-sarif@v3
   with:
     sarif_file: glsec.sarif


### PR DESCRIPTION
## What

Implements Option A and C from issue #39 — Docker image on GHCR and binary download instructions.

## Docker image (`ghcr.io/glsec/glsec`)

- Multi-stage build: `golang:1.24-alpine` builder → `alpine:3.19` runtime
- Published automatically on every `v*` tag via `.github/workflows/docker.yml`
- Tagged as `latest`, `X.Y`, and `X.Y.Z`
- CA certificates included (alpine base) so HTTPS works in scripts

## Workflow

`.github/workflows/docker.yml` — triggered on `v*` tags, uses SHA-pinned actions:
- `docker/setup-buildx-action`
- `docker/login-action` (GHCR with `GITHUB_TOKEN`)
- `docker/metadata-action` (auto-generates tags)
- `docker/build-push-action`

## README

Updated CI integration section with three usage patterns:
1. **Docker image** (recommended) — `image: ghcr.io/glsec/glsec:latest`
2. **Binary download** with checksum verification — for pipelines without GHCR access
3. **GitHub Actions** — binary download + SARIF upload example

## Verified

Tested locally:
```
docker run --rm -v $PWD/.gitlab-ci.yml:/ci.yml ghcr.io/glsec/glsec /ci.yml
```

Closes #39