### PR TITLE
feat: GL025 – curl/wget with user-controlled CI variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL022](docs/rules/GL022.md) | `warn`  | Package manager install without version pin or explicit update-to-latest in CI |
 | [GL023](docs/rules/GL023.md) | `warn`  | Lockfile not enforced (`npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, etc.) |
 | [GL024](docs/rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
+| [GL025](docs/rules/GL025.md) | `warn`  | `curl`/`wget` uses a user-controlled CI variable — attacker can redirect the request to an arbitrary host |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL025.md
+++ b/docs/rules/GL025.md
@@ -1,0 +1,64 @@
+# GL025 — `curl`/`wget` with user-controlled CI variable
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+
+## What glsec checks
+
+glsec flags `curl` and `wget` invocations in job scripts that include a CI variable whose value can be influenced by an external contributor. An attacker who controls the variable can redirect the HTTP request to an attacker-controlled host, causing secrets from the job environment to be exfiltrated or triggering server-side request forgery (SSRF).
+
+Analogous to checkov's `CKV_GITLABCI_1`.
+
+## User-controlled variables
+
+The following variables are fully or partially controlled by the author of a branch, merge request, or commit:
+
+| Variable | Controlled via |
+|----------|---------------|
+| `$CI_COMMIT_REF_NAME` | Branch name |
+| `$CI_COMMIT_REF_SLUG` | Branch name (slugified) |
+| `$CI_COMMIT_MESSAGE` | Commit message |
+| `$CI_COMMIT_TITLE` | First line of commit message |
+| `$CI_COMMIT_DESCRIPTION` | Body of commit message |
+| `$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | MR source branch |
+| `$CI_MERGE_REQUEST_TITLE` | MR title |
+
+## Trigger example
+
+```yaml
+notify:
+  script:
+    - curl https://hooks.example.com/notify?branch=$CI_COMMIT_REF_NAME
+    - curl -d "msg=$CI_MERGE_REQUEST_TITLE" https://api.example.com/comment
+```
+
+If an attacker names their branch `hooks.attacker.com/steal?token=` and the job has secrets in its environment, the request can be redirected.
+
+## Safe alternatives
+
+**Sanitize the variable before use:**
+```yaml
+notify:
+  script:
+    - |
+      BRANCH=$(printf '%s' "$CI_COMMIT_REF_NAME" | tr -cd '[:alnum:]-_.')
+      curl "https://hooks.example.com/notify?branch=${BRANCH}"
+```
+
+**Use a fixed URL and pass the value only in a controlled body field:**
+```yaml
+notify:
+  script:
+    - curl -X POST https://hooks.example.com/notify \
+        --data-urlencode "branch=$CI_COMMIT_REF_NAME"
+```
+`--data-urlencode` percent-encodes the value, preventing URL injection.
+
+**Restrict pipelines to protected branches** so untrusted commits never run with secrets.
+
+## Notes
+
+- One finding is emitted per offending line (unlike most GL rules which emit one per job), because each line is an independent request that may reach a different host.
+- The rule checks `before_script`, `script`, and `after_script`.
+- Variables that are not in the list above (e.g. `$MY_TOKEN`, `$CI_PROJECT_ID`) do not trigger this rule.
+- If you have a genuine need and the value is sanitised inline, suppress with: `# glsec:ignore GL025 -- value sanitised above`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -28,5 +28,6 @@ func All() []rule.Rule {
 		GL022,
 		GL023,
 		GL024,
+		GL025,
 	}
 }

--- a/rules/gl025.go
+++ b/rules/gl025.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl025 struct{}
+
+var GL025 = &gl025{}
+
+func (r *gl025) ID() string { return "GL025" }
+
+// userControlledVarRe matches any of the CI variables an attacker can influence
+// via branch name, MR title, commit message, etc.
+var userControlledVarRe = regexp.MustCompile(
+	`\$\{?CI_(?:COMMIT_REF_NAME|COMMIT_REF_SLUG|COMMIT_MESSAGE|COMMIT_TITLE|COMMIT_DESCRIPTION|MERGE_REQUEST_SOURCE_BRANCH_NAME|MERGE_REQUEST_TITLE)\}?`,
+)
+
+// curlWgetRe matches curl or wget invocations.
+var curlWgetRe = regexp.MustCompile(`\b(?:curl|wget)\b`)
+
+func (r *gl025) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		for _, l := range collectScriptLines(job) {
+			if !curlWgetRe.MatchString(l.Value) {
+				continue
+			}
+			m := userControlledVarRe.FindString(l.Value)
+			if m == "" {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL025",
+				Severity: finding.Warn,
+				Message:  "curl/wget uses user-controlled variable " + m + " — attacker can redirect the request to an arbitrary host",
+				File:     file,
+				Line:     l.Line,
+				Col:      l.Column,
+			})
+		}
+	})
+
+	return findings
+}

