### PR TITLE
feat: GL021 – secret variable printed to job log

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL016](docs/rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL017](docs/rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
 | [GL020](docs/rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
+| [GL021](docs/rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL021.md
+++ b/docs/rules/GL021.md
@@ -1,0 +1,52 @@
+# GL021 — Secret variable printed to job log
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags script lines that pass a CI variable with a secret-indicating name directly to a print command (`echo`, `printf`, `print`). GitLab's log masking may fail to redact the value if it is shorter than the masking threshold, contains special characters, or appears in certain output contexts — causing it to appear in plain text in the job log.
+
+Variables are considered secret if their name ends with one of: `_TOKEN`, `_SECRET`, `_PASSWORD`, `_PASSWD`, `_PASS`, `_PWD`, `_KEY`, `_CREDENTIAL`, `_CERT`.
+
+## Trigger example
+
+```yaml
+debug:
+  script:
+    - echo $CI_JOB_TOKEN
+    - echo $DEPLOY_PASSWORD
+    - printf "%s\n" "$API_SECRET"
+```
+
+## Safe alternatives
+
+**Check presence without printing the value:**
+
+```yaml
+debug:
+  script:
+    - '[ -n "$CI_JOB_TOKEN" ] && echo "token is set" || echo "token is missing"'
+```
+
+**Print masked confirmation:**
+
+```yaml
+debug:
+  script:
+    - echo "Token length${CI_JOB_TOKEN:+ (set)}"
+```
+
+## Known limitations
+
+- Lines where `: ` (colon space) appears inside the script command may be parsed by YAML as a mapping and will not be scanned. Use single-quoted scalars in `.gitlab-ci.yml` to avoid YAML parsing ambiguity: `- 'echo $MY_TOKEN'`.
+- Detection is based on variable name patterns, not on whether GitLab has actually masked the variable. A variable named `MY_DATA` would not be flagged even if it contains a secret.
+
+## False positives
+
+If a variable name matches the pattern but its value is intentionally public (e.g. `ENVIRONMENT_KEY` used as a config key name, not a credential), suppress with:
+
+```yaml
+script:
+  - echo $ENVIRONMENT_KEY  # glsec:ignore GL021 -- not a secret, public config key name
+```

--- a/rules/all.go
+++ b/rules/all.go
@@ -22,5 +22,6 @@ func All() []rule.Rule {
 		GL016,
 		GL017,
 		GL020,
+		GL021,
 	}
 }

--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -1,0 +1,68 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl021 struct{}
+
+var GL021 = &gl021{}
+
+func (r *gl021) ID() string { return "GL021" }
+
+var (
+	// printCmdRe matches shell output commands.
+	printCmdRe = regexp.MustCompile(`\b(?:echo|printf|print)\b`)
+
+	// secretVarRe matches CI variable references whose names end with a secret-indicating suffix.
+	secretVarRe = regexp.MustCompile(`\$\{?[A-Za-z_][A-Za-z0-9_]*(?:_TOKEN|_SECRET|_PASSWORD|_PASSWD|_PASS|_PWD|_KEY|_CREDENTIAL|_CERT)\}?`)
+
+	// safeCheckRe matches patterns that reference the variable without printing its value:
+	// length checks (-n "$VAR"), default expansions (${VAR:-}, ${VAR:+}), and masked prints.
+	safeCheckRe = regexp.MustCompile(`\[\s*(?:-n|-z)\s+|:\-|:\+`)
+)
+
+func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"before_script", "script", "after_script"} {
+			node := parser.FindKey(job, key)
+			if node == nil || node.Kind != yaml.SequenceNode {
+				continue
+			}
+			for _, item := range node.Content {
+				if item.Kind != yaml.ScalarNode {
+					continue
+				}
+				line := item.Value
+				if !printCmdRe.MatchString(line) {
+					continue
+				}
+				match := secretVarRe.FindString(line)
+				if match == "" {
+					continue
+				}
+				// Skip lines that only check the variable's presence, not its value.
+				if safeCheckRe.MatchString(line) {
+					continue
+				}
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL021",
+					Severity: finding.Warn,
+					Message:  fmt.Sprintf("script prints secret variable %s — value may appear in job logs", match),
+					File:     file,
+					Line:     item.Line,
+					Col:      item.Column,
+				})
+			}
+		}
+	})
+
+	return findings
+}

