### PR TITLE
feat: GL020 – download without checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL015](docs/rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
 | [GL016](docs/rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL017](docs/rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
+| [GL020](docs/rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL020.md
+++ b/docs/rules/GL020.md
@@ -1,0 +1,61 @@
+# GL020 — Downloaded file without checksum verification
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags jobs that download a file with `curl` or `wget` (saving to disk) but do not verify its integrity before using it. An attacker who compromises the download source — or performs a man-in-the-middle attack — can replace the file with malicious content that will execute with full pipeline privileges.
+
+This rule complements GL011 (download-and-execute): GL011 catches the immediate `curl | bash` pattern, GL020 catches the subtler two-step variant where the file is saved first and verified later (or not at all).
+
+A job is flagged when:
+1. Any `script`/`before_script`/`after_script` line downloads to disk via `curl -o`, `curl -O`, `curl --output`, `curl -sSLO`, or `wget`
+2. No checksum/signature verification command (`sha256sum`, `shasum`, `md5sum`, `gpg --verify`, `cosign verify`, `openssl dgst`) appears anywhere in the job's script
+
+## Trigger example
+
+```yaml
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - tar xzf tool.tar.gz
+    - ./tool install  # no integrity check performed
+```
+
+## Safe alternatives
+
+**Checksum file:**
+```yaml
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - echo "a3b4c5d6…  tool.tar.gz" | sha256sum -c
+    - tar xzf tool.tar.gz
+    - ./tool install
+```
+
+**GPG signature:**
+```yaml
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - curl -sSLO https://example.com/tool.tar.gz.sig
+    - gpg --verify tool.tar.gz.sig tool.tar.gz
+    - tar xzf tool.tar.gz
+```
+
+**cosign (for OCI artefacts):**
+```yaml
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - cosign verify tool.tar.gz
+    - tar xzf tool.tar.gz
+```
+
+## Notes
+
+- One finding is emitted per job, pointing to the first unverified download line.
+- If checksum verification appears in `before_script`, it counts — the check considers all three script keys together.
+- For the immediate `curl | bash` pattern, see GL011.

--- a/rules/all.go
+++ b/rules/all.go
@@ -21,5 +21,6 @@ func All() []rule.Rule {
 		GL015,
 		GL016,
 		GL017,
+		GL020,
 	}
 }

--- a/rules/gl020.go
+++ b/rules/gl020.go
@@ -1,0 +1,82 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl020 struct{}
+
+var GL020 = &gl020{}
+
+func (r *gl020) ID() string { return "GL020" }
+
+var (
+	// downloadSavesRe matches curl/wget invocations that save to disk rather than piping directly.
+	// Handles -O, -o, --output, and combined flag clusters like -sSLO.
+	downloadSavesRe = regexp.MustCompile(`\b(?:curl\b[^|]*(?:-[a-zA-Z]*[oO]\b|--output\b)|wget\b)`)
+
+	// checksumRe matches checksum/signature verification commands.
+	checksumRe = regexp.MustCompile(`\b(?:sha(?:256|512|1|224|384)sum|shasum|md5sum|gpg\s+--verify|cosign\s+verify|openssl\s+dgst)\b`)
+)
+
+func (r *gl020) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		lines := collectScriptLines(job)
+		if len(lines) == 0 {
+			return
+		}
+
+		// Find the first download-to-disk line.
+		var downloadLine *yaml.Node
+		for _, l := range lines {
+			if downloadSavesRe.MatchString(l.Value) && !isDownloadExecute(l.Value) {
+				downloadLine = l
+				break
+			}
+		}
+		if downloadLine == nil {
+			return
+		}
+
+		// If any line in the job has a checksum command, the job is considered safe.
+		for _, l := range lines {
+			if checksumRe.MatchString(l.Value) {
+				return
+			}
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL020",
+			Severity: finding.Warn,
+			Message:  "job downloads a file with curl/wget but no checksum verification (sha256sum, gpg --verify, etc.) found in script",
+			File:     file,
+			Line:     downloadLine.Line,
+			Col:      downloadLine.Column,
+		})
+	})
+
+	return findings
+}
+
+// collectScriptLines returns all scalar script lines across script/before_script/after_script.
+func collectScriptLines(job *yaml.Node) []*yaml.Node {
+	var lines []*yaml.Node
+	for _, key := range []string{"before_script", "script", "after_script"} {
+		node := parser.FindKey(job, key)
+		if node == nil || node.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range node.Content {
+			if item.Kind == yaml.ScalarNode {
+				lines = append(lines, item)
+			}
+		}
+	}
+	return lines
+}

