### PR TITLE
feat: GL017 – deploy job without runner tag restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL014](docs/rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 | [GL015](docs/rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
 | [GL016](docs/rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
+| [GL017](docs/rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL017.md
+++ b/docs/rules/GL017.md
@@ -1,0 +1,54 @@
+# GL017 — Deploy/publish job has no `tags:` restriction
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-9 – Improper Artifact Integrity Validation](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation)
+
+## What glsec checks
+
+glsec flags deployment and publish jobs that do not restrict which runner can execute them via `tags:`. Without a `tags:` filter, the job runs on any available runner — including compromised or untrusted self-hosted runners that a team may not intend to use for production workloads.
+
+A job is considered a deployment/publish job if it has:
+- An `environment:` key (any value), or
+- A `stage:` value containing `deploy`, `release`, `publish`, or `ship`
+
+## Trigger example
+
+```yaml
+deploy-prod:
+  stage: deploy
+  environment: production
+  script:
+    - ./deploy.sh
+  # no tags: — runs on any available runner
+```
+
+## Safe alternative
+
+```yaml
+deploy-prod:
+  stage: deploy
+  environment: production
+  tags:
+    - production
+    - docker
+  script:
+    - ./deploy.sh
+```
+
+## Why this matters
+
+In organisations that mix GitLab SaaS runners with self-hosted runners, a deploy job without `tags:` may land on a shared or less-trusted runner. If that runner is compromised, secrets injected into the deployment environment (SSH keys, cloud credentials, API tokens) are exposed to the attacker.
+
+Restricting runners with `tags:` ensures only explicitly trusted infrastructure executes sensitive jobs.
+
+## False positives
+
+If you intentionally run all jobs — including deployments — on GitLab SaaS shared runners and have no self-hosted runners in the project, this finding can be suppressed:
+
+```yaml
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  # glsec:ignore GL017 -- SaaS-only project, no self-hosted runners
+```

--- a/rules/all.go
+++ b/rules/all.go
@@ -20,5 +20,6 @@ func All() []rule.Rule {
 		GL014,
 		GL015,
 		GL016,
+		GL017,
 	}
 }

--- a/rules/gl017.go
+++ b/rules/gl017.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl017 struct{}
+
+var GL017 = &gl017{}
+
+func (r *gl017) ID() string { return "GL017" }
+
+// deployStageKeywords identifies stages that indicate deployment activity.
+var deployStageKeywords = []string{"deploy", "release", "publish", "ship"}
+
+func (r *gl017) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if !isSensitiveJob(job) {
+			return
+		}
+		tagsNode := parser.FindKey(job, "tags")
+		if tagsNode != nil && tagsNode.Kind == yaml.SequenceNode && len(tagsNode.Content) > 0 {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL017",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"job %q deploys or publishes but has no tags: — it can run on any available runner, including untrusted self-hosted runners",
+				name.Value,
+			),
+			File: file,
+			Line: name.Line,
+			Col:  name.Column,
+		})
+	})
+
+	return findings
+}
+
+// isSensitiveJob returns true for jobs that deploy to an environment or
+// whose stage name suggests deployment/release activity.
+func isSensitiveJob(job *yaml.Node) bool {
+	if parser.FindKey(job, "environment") != nil {
+		return true
+	}
+	stageNode := parser.FindKey(job, "stage")
+	if stageNode != nil && stageNode.Kind == yaml.ScalarNode {
+		lower := strings.ToLower(stageNode.Value)
+		for _, kw := range deployStageKeywords {
+			if strings.Contains(lower, kw) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/rules/gl017_test.go
+++ b/rules/gl017_test.go
@@ -1,0 +1,156 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings017(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL017.Check(doc.Root, "test.yml")
+}
+
+func TestGL017_DeployNoTags(t *testing.T) {
+	f := findings017(t, `
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL017_EnvironmentNoTags(t *testing.T) {
+	f := findings017(t, `
+deploy:
+  environment: production
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for environment job without tags, got %d", len(f))
+	}
+}
+
+func TestGL017_DeployWithTags_NoFinding(t *testing.T) {
+	f := findings017(t, `
+deploy-prod:
+  stage: deploy
+  tags:
+    - production
+    - docker
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when tags are set, got %d", len(f))
+	}
+}
+
+func TestGL017_EmptyTagsList(t *testing.T) {
+	f := findings017(t, `
+deploy-prod:
+  stage: deploy
+  tags: []
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for empty tags list, got %d", len(f))
+	}
+}
+
+func TestGL017_BuildJobNoTags_NoFinding(t *testing.T) {
+	f := findings017(t, `
+build:
+  stage: build
+  script:
+    - go build ./...
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-deploy job without tags, got %d", len(f))
+	}
+}
+
+func TestGL017_TestJobNoTags_NoFinding(t *testing.T) {
+	f := findings017(t, `
+unit-tests:
+  stage: test
+  script:
+    - go test ./...
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for test job without tags, got %d", len(f))
+	}
+}
+
+func TestGL017_ReleaseStage(t *testing.T) {
+	f := findings017(t, `
+publish-pkg:
+  stage: release
+  script:
+    - npm publish
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for release-stage job without tags, got %d", len(f))
+	}
+}
+
+func TestGL017_PublishStage(t *testing.T) {
+	f := findings017(t, `
+publish-image:
+  stage: publish
+  script:
+    - docker push $CI_REGISTRY_IMAGE
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for publish-stage job without tags, got %d", len(f))
+	}
+}
+
+func TestGL017_MultipleJobs(t *testing.T) {
+	f := findings017(t, `
+build:
+  stage: build
+  script: [go build]
+
+deploy-staging:
+  stage: deploy
+  script: [./deploy.sh staging]
+
+deploy-prod:
+  environment: production
+  script: [./deploy.sh prod]
+  tags:
+    - prod-runner
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (deploy-staging has no tags), got %d", len(f))
+	}
+}
+
+func TestGL017_LineNumber(t *testing.T) {
+	f := findings017(t, `
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl017-self-hosted-runner.yml
+++ b/testdata/fixtures/gl017-self-hosted-runner.yml
@@ -1,0 +1,16 @@
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  image: golang:1.24-alpine
+  script:
+    - go build ./...
+
+deploy-prod:
+  stage: deploy
+  environment: production
+  script:
+    - ./deploy.sh
+  # no tags: — runs on any available runner


### PR DESCRIPTION
## Summary

Implements GL017: flags deployment and publish jobs that have no `tags:` restriction, meaning they can run on any available runner — including untrusted self-hosted runners.

Closes #73

## Detection logic

A job is flagged if:
1. It has an `environment:` key (any value) **or** its `stage:` contains `deploy`, `release`, `publish`, or `ship`
2. It has no `tags:` key, or `tags: []` (empty list)

Build, test, and lint jobs without tags are intentionally not flagged — the risk only applies to jobs with elevated trust requirements (deploying to environments, publishing artefacts).

## Files changed

- `rules/gl017.go` — rule implementation
- `rules/gl017_test.go` — 10 test cases covering deploy/release/publish stages, environment key, empty tags list, and non-sensitive jobs
- `docs/rules/GL017.md` — rule documentation with false-positive guidance
- `testdata/fixtures/gl017-self-hosted-runner.yml` — fixture for schema validation
- `rules/all.go` — GL017 registered
- `README.md` — GL017 added to rules table

## Test plan

- `go test ./rules/ -run TestGL017` — all 10 cases pass
- `go test ./...` — full suite green
- `go build ./...` — clean build