### PR TITLE
feat: GL024 – shell pipe without set -o pipefail

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL021](docs/rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
 | [GL022](docs/rules/GL022.md) | `warn`  | Package manager install without version pin or explicit update-to-latest in CI |
 | [GL023](docs/rules/GL023.md) | `warn`  | Lockfile not enforced (`npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, etc.) |
+| [GL024](docs/rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL024.md
+++ b/docs/rules/GL024.md
@@ -1,0 +1,69 @@
+# GL024 — Shell pipe without `set -o pipefail`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+
+## What glsec checks
+
+glsec flags jobs that use shell pipes (`|`) in their scripts without enabling `pipefail`. By default, a pipeline's exit code is the exit code of the **last** command in the chain. If any earlier command fails, the failure is silently discarded and the job continues.
+
+This is especially dangerous in security-sensitive contexts:
+- A failed `curl | bash` download still "succeeds" — bash executes with empty input and exits 0
+- A failed secret-fetching step before a deployment is ignored
+- Corrupted data passes through to downstream steps undetected
+
+Analogous to ansible-lint's `risky-shell-pipe` rule.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - curl https://install.example.com/tool.sh | bash   # if curl fails, bash runs on empty input
+    - generate-config | tee config.yml                  # if generate-config fails, job still passes
+```
+
+## Safe alternatives
+
+**Set once at the top of the script:**
+```yaml
+build:
+  script:
+    - set -o pipefail
+    - generate-config | tee config.yml
+    - curl https://install.example.com/tool.sh | bash
+```
+
+**Set as part of a combined shell options header:**
+```yaml
+build:
+  script:
+    - set -euo pipefail
+    - generate-config | tee config.yml
+```
+
+**Set inline per line:**
+```yaml
+build:
+  script:
+    - set -o pipefail && generate-config | tee config.yml
+```
+
+**Set in `before_script` to apply to all jobs using the same template:**
+```yaml
+.base:
+  before_script:
+    - set -o pipefail
+
+build:
+  extends: .base
+  script:
+    - generate-config | tee config.yml
+```
+
+## Notes
+
+- One finding is emitted per job, pointing to the first piped line.
+- `||` (logical OR) and `|&` (stderr+stdout redirect) are not treated as pipes and do not trigger this rule.
+- `pipefail` set anywhere in `before_script`, `script`, or `after_script` suppresses the finding.
+- If you intentionally ignore a pipe failure (e.g. `cmd | true`), suppress the finding inline: `# glsec:ignore GL024 -- intentional, fallback handled`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -27,5 +27,6 @@ func All() []rule.Rule {
 		GL021,
 		GL022,
 		GL023,
+		GL024,
 	}
 }

--- a/rules/gl024.go
+++ b/rules/gl024.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl024 struct{}
+
+var GL024 = &gl024{}
+
+func (r *gl024) ID() string { return "GL024" }
+
+var (
+	// realPipeRe matches a shell pipe (|) that is not || (logical OR), |& (stderr+stdout),
+	// or >| (force redirect). Requires the preceding char to be neither | nor >.
+	realPipeRe = regexp.MustCompile(`(?:^|[^|>])\|[^|&]`)
+
+	// pipefailRe matches a line that enables pipefail.
+	pipefailRe = regexp.MustCompile(`\bpipefail\b`)
+)
+
+func (r *gl024) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		lines := collectScriptLines(job)
+		if len(lines) == 0 {
+			return
+		}
+
+		// Check if pipefail is set anywhere in the job's script.
+		for _, l := range lines {
+			if pipefailRe.MatchString(l.Value) {
+				return
+			}
+		}
+
+		// Find the first line that contains a real pipe.
+		for _, l := range lines {
+			if realPipeRe.MatchString(l.Value) {
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL024",
+					Severity: finding.Warn,
+					Message:  "script uses a pipe without set -o pipefail — failures in all but the last command are silently ignored",
+					File:     file,
+					Line:     l.Line,
+					Col:      l.Column,
+				})
+				return // one finding per job
+			}
+		}
+	})
+
+	return findings
+}