--- a/rules/gl021_test.go
+++ b/rules/gl021_test.go
@@ -1,0 +1,160 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings021(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL021.Check(doc.Root, "test.yml")
+}
+
+func TestGL021_EchoToken(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo $MY_API_TOKEN
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL021_EchoPassword(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo $DEPLOY_PASSWORD
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for PASSWORD variable, got %d", len(f))
+	}
+}
+
+func TestGL021_EchoCIJobToken(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo $CI_JOB_TOKEN
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_JOB_TOKEN, got %d", len(f))
+	}
+}
+
+func TestGL021_PrintfSecret(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - printf "%s\n" "$API_SECRET"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for printf with secret, got %d", len(f))
+	}
+}
+
+func TestGL021_EchoKey(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo $AWS_SECRET_ACCESS_KEY
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for _KEY variable, got %d", len(f))
+	}
+}
+
+func TestGL021_SafePresenceCheck_NoFinding(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - '[ -n "$MY_API_TOKEN" ] && echo "token set"'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for presence check, got %d", len(f))
+	}
+}
+
+func TestGL021_NoSecretVar_NoFinding(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo "Branch is $CI_COMMIT_REF_NAME"
+    - echo "Job ID: $CI_JOB_ID"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-secret variables, got %d", len(f))
+	}
+}
+
+func TestGL021_NoPrintCommand_NoFinding(t *testing.T) {
+	f := findings021(t, `
+deploy:
+  script:
+    - curl -H "Authorization: Bearer $API_TOKEN" https://api.example.com/deploy
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when no print command present, got %d", len(f))
+	}
+}
+
+func TestGL021_BraceExpansion(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo ${DEPLOY_PASSWORD}
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for brace expansion, got %d", len(f))
+	}
+}
+
+func TestGL021_BeforeScript(t *testing.T) {
+	f := findings021(t, `
+debug:
+  before_script:
+    - echo $CI_REGISTRY_PASSWORD
+  script:
+    - docker login
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in before_script, got %d", len(f))
+	}
+}
+
+func TestGL021_MultipleFindings(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo $API_TOKEN
+    - echo $DEPLOY_PASSWORD
+    - echo "non-secret info"
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL021_LineNumber(t *testing.T) {
+	f := findings021(t, `
+debug:
+  script:
+    - echo $MY_API_TOKEN
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl021-unredacted-secrets.yml
+++ b/testdata/fixtures/gl021-unredacted-secrets.yml
@@ -1,0 +1,14 @@
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  script:
+    - go build ./...
+
+deploy:
+  stage: deploy
+  script:
+    - echo $CI_JOB_TOKEN
+    - ./deploy.sh


### PR DESCRIPTION
## Summary

Implements GL021: flags script lines that pass a CI variable with a secret-indicating name (`_TOKEN`, `_SECRET`, `_PASSWORD`, `_PASSWD`, `_PASS`, `_PWD`, `_KEY`, `_CREDENTIAL`, `_CERT`) to `echo`, `printf`, or `print`. GitLab's log masking is not guaranteed to redact all values.

Closes #77

## Detection logic

Per script line (across `before_script`/`script`/`after_script`):
1. Line contains `echo`, `printf`, or `print`
2. Line contains `$VAR` or `${VAR}` where VAR ends with a secret-indicating suffix
3. Line does NOT match a safe presence-check pattern (`[ -n "$VAR"`, `:-`, `:+`)

One finding per matching line.

## Notable discovery during development

`echo "Token is: $MY_API_TOKEN"` contains `: ` (colon space) which causes gopkg.in/yaml.v3 to parse the sequence item as a MappingNode instead of a ScalarNode — the YAML spec treats `: ` as a key-value separator even inside unquoted scalars. The rule (and the test) is documented accordingly: users should single-quote script lines containing `: ` to avoid YAML ambiguity. This is documented in `docs/rules/GL021.md` under Known limitations.

## Files changed

- `rules/gl021.go` — rule implementation
- `rules/gl021_test.go` — 12 test cases covering `echo`/`printf`, `_TOKEN`/`_PASSWORD`/`_KEY`, brace expansion, before_script, safe presence checks, non-secret vars
- `docs/rules/GL021.md` — rule documentation including YAML parsing limitation
- `testdata/fixtures/gl021-unredacted-secrets.yml` — schema validation fixture
- `rules/all.go` — GL021 registered
- `README.md` — GL021 added to rules table

## Test plan

- `go test ./rules/ -run TestGL021` — all 12 cases pass
- `go test ./...` — full suite green
- `go build ./...` — clean build