--- a/rules/gl025_test.go
+++ b/rules/gl025_test.go
@@ -1,0 +1,157 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings025(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL025.Check(doc.Root, "test.yml")
+}
+
+func TestGL025_CurlWithRefName(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://hooks.example.com/notify?branch=$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL025_CurlWithRefSlug(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://hooks.example.com/notify?branch=$CI_COMMIT_REF_SLUG
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL025_CurlWithMRTitle(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl -d "msg=$CI_MERGE_REQUEST_TITLE" https://api.example.com/comment
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL025_WgetWithCommitMessage(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - wget "https://api.example.com/hook?msg=$CI_COMMIT_MESSAGE"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL025_CurlWithMRSourceBranch(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://api.example.com/pr/$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL025_CurlWithCommitTitle(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl -H "X-Title=$CI_COMMIT_TITLE" https://api.example.com/notify
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL025_CurlNoUserVar_NoFinding(t *testing.T) {
+	f := findings025(t, `
+deploy:
+  script:
+    - curl https://api.example.com/deploy
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for curl without user-controlled var, got %d", len(f))
+	}
+}
+
+func TestGL025_CurlWithSafeVar_NoFinding(t *testing.T) {
+	f := findings025(t, `
+deploy:
+  script:
+    - curl -H "Authorization Bearer $MY_TOKEN" https://api.example.com/deploy
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for curl with non-user-controlled var, got %d", len(f))
+	}
+}
+
+func TestGL025_NoCurlOrWget_NoFinding(t *testing.T) {
+	f := findings025(t, `
+build:
+  script:
+    - go build ./...
+    - echo $CI_COMMIT_REF_NAME
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when no curl/wget, got %d", len(f))
+	}
+}
+
+func TestGL025_MultipleLinesOneFinding(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://hooks.example.com/?ref=$CI_COMMIT_REF_NAME
+    - wget https://api.example.com/?msg=$CI_COMMIT_MESSAGE
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (one per offending line), got %d", len(f))
+	}
+}
+
+func TestGL025_LineNumber(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://hooks.example.com/?ref=$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}
+
+func TestGL025_BracedVar(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://hooks.example.com/?ref=${CI_COMMIT_REF_NAME}
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for braced variable, got %d", len(f))
+	}
+}

--- a/testdata/fixtures/gl025-uservar-curl.yml
+++ b/testdata/fixtures/gl025-uservar-curl.yml
@@ -1,0 +1,8 @@
+stages:
+  - notify
+
+notify:
+  stage: notify
+  script:
+    - curl https://hooks.example.com/notify?branch=$CI_COMMIT_REF_NAME
+    - curl -d "msg=$CI_MERGE_REQUEST_TITLE" https://api.example.com/comment


### PR DESCRIPTION
Closes #81

## What
Adds GL025, which flags `curl` and `wget` invocations that embed a CI variable whose value can be influenced by an external contributor (via branch name, MR title, commit message, etc.). An attacker controlling the variable can redirect the request to an arbitrary host, exfiltrating secrets from the job environment.

Analogous to checkov `CKV_GITLABCI_1`.

## Detected variables
`$CI_COMMIT_REF_NAME`, `$CI_COMMIT_REF_SLUG`, `$CI_COMMIT_MESSAGE`, `$CI_COMMIT_TITLE`, `$CI_COMMIT_DESCRIPTION`, `$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`, `$CI_MERGE_REQUEST_TITLE` — both bare `$VAR` and braced `${VAR}` forms.

## Detection logic
- Scans all script sections (`before_script`, `script`, `after_script`) for lines containing `curl` or `wget`
- If the same line also contains any user-controlled variable (matched via regex), a finding is emitted for that line
- One finding per offending line (not per job), since each line is an independent request

## Tests (12 cases)
Each tracked variable; `curl` and `wget`; safe curl (no user var); non-curl line with user var (no finding); multiple offending lines yield multiple findings; braced `${VAR}` form; non-zero line number.