### PR TITLE
feat: GL019 – deploy job missing resource_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL016](docs/rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL017](docs/rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
 | [GL018](docs/rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
+| [GL019](docs/rules/GL019.md) | `warn`  | Deploy/publish job has no `resource_group:` — concurrent runs risk race conditions or partial deploys |
 | [GL020](docs/rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
 | [GL021](docs/rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
 

--- a/docs/rules/GL019.md
+++ b/docs/rules/GL019.md
@@ -1,0 +1,50 @@
+# GL019 — Deploy job missing `resource_group:`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+
+## What glsec checks
+
+glsec flags deployment and publish jobs that do not have a `resource_group:` key. Without it, multiple pipeline runs can execute the same deploy job concurrently — causing race conditions, partial deploys, overwritten state, or conflicting releases.
+
+A job is considered a deployment/publish job if it has:
+- An `environment:` key (any value), or
+- A `stage:` value containing `deploy`, `release`, `publish`, or `ship`
+
+## Trigger example
+
+```yaml
+deploy-prod:
+  stage: deploy
+  environment: production
+  script:
+    - ./deploy.sh
+  # no resource_group: — two pipeline runs can deploy simultaneously
+```
+
+## Safe alternative
+
+```yaml
+deploy-prod:
+  stage: deploy
+  environment: production
+  resource_group: production
+  script:
+    - ./deploy.sh
+```
+
+GitLab serialises jobs in the same `resource_group` — the second run waits until the first completes. Use separate group names per environment (e.g. `staging`, `production`) if you want concurrent deploys across environments but serialised deploys within each.
+
+## Why this matters
+
+Without concurrency control, two developers merging to the same branch within seconds of each other can trigger overlapping deploys. The later deploy may start before the earlier one finishes, causing:
+- Configuration to be applied out of order
+- Database migrations to run twice or in the wrong sequence
+- Health checks to pass against the wrong version
+- Partial state visible to end users
+
+## References
+
+- [GitLab `resource_group` documentation](https://docs.gitlab.com/ee/ci/resource_groups/)
+- zizmor `concurrency-limits`
+- GL017 (deploy job without runner `tags:` — complementary rule)

--- a/rules/all.go
+++ b/rules/all.go
@@ -22,6 +22,7 @@ func All() []rule.Rule {
 		GL016,
 		GL017,
 		GL018,
+		GL019,
 		GL020,
 		GL021,
 	}

--- a/rules/gl019.go
+++ b/rules/gl019.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl019 struct{}
+
+var GL019 = &gl019{}
+
+func (r *gl019) ID() string { return "GL019" }
+
+func (r *gl019) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if !isSensitiveJob(job) {
+			return
+		}
+		if parser.FindKey(job, "resource_group") != nil {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL019",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"job %q deploys or publishes but has no resource_group: — concurrent pipeline runs can cause race conditions or partial deploys",
+				name.Value,
+			),
+			File: file,
+			Line: name.Line,
+			Col:  name.Column,
+		})
+	})
+
+	return findings
+}

--- a/rules/gl019_test.go
+++ b/rules/gl019_test.go
@@ -1,0 +1,137 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings019(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL019.Check(doc.Root, "test.yml")
+}
+
+func TestGL019_DeployNoResourceGroup(t *testing.T) {
+	f := findings019(t, `
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL019_EnvironmentNoResourceGroup(t *testing.T) {
+	f := findings019(t, `
+deploy:
+  environment: production
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for environment job, got %d", len(f))
+	}
+}
+
+func TestGL019_WithResourceGroup_NoFinding(t *testing.T) {
+	f := findings019(t, `
+deploy-prod:
+  stage: deploy
+  environment: production
+  resource_group: production
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when resource_group is set, got %d", len(f))
+	}
+}
+
+func TestGL019_BuildJob_NoFinding(t *testing.T) {
+	f := findings019(t, `
+build:
+  stage: build
+  script:
+    - go build ./...
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for build job, got %d", len(f))
+	}
+}
+
+func TestGL019_TestJob_NoFinding(t *testing.T) {
+	f := findings019(t, `
+unit-tests:
+  stage: test
+  script:
+    - go test ./...
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for test job, got %d", len(f))
+	}
+}
+
+func TestGL019_ReleaseStage(t *testing.T) {
+	f := findings019(t, `
+publish-pkg:
+  stage: release
+  script:
+    - npm publish
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for release-stage job, got %d", len(f))
+	}
+}
+
+func TestGL019_PublishStage(t *testing.T) {
+	f := findings019(t, `
+publish-image:
+  stage: publish
+  script:
+    - docker push $CI_REGISTRY_IMAGE
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for publish-stage job, got %d", len(f))
+	}
+}
+
+func TestGL019_MultipleDeployJobs(t *testing.T) {
+	f := findings019(t, `
+deploy-staging:
+  stage: deploy
+  resource_group: staging
+  script: [./deploy.sh staging]
+
+deploy-prod:
+  environment: production
+  script: [./deploy.sh prod]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (deploy-prod missing resource_group), got %d", len(f))
+	}
+}
+
+func TestGL019_LineNumber(t *testing.T) {
+	f := findings019(t, `
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl019-no-resource-group.yml
+++ b/testdata/fixtures/gl019-no-resource-group.yml
@@ -1,0 +1,16 @@
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  image: golang:1.24-alpine
+  script:
+    - go build ./...
+
+deploy-prod:
+  stage: deploy
+  environment: production
+  script:
+    - ./deploy.sh
+  # no resource_group: — concurrent runs possible


### PR DESCRIPTION
## Summary

Implements GL019: flags deployment and publish jobs without `resource_group:`, which allows concurrent pipeline runs to deploy simultaneously — risking race conditions, out-of-order migrations, or partial state.

Closes #75

## Detection logic

Reuses `isSensitiveJob` from GL017 (same sensitive-job detection: `environment:` key OR stage containing `deploy`/`release`/`publish`/`ship`). Flags when `resource_group:` is absent.

The implementation is intentionally minimal at 18 lines — the detection predicate is shared with GL017, keeping duplication zero.

## Files changed

- `rules/gl019.go` — rule implementation (reuses `isSensitiveJob` from GL017)
- `rules/gl019_test.go` — 9 test cases: deploy/release/publish stages, environment key, with resource_group (no finding), build/test jobs (no finding), mixed scenario, line number
- `docs/rules/GL019.md` — rule documentation explaining race condition risks and separate group names per environment
- `testdata/fixtures/gl019-no-resource-group.yml` — schema validation fixture
- `rules/all.go` — GL019 registered between GL018 and GL020
- `README.md` — GL019 added to rules table

## Test plan

- `go test ./rules/ -run TestGL019` — all 9 cases pass
- `go test ./...` — full suite green
- `go build ./...` — clean build