### PR TITLE
feat: GL018 – secret variable re-exported at pipeline level

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL015](docs/rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
 | [GL016](docs/rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL017](docs/rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
+| [GL018](docs/rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
 | [GL020](docs/rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
 | [GL021](docs/rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
 

--- a/docs/rules/GL018.md
+++ b/docs/rules/GL018.md
@@ -1,0 +1,51 @@
+# GL018 — Secret variable re-exported at pipeline level
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags top-level `variables:` entries whose name ends with a secret-indicating suffix (`_TOKEN`, `_SECRET`, `_PASSWORD`, `_PASSWD`, `_PASS`, `_PWD`, `_KEY`, `_CREDENTIAL`, `_CERT`) and whose value is a CI variable reference (`$VAR` or `${VAR}`).
+
+This pattern re-exports a GitLab Settings variable at the pipeline level, making it available to **every job** in the pipeline — including test jobs, lint jobs, and jobs triggered by merge requests from untrusted forks. If any of those jobs are compromised (e.g. via a poisoned dependency or injected script), the secret is accessible.
+
+## Trigger example
+
+```yaml
+variables:
+  PROD_DB_PASSWORD: $PROD_DB_PASSWORD   # available to all jobs
+  AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+
+test:
+  script: npm test  # gets PROD_DB_PASSWORD and AWS_SECRET_ACCESS_KEY for free
+
+deploy:
+  environment: production
+  script: ./deploy.sh  # the only job that actually needs these
+```
+
+## Safe alternatives
+
+**Move the variable to job level** so only the job that needs it has access:
+
+```yaml
+deploy:
+  environment: production
+  variables:
+    PROD_DB_PASSWORD: $PROD_DB_PASSWORD   # only available in this job
+  script: ./deploy.sh
+```
+
+**Use GitLab Settings environment scoping** (Settings → CI/CD → Variables → Environment scope): restrict the variable to the `production` environment so it is only injected into jobs with `environment: production`.
+
+## Notes
+
+- Only top-level `variables:` entries are flagged — job-level variables are appropriately scoped and not reported.
+- Literal values (non-variable-reference) with secret-indicating names are covered by GL006, not this rule.
+- Both scalar and extended forms are checked:
+  ```yaml
+  variables:
+    DEPLOY_TOKEN:
+      value: $DEPLOY_TOKEN
+      description: "Used by deploy job"
+  ```

--- a/rules/all.go
+++ b/rules/all.go
@@ -21,6 +21,7 @@ func All() []rule.Rule {
 		GL015,
 		GL016,
 		GL017,
+		GL018,
 		GL020,
 		GL021,
 	}

--- a/rules/gl018.go
+++ b/rules/gl018.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl018 struct{}
+
+var GL018 = &gl018{}
+
+func (r *gl018) ID() string { return "GL018" }
+
+// secretNameSuffixes identifies variable names that suggest secret content.
+var secretNameSuffixes = []string{
+	"_TOKEN", "_SECRET", "_PASSWORD", "_PASSWD", "_PASS", "_PWD",
+	"_KEY", "_CREDENTIAL", "_CERT",
+}
+
+// varRefRe matches a value that is (or starts with) a CI variable reference.
+var varRefRe = regexp.MustCompile(`^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?`)
+
+func (r *gl018) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+	varsNode := parser.FindKey(mapping, "variables")
+	if varsNode == nil || varsNode.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	var findings []finding.Finding
+	for i := 0; i+1 < len(varsNode.Content); i += 2 {
+		nameNode := varsNode.Content[i]
+		valNode := varsNode.Content[i+1]
+
+		if !hasSecretSuffix(nameNode.Value) {
+			continue
+		}
+
+		// Resolve value: scalar or extended {value: ..., description: ...} form.
+		scalar := resolveScalar(valNode)
+		if scalar == nil || !varRefRe.MatchString(scalar.Value) {
+			continue
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL018",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"secret variable %q re-exported at pipeline level from %s — available to all jobs including untrusted ones; scope it to specific jobs or use GitLab Settings environment scoping",
+				nameNode.Value, scalar.Value,
+			),
+			File: file,
+			Line: nameNode.Line,
+			Col:  nameNode.Column,
+		})
+	}
+	return findings
+}
+
+func hasSecretSuffix(name string) bool {
+	upper := strings.ToUpper(name)
+	for _, suffix := range secretNameSuffixes {
+		if strings.HasSuffix(upper, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveScalar(node *yaml.Node) *yaml.Node {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node
+	case yaml.MappingNode:
+		if v := parser.FindKey(node, "value"); v != nil && v.Kind == yaml.ScalarNode {
+			return v
+		}
+	}
+	return nil
+}

--- a/rules/gl018_test.go
+++ b/rules/gl018_test.go
@@ -1,0 +1,135 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings018(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL018.Check(doc.Root, "test.yml")
+}
+
+func TestGL018_PipelineLevelToken(t *testing.T) {
+	f := findings018(t, `
+variables:
+  PROD_API_TOKEN: $PROD_API_TOKEN
+
+build:
+  script: go build
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL018_PipelineLevelPassword(t *testing.T) {
+	f := findings018(t, `
+variables:
+  PROD_DB_PASSWORD: $PROD_DB_PASSWORD
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for _PASSWORD, got %d", len(f))
+	}
+}
+
+func TestGL018_PipelineLevelKey(t *testing.T) {
+	f := findings018(t, `
+variables:
+  AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for _KEY suffix, got %d", len(f))
+	}
+}
+
+func TestGL018_BraceExpansionValue(t *testing.T) {
+	f := findings018(t, `
+variables:
+  API_TOKEN: ${CI_API_TOKEN}
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for brace-expansion value, got %d", len(f))
+	}
+}
+
+func TestGL018_ExtendedForm(t *testing.T) {
+	f := findings018(t, `
+variables:
+  DEPLOY_TOKEN:
+    value: $DEPLOY_TOKEN
+    description: "Deployment token"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for extended variable form, got %d", len(f))
+	}
+}
+
+func TestGL018_LiteralValue_NoFinding(t *testing.T) {
+	// Literal values are GL006's territory
+	f := findings018(t, `
+variables:
+  API_TOKEN: some-non-secret-value
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-variable-reference value, got %d", len(f))
+	}
+}
+
+func TestGL018_NonSecretName_NoFinding(t *testing.T) {
+	f := findings018(t, `
+variables:
+  REGISTRY_URL: $CI_REGISTRY
+  NODE_ENV: production
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-secret variable names, got %d", len(f))
+	}
+}
+
+func TestGL018_JobLevelOnly_NoFinding(t *testing.T) {
+	// Job-level variables are appropriately scoped — not flagged
+	f := findings018(t, `
+deploy:
+  variables:
+    DEPLOY_TOKEN: $DEPLOY_TOKEN
+  script: ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for job-level variables, got %d", len(f))
+	}
+}
+
+func TestGL018_MultipleSecrets(t *testing.T) {
+	f := findings018(t, `
+variables:
+  PROD_DB_PASSWORD: $PROD_DB_PASSWORD
+  API_TOKEN: $MY_API_TOKEN
+  REGISTRY_URL: $CI_REGISTRY
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (password + token), got %d", len(f))
+	}
+}
+
+func TestGL018_LineNumber(t *testing.T) {
+	f := findings018(t, `
+variables:
+  API_TOKEN: $MY_API_TOKEN
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl018-overprovisioned-secrets.yml
+++ b/testdata/fixtures/gl018-overprovisioned-secrets.yml
@@ -1,0 +1,20 @@
+stages:
+  - test
+  - deploy
+
+variables:
+  PROD_DB_PASSWORD: $PROD_DB_PASSWORD
+  API_TOKEN: $MY_API_TOKEN
+
+test:
+  stage: test
+  script:
+    - go test ./...
+
+deploy:
+  stage: deploy
+  environment: production
+  tags:
+    - production
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
## Summary

Implements GL018: flags top-level `variables:` entries whose name ends with a secret-indicating suffix (`_TOKEN`, `_SECRET`, `_PASSWORD`, `_KEY`, etc.) and whose value is a CI variable reference (`$VAR` / `${VAR}`). This re-export pattern makes GitLab Settings secrets available to every job in the pipeline — including untrusted jobs like test runners triggered by fork MRs.

Closes #74

## Detection logic

Checks **only** top-level `variables:` (not job-level — those are correctly scoped). Flags an entry when:
1. Variable NAME ends with a secret-indicating suffix (same set as GL021)
2. Variable VALUE matches `^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?` — a plain variable reference

Both scalar and extended `{value: ..., description: ...}` forms are handled. Literal secret values (non-reference) are GL006's territory.

## Files changed

- `rules/gl018.go` — rule implementation; shares `hasSecretSuffix` helper with similar naming patterns; introduces `resolveScalar` to handle the extended variable form
- `rules/gl018_test.go` — 10 test cases: token/password/key suffixes, brace expansion, extended form, literal values (no finding), non-secret names (no finding), job-level only (no finding), multiple secrets, line numbers
- `docs/rules/GL018.md` — rule documentation with job-level and GitLab Settings environment-scoping as safe alternatives
- `testdata/fixtures/gl018-overprovisioned-secrets.yml` — schema validation fixture
- `rules/all.go` — GL018 registered between GL017 and GL020
- `README.md` — GL018 added to rules table

## Test plan

- `go test ./rules/ -run TestGL018` — all 10 cases pass
- `go test ./...` — full suite green
- `go build ./...` — clean build