### PR TITLE
feat: GL022 – unpinned package manager install or update in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL019](docs/rules/GL019.md) | `warn`  | Deploy/publish job has no `resource_group:` — concurrent runs risk race conditions or partial deploys |
 | [GL020](docs/rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
 | [GL021](docs/rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
+| [GL022](docs/rules/GL022.md) | `warn`  | Package manager install without version pin or explicit update-to-latest in CI |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL022.md
+++ b/docs/rules/GL022.md
@@ -1,0 +1,62 @@
+# GL022 — Package manager install without version pin
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags two categories of problematic package manager usage in CI scripts:
+
+**1. Install without a pinned version** — pulls whatever is latest at the time the job runs, making the pipeline non-reproducible. A compromised or updated package can silently change pipeline behaviour.
+
+**2. Explicit update-to-latest commands** — commands like `npm update`, `composer update`, or `pip install --upgrade` are designed for local development workflows and are almost never appropriate in CI.
+
+## Detected package managers
+
+### Unpinned installs
+
+| Package manager | Unpinned (flagged) | Pinned (safe) |
+|----------------|-------------------|---------------|
+| pip | `pip install requests` | `pip install requests==2.31.0` |
+| npm (global) | `npm install -g typescript` | `npm install -g typescript@5.4.5` |
+| apt-get / apt | `apt-get install jq` | `apt-get install jq=1.6-2` |
+| apk | `apk add curl` | `apk add curl=8.5.0-r0` |
+| gem | `gem install bundler` | `gem install bundler -v 2.5.6` |
+| cargo | `cargo install cargo-audit` | `cargo install cargo-audit --version 0.20.0` |
+
+### Explicit update commands (always flagged)
+
+`npm update`, `yarn upgrade`, `pnpm update`, `composer update`, `bundle update`, `gem update`, `cargo update`, `pip install --upgrade <pkg>`
+
+## Trigger examples
+
+```yaml
+build:
+  script:
+    - pip install ansible              # unpinned
+    - npm install -g @angular/cli      # unpinned scoped package
+    - apt-get install -y jq            # unpinned
+    - npm update                       # explicit update
+    - composer update                  # explicit update
+    - pip install --upgrade ansible    # explicit upgrade
+```
+
+## Safe alternatives
+
+```yaml
+build:
+  script:
+    - pip install ansible==9.2.0
+    - npm install -g @angular/cli@17.3.6
+    - apt-get install -y jq=1.6-2
+    - apk add --no-cache curl=8.5.0-r0
+    - gem install bundler -v 2.5.6
+    - cargo install cargo-audit --version 0.20.0
+```
+
+## Notes
+
+- `pip install -r requirements.txt` and `pip install .` are not flagged — use of a requirements file or local package install is expected.
+- `npm install` without `-g` / `--global` is not flagged — it installs from `package.json` (see GL023 for lockfile concerns).
+- `npm install -g @scope/pkg` (scoped package without version) is flagged; `@scope/pkg@version` is safe.
+- For project-level dependency lockfile concerns (e.g. `npm install` vs `npm ci`), see GL023.

--- a/rules/all.go
+++ b/rules/all.go
@@ -25,5 +25,6 @@ func All() []rule.Rule {
 		GL019,
 		GL020,
 		GL021,
+		GL022,
 	}
 }

--- a/rules/gl022.go
+++ b/rules/gl022.go
@@ -1,0 +1,138 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl022 struct{}
+
+var GL022 = &gl022{}
+
+func (r *gl022) ID() string { return "GL022" }
+
+// pmInstallCheck describes how to detect an unpinned package manager install.
+type pmInstallCheck struct {
+	manager string
+	trigger *regexp.Regexp // matches the install command
+	pinned  *regexp.Regexp // if present, version is pinned → no finding
+	skip    *regexp.Regexp // if present, skip the line entirely (e.g. -r file)
+}
+
+// pmUpdateCheck describes explicit update-to-latest commands that are always wrong in CI.
+type pmUpdateCheck struct {
+	manager string
+	re      *regexp.Regexp
+}
+
+var (
+	pmInstallChecks = []pmInstallCheck{
+		{
+			manager: "pip",
+			trigger: regexp.MustCompile(`\bpip[23]?\s+install\b`),
+			pinned:  regexp.MustCompile(`==|~=|!=|>=|<=`),
+			skip:    regexp.MustCompile(`\s-r\s|\s-r$|-e\s|\.\s*(?:$|&&|\|)|--upgrade\b|-U\b`),
+		},
+		{
+			manager: "npm (global)",
+			trigger: regexp.MustCompile(`\bnpm\s+install\b.*(?:-g\b|--global\b)`),
+			pinned:  regexp.MustCompile(`@\d`),
+			skip:    nil,
+		},
+		{
+			manager: "apt-get",
+			trigger: regexp.MustCompile(`\bapt(?:-get)?\s+install\b`),
+			pinned:  regexp.MustCompile(`\b\S+=\d`),
+			skip:    nil,
+		},
+		{
+			manager: "apk",
+			trigger: regexp.MustCompile(`\bapk\s+add\b`),
+			pinned:  regexp.MustCompile(`\b\S+=\d`),
+			skip:    nil,
+		},
+		{
+			manager: "gem",
+			trigger: regexp.MustCompile(`\bgem\s+install\b`),
+			pinned:  regexp.MustCompile(`(?:-v|--version)\s+\d`),
+			skip:    nil,
+		},
+		{
+			manager: "cargo",
+			trigger: regexp.MustCompile(`\bcargo\s+install\b`),
+			pinned:  regexp.MustCompile(`(?:--version|--vers)\s+\d`),
+			skip:    nil,
+		},
+	}
+
+	pmUpdateChecks = []pmUpdateCheck{
+		{"npm", regexp.MustCompile(`\bnpm\s+update\b`)},
+		{"yarn", regexp.MustCompile(`\byarn\s+upgrade\b`)},
+		{"pnpm", regexp.MustCompile(`\bpnpm\s+update\b`)},
+		{"composer", regexp.MustCompile(`\bcomposer\s+update\b`)},
+		{"bundler", regexp.MustCompile(`\bbundle\s+update\b`)},
+		{"gem", regexp.MustCompile(`\bgem\s+update\b`)},
+		{"cargo", regexp.MustCompile(`\bcargo\s+update\b`)},
+		{"pip (--upgrade)", regexp.MustCompile(`\bpip[23]?\s+install\b.*(?:--upgrade\b|-U\b)`)},
+	}
+)
+
+func (r *gl022) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		lines := collectScriptLines(job)
+		for _, l := range lines {
+			if f := checkPMLine(l.Value, file, l.Line, l.Column); f != nil {
+				findings = append(findings, *f)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkPMLine(line, file string, lineNum, col int) *finding.Finding {
+	// Explicit update commands — always wrong in CI.
+	for _, uc := range pmUpdateChecks {
+		if uc.re.MatchString(line) {
+			f := finding.Finding{
+				RuleID:   "GL022",
+				Severity: finding.Warn,
+				Message:  fmt.Sprintf("%s update command used in CI — always pulls latest, making the pipeline non-reproducible", uc.manager),
+				File:     file,
+				Line:     lineNum,
+				Col:      col,
+			}
+			return &f
+		}
+	}
+
+	// Install without version pin.
+	for _, ic := range pmInstallChecks {
+		if !ic.trigger.MatchString(line) {
+			continue
+		}
+		if ic.skip != nil && ic.skip.MatchString(line) {
+			continue
+		}
+		if ic.pinned != nil && ic.pinned.MatchString(line) {
+			continue
+		}
+		f := finding.Finding{
+			RuleID:   "GL022",
+			Severity: finding.Warn,
+			Message:  fmt.Sprintf("%s install without version pin — use an exact version to make the pipeline reproducible", ic.manager),
+			File:     file,
+			Line:     lineNum,
+			Col:      col,
+		}
+		return &f
+	}
+
+	return nil
+}

--- a/rules/gl022_test.go
+++ b/rules/gl022_test.go
@@ -1,0 +1,293 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings022(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL022.Check(doc.Root, "test.yml")
+}
+
+// --- pip ---
+
+func TestGL022_PipUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - pip install ansible
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned pip install, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL022_PipPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - pip install ansible==9.2.0
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned pip install, got %d", len(f))
+	}
+}
+
+func TestGL022_PipRequirementsFile_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - pip install -r requirements.txt
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pip install -r, got %d", len(f))
+	}
+}
+
+func TestGL022_PipUpgrade(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - pip install --upgrade ansible
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for pip --upgrade, got %d", len(f))
+	}
+}
+
+func TestGL022_PipLocalPackage_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - pip install .
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pip install . (local), got %d", len(f))
+	}
+}
+
+// --- npm ---
+
+func TestGL022_NpmGlobalUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - npm install -g typescript
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned npm install -g, got %d", len(f))
+	}
+}
+
+func TestGL022_NpmGlobalPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - npm install -g typescript@5.4.5
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned npm install -g, got %d", len(f))
+	}
+}
+
+func TestGL022_NpmScopedUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - npm install -g @angular/cli
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for scoped npm package without version, got %d", len(f))
+	}
+}
+
+func TestGL022_NpmScopedPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - npm install -g @angular/cli@17.3.6
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for scoped npm package with version, got %d", len(f))
+	}
+}
+
+func TestGL022_NpmUpdate(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - npm update
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for npm update, got %d", len(f))
+	}
+}
+
+func TestGL022_NpmInstallLocal_NoFinding(t *testing.T) {
+	// npm install without -g installs from package.json — covered by GL023
+	f := findings022(t, `
+build:
+  script:
+    - npm install
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for npm install (local), got %d", len(f))
+	}
+}
+
+// --- apt-get ---
+
+func TestGL022_AptGetUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - apt-get install -y jq
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned apt-get install, got %d", len(f))
+	}
+}
+
+func TestGL022_AptGetPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - apt-get install -y jq=1.6-2
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned apt-get install, got %d", len(f))
+	}
+}
+
+// --- apk ---
+
+func TestGL022_ApkUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - apk add --no-cache curl
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned apk add, got %d", len(f))
+	}
+}
+
+func TestGL022_ApkPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - apk add --no-cache curl=8.5.0-r0
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned apk add, got %d", len(f))
+	}
+}
+
+// --- gem ---
+
+func TestGL022_GemUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - gem install bundler
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned gem install, got %d", len(f))
+	}
+}
+
+func TestGL022_GemPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - gem install bundler -v 2.5.6
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned gem install, got %d", len(f))
+	}
+}
+
+// --- cargo ---
+
+func TestGL022_CargoUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - cargo install cargo-audit
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned cargo install, got %d", len(f))
+	}
+}
+
+func TestGL022_CargoPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - cargo install cargo-audit --version 0.20.0
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned cargo install, got %d", len(f))
+	}
+}
+
+// --- update commands ---
+
+func TestGL022_ComposerUpdate(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - composer update
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for composer update, got %d", len(f))
+	}
+}
+
+func TestGL022_BundleUpdate(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - bundle update
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for bundle update, got %d", len(f))
+	}
+}
+
+func TestGL022_CargoUpdate(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - cargo update
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for cargo update, got %d", len(f))
+	}
+}
+
+// --- general ---
+
+func TestGL022_LineNumber(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - pip install ansible
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl022-unpinned-packages.yml
+++ b/testdata/fixtures/gl022-unpinned-packages.yml
@@ -1,0 +1,10 @@
+stages:
+  - build
+
+build:
+  stage: build
+  image: python:3.12
+  script:
+    - pip install ansible
+    - npm install -g @angular/cli
+    - apt-get install -y jq


### PR DESCRIPTION
## Summary

Implements GL022: flags script lines that install packages without a version pin, or use explicit update-to-latest commands (`npm update`, `composer update`, etc.) that are almost never appropriate in CI.

Closes #78

## Detection logic

Two categories, checked per script line:

**Explicit update commands** (always flagged): `npm update`, `yarn upgrade`, `pnpm update`, `composer update`, `bundle update`, `gem update`, `cargo update`, `pip install --upgrade`

**Unpinned installs** (flagged when no version pin present):

| PM | Trigger | Pin pattern | Skip |
|----|---------|-------------|------|
| pip | `pip install` | `==`, `~=`, `>=` etc. | `-r file`, `.`, `-e`, `--upgrade` |
| npm global | `npm install -g` | `@<digit>` | — |
| apt-get/apt | `apt[-get] install` | `pkg=<digit>` | — |
| apk | `apk add` | `pkg=<digit>` | — |
| gem | `gem install` | `-v`/`--version <digit>` | — |
| cargo | `cargo install` | `--version`/`--vers <digit>` | — |

`npm install` without `-g` is intentionally excluded — that's a lockfile concern covered by GL023.

## Files changed

- `rules/gl022.go` — `pmInstallCheck` and `pmUpdateCheck` structs; `checkPMLine` helper for clean per-line evaluation; reuses `collectScriptLines` from GL020
- `rules/gl022_test.go` — 23 test cases covering all 6 package managers (pinned + unpinned), scoped npm packages, local pip install, 3 update commands, line number
- `docs/rules/GL022.md` — full rule documentation
- `testdata/fixtures/gl022-unpinned-packages.yml` — schema validation fixture
- `rules/all.go` — GL022 registered
- `README.md` — GL022 added to rules table

## Test plan

- `go test ./rules/ -run TestGL022` — all 23 cases pass
- `go test ./...` — full suite green
- `go build ./...` — clean build