### PR TITLE
feat: GL023 – lockfile not enforced in CI install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL020](docs/rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
 | [GL021](docs/rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
 | [GL022](docs/rules/GL022.md) | `warn`  | Package manager install without version pin or explicit update-to-latest in CI |
+| [GL023](docs/rules/GL023.md) | `warn`  | Lockfile not enforced (`npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, etc.) |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL023.md
+++ b/docs/rules/GL023.md
@@ -1,0 +1,61 @@
+# GL023 — Lockfile not enforced in CI install command
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags package manager install commands that do not enforce the committed lockfile. Even when a lockfile (`package-lock.json`, `yarn.lock`, `Gemfile.lock`, etc.) exists, using the wrong command allows the package manager to silently resolve to different versions — either because version ranges in the manifest allow newer versions, or because the lockfile is out of sync with the manifest.
+
+This is distinct from GL022 (installing without any version pin): GL023 assumes a lockfile exists but flags the command that ignores it.
+
+## Detected patterns
+
+| Package manager | Non-strict (flagged) | Strict alternative |
+|----------------|---------------------|-------------------|
+| npm | `npm install` | `npm ci` |
+| Yarn | `yarn install` | `yarn install --frozen-lockfile` |
+| Yarn Berry | `yarn install` | `yarn install --immutable` |
+| pnpm | `pnpm install` | `pnpm install --frozen-lockfile` |
+| Bundler | `bundle install` | `bundle install --frozen` or `--deployment` |
+
+## Trigger examples
+
+```yaml
+build:
+  script:
+    - npm install              # can update package-lock.json
+    - yarn install             # resolves without lockfile enforcement
+    - pnpm install             # same
+    - bundle install           # same
+    - npm install --production # flags are allowed but strictness still missing
+```
+
+## Safe alternatives
+
+```yaml
+build:
+  script:
+    - npm ci
+    - yarn install --frozen-lockfile
+    - pnpm install --frozen-lockfile
+    - bundle install --frozen
+```
+
+## Why `npm install` vs `npm ci` matters
+
+`npm install`:
+- Updates `package-lock.json` if it is out of sync with `package.json`
+- Installs the latest version permitted by version ranges
+- Does NOT fail if the lockfile is missing
+
+`npm ci`:
+- Fails immediately if `package-lock.json` is missing or out of sync
+- Always installs exactly what is in the lockfile
+- Removes `node_modules` before installing (clean state)
+
+## Notes
+
+- `npm install <package-name>` (installing a specific package) is not flagged by this rule — that is GL022's concern.
+- `npm install -g <package>` (global install) is GL022's concern.
+- `composer install` (PHP) is the correct lockfile-respecting command and is not flagged. `composer update` is flagged by GL022.

--- a/rules/all.go
+++ b/rules/all.go
@@ -26,5 +26,6 @@ func All() []rule.Rule {
 		GL020,
 		GL021,
 		GL022,
+		GL023,
 	}
 }

--- a/rules/gl023.go
+++ b/rules/gl023.go
@@ -1,0 +1,98 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl023 struct{}
+
+var GL023 = &gl023{}
+
+func (r *gl023) ID() string { return "GL023" }
+
+// lockfileCheck describes a non-lockfile-strict install command.
+type lockfileCheck struct {
+	manager    string
+	trigger    *regexp.Regexp // matches the non-strict command
+	strictFlag *regexp.Regexp // if present in the same line, command is already strict
+	skip       *regexp.Regexp // skip the line entirely (e.g., package argument present)
+	hint       string         // safe alternative to show in the message
+}
+
+var lockfileChecks = []lockfileCheck{
+	{
+		// npm install (bare, no package args) — strict form is `npm ci`
+		manager: "npm",
+		// Matches npm install followed by only flags (words starting with -), then end/separator.
+		// If a non-flag argument (package name) follows, the regex won't match.
+		trigger:    regexp.MustCompile(`\bnpm\s+install(?:\s+--?[\w=@./:-]+)*\s*(?:$|[|&;])`),
+		strictFlag: nil, // npm ci is a different command entirely
+		skip:       regexp.MustCompile(`-g\b|--global\b`),
+		hint:       "npm ci",
+	},
+	{
+		manager:    "yarn",
+		trigger:    regexp.MustCompile(`\byarn\s+install\b`),
+		strictFlag: regexp.MustCompile(`--frozen-lockfile\b|--immutable\b`),
+		skip:       nil,
+		hint:       "yarn install --frozen-lockfile",
+	},
+	{
+		manager:    "pnpm",
+		trigger:    regexp.MustCompile(`\bpnpm\s+install\b`),
+		strictFlag: regexp.MustCompile(`--frozen-lockfile\b`),
+		skip:       nil,
+		hint:       "pnpm install --frozen-lockfile",
+	},
+	{
+		manager:    "bundler",
+		trigger:    regexp.MustCompile(`\bbundle\s+install\b`),
+		strictFlag: regexp.MustCompile(`--frozen\b|--deployment\b`),
+		skip:       nil,
+		hint:       "bundle install --frozen",
+	},
+}
+
+func (r *gl023) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		lines := collectScriptLines(job)
+		for _, l := range lines {
+			if f := checkLockfileLine(l.Value, file, l.Line, l.Column); f != nil {
+				findings = append(findings, *f)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkLockfileLine(line, file string, lineNum, col int) *finding.Finding {
+	for _, lc := range lockfileChecks {
+		if !lc.trigger.MatchString(line) {
+			continue
+		}
+		if lc.skip != nil && lc.skip.MatchString(line) {
+			continue
+		}
+		if lc.strictFlag != nil && lc.strictFlag.MatchString(line) {
+			continue
+		}
+		f := finding.Finding{
+			RuleID:   "GL023",
+			Severity: finding.Warn,
+			Message:  fmt.Sprintf("%s install without lockfile enforcement — use %q to guarantee reproducible dependency resolution", lc.manager, lc.hint),
+			File:     file,
+			Line:     lineNum,
+			Col:      col,
+		}
+		return &f
+	}
+	return nil
+}

--- a/rules/gl023_test.go
+++ b/rules/gl023_test.go
@@ -1,0 +1,204 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings023(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL023.Check(doc.Root, "test.yml")
+}
+
+// --- npm ---
+
+func TestGL023_NpmInstall(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - npm install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for npm install, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL023_NpmInstallWithFlags(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - npm install --production
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for npm install --production, got %d", len(f))
+	}
+}
+
+func TestGL023_NpmCi_NoFinding(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - npm ci
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for npm ci, got %d", len(f))
+	}
+}
+
+func TestGL023_NpmInstallPackage_NoFinding(t *testing.T) {
+	// Installing a specific package is GL022's territory, not GL023
+	f := findings023(t, `
+build:
+  script:
+    - npm install typescript
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for npm install <package>, got %d", len(f))
+	}
+}
+
+func TestGL023_NpmInstallGlobal_NoFinding(t *testing.T) {
+	// Global installs are GL022's territory
+	f := findings023(t, `
+build:
+  script:
+    - npm install -g typescript
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for npm install -g (covered by GL022), got %d", len(f))
+	}
+}
+
+// --- yarn ---
+
+func TestGL023_YarnInstall(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - yarn install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for yarn install, got %d", len(f))
+	}
+}
+
+func TestGL023_YarnFrozen_NoFinding(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - yarn install --frozen-lockfile
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for yarn install --frozen-lockfile, got %d", len(f))
+	}
+}
+
+func TestGL023_YarnImmutable_NoFinding(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - yarn install --immutable
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for yarn install --immutable (Yarn Berry), got %d", len(f))
+	}
+}
+
+// --- pnpm ---
+
+func TestGL023_PnpmInstall(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - pnpm install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for pnpm install, got %d", len(f))
+	}
+}
+
+func TestGL023_PnpmFrozen_NoFinding(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - pnpm install --frozen-lockfile
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pnpm install --frozen-lockfile, got %d", len(f))
+	}
+}
+
+// --- bundler ---
+
+func TestGL023_BundleInstall(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - bundle install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for bundle install, got %d", len(f))
+	}
+}
+
+func TestGL023_BundleFrozen_NoFinding(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - bundle install --frozen
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for bundle install --frozen, got %d", len(f))
+	}
+}
+
+func TestGL023_BundleDeployment_NoFinding(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - bundle install --deployment
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for bundle install --deployment, got %d", len(f))
+	}
+}
+
+// --- general ---
+
+func TestGL023_MultipleJobs(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - npm ci
+
+test:
+  script:
+    - yarn install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (yarn, not npm ci), got %d", len(f))
+	}
+}
+
+func TestGL023_LineNumber(t *testing.T) {
+	f := findings023(t, `
+build:
+  script:
+    - npm install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl023-lockfile-integrity.yml
+++ b/testdata/fixtures/gl023-lockfile-integrity.yml
@@ -1,0 +1,15 @@
+stages:
+  - build
+  - test
+
+build:
+  stage: build
+  image: node:20
+  script:
+    - npm install
+
+test:
+  stage: test
+  image: ruby:3.3
+  script:
+    - bundle install


### PR DESCRIPTION
## Summary

Implements GL023: flags package manager install commands that don't enforce the committed lockfile — `npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, `pnpm install` without `--frozen-lockfile`, and `bundle install` without `--frozen`/`--deployment`.

Closes #79

## Detection logic

`lockfileCheck` struct (trigger regex + strictFlag regex + skip regex + hint string), evaluated per script line via `checkLockfileLine`. Reuses `collectScriptLines` from GL020.

The npm case required a careful regex to distinguish `npm install` (bare, flag GL023) from `npm install <package>` (package arg, skip — GL022 handles that) and `npm install -g <pkg>` (global, skip — GL022 handles that):

```
\bnpm\s+install(?:\s+--?[\w=@./:-]+)*\s*(?:$|[|&;])
```

After `install`, only words starting with `-` are allowed as flags. If a non-flag word (package name like `typescript` or `@angular/cli`) follows, the regex fails to match → not flagged by GL023.

## Files changed

- `rules/gl023.go` — `lockfileCheck` struct; `checkLockfileLine` helper; 4 ecosystem checks (npm, yarn, pnpm, bundler)
- `rules/gl023_test.go` — 15 test cases covering all 4 ecosystems, flags-only npm install, npm ci (no finding), package arg (no finding), global (no finding), Yarn Berry `--immutable`, `--deployment`
- `docs/rules/GL023.md` — full documentation with npm install vs npm ci explanation
- `testdata/fixtures/gl023-lockfile-integrity.yml` — schema validation fixture
- `rules/all.go` — GL023 registered
- `README.md` — GL023 added to rules table

## Test plan

- `go test ./rules/ -run TestGL023` — all 15 cases pass
- `go test ./...` — full suite green
- `go build ./...` — clean build