--- a/rules/gl024_test.go
+++ b/rules/gl024_test.go
@@ -1,0 +1,156 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings024(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL024.Check(doc.Root, "test.yml")
+}
+
+func TestGL024_PipeWithoutPipefail(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - generate-config | tee config.yml
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL024_PipefailSet_NoFinding(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - set -o pipefail
+    - generate-config | tee config.yml
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when pipefail is set, got %d", len(f))
+	}
+}
+
+func TestGL024_PipefailInline_NoFinding(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - set -o pipefail && generate-config | tee config.yml
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when pipefail set inline, got %d", len(f))
+	}
+}
+
+func TestGL024_SetEuoPipefail_NoFinding(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - set -euo pipefail
+    - generate-config | tee config.yml
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for set -euo pipefail, got %d", len(f))
+	}
+}
+
+func TestGL024_LogicalOr_NoFinding(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - cmd || true
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for || (logical OR), got %d", len(f))
+	}
+}
+
+func TestGL024_PipeAndLogicalOr(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - generate-config | tee config.yml || true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (real pipe present despite ||), got %d", len(f))
+	}
+}
+
+func TestGL024_NoPipe_NoFinding(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - go build ./...
+    - go test ./...
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for script without pipes, got %d", len(f))
+	}
+}
+
+func TestGL024_PipefailInBeforeScript_NoFinding(t *testing.T) {
+	f := findings024(t, `
+build:
+  before_script:
+    - set -o pipefail
+  script:
+    - generate-config | tee config.yml
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when pipefail set in before_script, got %d", len(f))
+	}
+}
+
+func TestGL024_OneFindingPerJob(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - cmd1 | tee out1.txt
+    - cmd2 | tee out2.txt
+    - cmd3 | tee out3.txt
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected exactly 1 finding per job (at first pipe), got %d", len(f))
+	}
+}
+
+func TestGL024_MultipleJobs(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - set -o pipefail
+    - cmd | tee out.txt
+
+test:
+  script:
+    - cmd | tee out.txt
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (only test job), got %d", len(f))
+	}
+}
+
+func TestGL024_LineNumber(t *testing.T) {
+	f := findings024(t, `
+build:
+  script:
+    - generate-config | tee config.yml
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl024-pipefail.yml
+++ b/testdata/fixtures/gl024-pipefail.yml
@@ -1,0 +1,8 @@
+stages:
+  - build
+
+build:
+  stage: build
+  script:
+    - generate-config | tee config.yml
+    - cat config.yml | grep key


### PR DESCRIPTION
Closes #80

## What
Adds GL024, which flags jobs that use shell pipes (`|`) without `set -o pipefail`. Without `pipefail`, the exit code of a pipeline is the exit code of the last command only — failures in earlier commands are silently discarded.

## Detection logic
- Scans `before_script`, `script`, and `after_script` for real pipe characters
- Excludes `||` (logical OR) and `|&` (stderr+stdout redirect) via `(?:^|[^|>])\|[^|&]`
- If `pipefail` is found anywhere in any of those three sections, the job is considered safe
- Emits at most one finding per job, pointing to the first piped line

## Safe patterns recognised (no finding emitted)
- `set -o pipefail` or `set -euo pipefail` anywhere in `before_script`/`script`/`after_script`
- `set -o pipefail && cmd | tee ...` inline
- `extends:` a base job whose `before_script` already sets `pipefail` (covered because glsec evaluates the resolved YAML, and in the common single-file case the `before_script` is merged)

## Tests (11 cases)
Pipe without pipefail → 1 finding; pipefail set standalone, inline, or via `set -euo`; logical-OR only; pipe with logical-OR present; no pipe; pipefail in `before_script`; one finding per job (not per line); multiple jobs (only unsafe one flagged); non-zero line number.