--- a/rules/gl020_test.go
+++ b/rules/gl020_test.go
@@ -1,0 +1,177 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings020(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL020.Check(doc.Root, "test.yml")
+}
+
+func TestGL020_CurlOThenExecute(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - tar xzf tool.tar.gz
+    - ./tool install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL020_CurlOutputFlag(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSL -o tool.sh https://example.com/install.sh
+    - bash tool.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for -o flag, got %d", len(f))
+	}
+}
+
+func TestGL020_WgetNoChecksum(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - wget https://example.com/tool.tar.gz
+    - tar xzf tool.tar.gz
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for wget without checksum, got %d", len(f))
+	}
+}
+
+func TestGL020_WithSha256sum_NoFinding(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - echo "abc123def456  tool.tar.gz" | sha256sum -c
+    - tar xzf tool.tar.gz
+    - ./tool install
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when sha256sum is present, got %d", len(f))
+	}
+}
+
+func TestGL020_WithShasum_NoFinding(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - shasum -a 256 -c checksums.txt
+    - tar xzf tool.tar.gz
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when shasum is present, got %d", len(f))
+	}
+}
+
+func TestGL020_WithGpgVerify_NoFinding(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - curl -sSLO https://example.com/tool.tar.gz.sig
+    - gpg --verify tool.tar.gz.sig tool.tar.gz
+    - tar xzf tool.tar.gz
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when gpg --verify is present, got %d", len(f))
+	}
+}
+
+func TestGL020_WithCosignVerify_NoFinding(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - cosign verify tool.tar.gz
+    - tar xzf tool.tar.gz
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when cosign verify is present, got %d", len(f))
+	}
+}
+
+func TestGL020_CurlPipeBash_NoFinding(t *testing.T) {
+	// GL011 territory — direct pipe, not a save-then-execute pattern
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSL https://example.com/install.sh | bash
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no GL020 finding for direct curl|bash (covered by GL011), got %d", len(f))
+	}
+}
+
+func TestGL020_NoCurlWget_NoFinding(t *testing.T) {
+	f := findings020(t, `
+build:
+  script:
+    - go build ./...
+    - tar xzf prebuilt.tar.gz
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when no curl/wget present, got %d", len(f))
+	}
+}
+
+func TestGL020_ChecksumInBeforeScript_NoFinding(t *testing.T) {
+	f := findings020(t, `
+install:
+  before_script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - sha256sum -c checksums.txt
+  script:
+    - ./tool install
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when sha256sum is in before_script, got %d", len(f))
+	}
+}
+
+func TestGL020_OneFindinPerJob(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSLO https://example.com/tool1.tar.gz
+    - curl -sSLO https://example.com/tool2.tar.gz
+    - tar xzf tool1.tar.gz && tar xzf tool2.tar.gz
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected exactly 1 finding per job (not per download), got %d", len(f))
+	}
+}
+
+func TestGL020_LineNumber(t *testing.T) {
+	f := findings020(t, `
+install:
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - ./tool install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl020-download-no-checksum.yml
+++ b/testdata/fixtures/gl020-download-no-checksum.yml
@@ -1,0 +1,15 @@
+stages:
+  - install
+  - build
+
+install-tool:
+  stage: install
+  script:
+    - curl -sSLO https://example.com/tool.tar.gz
+    - tar xzf tool.tar.gz
+    - ./tool install
+
+build:
+  stage: build
+  script:
+    - go build ./...


### PR DESCRIPTION
## Summary

Implements GL020: flags jobs that download a file with `curl`/`wget` (saving to disk) but perform no checksum or signature verification before execution.

Closes #76

## Detection logic

A job is flagged when:
1. Any script line downloads to disk via `curl -o`, `curl -O`, `curl --output`, combined flag clusters like `curl -sSLO`, or bare `wget <url>`
2. No verification command (`sha256sum`, `shasum`, `md5sum`, `gpg --verify`, `cosign verify`, `openssl dgst`) appears anywhere across `before_script`/`script`/`after_script`

One finding per job (not per download line). Direct `curl | bash` is explicitly excluded — that's GL011's territory.

Key regex fix during development: `-[oO]\b` didn't match `-sSLO` (bundled flags). Changed to `-[a-zA-Z]*[oO]\b` to handle combined flag clusters.

## Files changed

- `rules/gl020.go` — rule implementation reusing `isDownloadExecute` from GL011 and new `collectScriptLines` helper
- `rules/gl020_test.go` — 12 test cases covering `-sSLO`, `-o flag`, `wget`, sha256sum/shasum/gpg/cosign verification, `curl|bash` exclusion, multi-download dedup, and before_script verification
- `docs/rules/GL020.md` — rule documentation with three safe alternatives
- `testdata/fixtures/gl020-download-no-checksum.yml` — schema validation fixture
- `rules/all.go` — GL020 registered
- `README.md` — GL020 added to rules table

## Test plan

- `go test ./rules/ -run TestGL020` — all 12 cases pass
- `go test ./...` — full suite green
- `go build ./...` — clean build