### PR TITLE
feat: GL026 – git clone/checkout without pinned commit SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 | [GL023](docs/rules/GL023.md) | `warn`  | Lockfile not enforced (`npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, etc.) |
 | [GL024](docs/rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
 | [GL025](docs/rules/GL025.md) | `warn`  | `curl`/`wget` uses a user-controlled CI variable — attacker can redirect the request to an arbitrary host |
+| [GL026](docs/rules/GL026.md) | `warn`  | `git clone`/`checkout` uses a mutable ref (branch or tag) instead of a pinned commit SHA |
 
 Each rule page contains the full risk description, trigger examples, safe alternatives, and detection notes.
 

--- a/docs/rules/GL026.md
+++ b/docs/rules/GL026.md
@@ -1,0 +1,45 @@
+# GL026 — `git clone`/`checkout` without pinned commit
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags `git clone` and `git checkout` invocations in job scripts that use a mutable ref (branch name, tag, or HEAD) instead of a full 40-character commit SHA. Mutable refs can be silently updated between pipeline runs — a compromised upstream repository can inject malicious code into your build without any change to your `.gitlab-ci.yml`.
+
+Analogous to GL001 (mutable image tag) and GL003 (mutable `include:` ref), but at the script level. Mirrors ansible-lint's `latest` rule for VCS module checkouts.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - git clone https://github.com/org/shared-scripts.git          # clones HEAD of default branch
+    - git clone --branch main https://github.com/org/tools.git     # mutable branch
+    - git clone --depth 1 --branch v2.3 https://github.com/org/lib.git  # mutable tag
+    - git checkout develop                                          # mutable branch
+```
+
+## Safe alternatives
+
+**Clone then pin with SHA checkout:**
+```yaml
+build:
+  script:
+    - git clone https://github.com/org/shared-scripts.git
+    - git -C shared-scripts checkout a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+```
+
+**Use a Git submodule with a pinned SHA** (tracked in `.gitmodules` + committed `HEAD`):
+```yaml
+build:
+  script:
+    - git submodule update --init --recursive
+```
+
+## Notes
+
+- A bare `git clone <url>` (no `--branch`) is suppressed when the same job also contains a `git checkout <sha>` (40-character hex) in any of `before_script`, `script`, or `after_script` — that is the intended safe pattern.
+- `git checkout -b <name>` (local branch creation) does not trigger this rule.
+- `git checkout <sha>` with a full 40-character SHA does not trigger this rule.
+- Suppress intentionally mutable checkouts with: `# glsec:ignore GL026 -- upstream repo is trusted and content-addressed by other means`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -29,5 +29,6 @@ func All() []rule.Rule {
 		GL023,
 		GL024,
 		GL025,
+		GL026,
 	}
 }

--- a/rules/gl026.go
+++ b/rules/gl026.go
@@ -1,0 +1,103 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl026 struct{}
+
+var GL026 = &gl026{}
+
+func (r *gl026) ID() string { return "GL026" }
+
+var (
+	// shaRe matches a full 40-character lowercase hex commit SHA.
+	shaRe = regexp.MustCompile(`[0-9a-f]{40}`)
+
+	// gitCloneRe matches a git clone invocation (handles git -C <dir> clone too).
+	gitCloneRe = regexp.MustCompile(`\bgit\b[^|;&]*\bclone\b`)
+
+	// gitCheckoutRe matches a git checkout invocation.
+	gitCheckoutRe = regexp.MustCompile(`\bgit\b[^|;&]*\bcheckout\b`)
+
+	// branchFlagRe captures the value of --branch or -b.
+	branchFlagRe = regexp.MustCompile(`(?:--branch|-b)\s+(\S+)`)
+
+	// newBranchFlagRe detects -b or --orphan (creates a local branch, not a dep checkout).
+	newBranchFlagRe = regexp.MustCompile(`\s(?:-b|--orphan)(?:\s|$)`)
+)
+
+func (r *gl026) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		lines := collectScriptLines(job)
+		if len(lines) == 0 {
+			return
+		}
+
+		// Pre-check: does the job have any SHA-pinned checkout?
+		// A bare `git clone` paired with `git checkout <sha>` is the safe pattern.
+		hasSHACheckout := false
+		for _, l := range lines {
+			if gitCheckoutRe.MatchString(l.Value) && shaRe.MatchString(l.Value) {
+				hasSHACheckout = true
+				break
+			}
+		}
+
+		for _, l := range lines {
+			line := l.Value
+
+			if gitCloneRe.MatchString(line) {
+				m := branchFlagRe.FindStringSubmatch(line)
+				if len(m) >= 2 {
+					ref := m[1]
+					if !shaRe.MatchString(ref) {
+						findings = append(findings, finding.Finding{
+							RuleID:   "GL026",
+							Severity: finding.Warn,
+							Message:  "git clone uses mutable ref \"" + ref + "\" — pin to a full commit SHA with git checkout after cloning",
+							File:     file,
+							Line:     l.Line,
+							Col:      l.Column,
+						})
+					}
+				} else if !hasSHACheckout {
+					findings = append(findings, finding.Finding{
+						RuleID:   "GL026",
+						Severity: finding.Warn,
+						Message:  "git clone without --branch clones HEAD of the default branch — follow with git checkout <sha> to pin the revision",
+						File:     file,
+						Line:     l.Line,
+						Col:      l.Column,
+					})
+				}
+				continue
+			}
+
+			if gitCheckoutRe.MatchString(line) {
+				if newBranchFlagRe.MatchString(line) {
+					continue // creating a local branch, not a dependency checkout
+				}
+				if shaRe.MatchString(line) {
+					continue // SHA-pinned — safe
+				}
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL026",
+					Severity: finding.Warn,
+					Message:  "git checkout uses a mutable ref — pin to a full 40-character commit SHA",
+					File:     file,
+					Line:     l.Line,
+					Col:      l.Column,
+				})
+			}
+		}
+	})
+
+	return findings
+}

--- a/rules/gl026_test.go
+++ b/rules/gl026_test.go
@@ -1,0 +1,176 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings026(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL026.Check(doc.Root, "test.yml")
+}
+
+const sha40 = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+func TestGL026_CloneWithMutableBranch(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone --branch main https://github.com/org/tools.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL026_CloneWithMutableTag(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone --depth 1 --branch v2.3 https://github.com/org/lib.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for mutable tag, got %d", len(f))
+	}
+}
+
+func TestGL026_CloneWithBranchFlagShortForm(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone -b develop https://github.com/org/lib.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for -b develop, got %d", len(f))
+	}
+}
+
+func TestGL026_CloneBareNoSHACheckout(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone https://github.com/org/shared-scripts.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for bare clone without SHA checkout, got %d", len(f))
+	}
+}
+
+func TestGL026_CloneBareWithSHACheckout_NoFinding(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone https://github.com/org/shared-scripts.git
+    - git -C shared-scripts checkout `+sha40+`
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for bare clone paired with SHA checkout, got %d", len(f))
+	}
+}
+
+func TestGL026_CloneWithSHABranch_NoFinding(t *testing.T) {
+	// --branch accepts tag names but not SHAs in practice; if someone passes
+	// a SHA-shaped string we treat it as safe.
+	f := findings026(t, `
+build:
+  script:
+    - git clone --branch `+sha40+` https://github.com/org/lib.git
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when --branch value is a SHA, got %d", len(f))
+	}
+}
+
+func TestGL026_CheckoutMutableBranch(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git checkout main
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for checkout of mutable branch, got %d", len(f))
+	}
+}
+
+func TestGL026_CheckoutSHA_NoFinding(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git checkout `+sha40+`
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for SHA-pinned checkout, got %d", len(f))
+	}
+}
+
+func TestGL026_CheckoutCreateBranch_NoFinding(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git checkout -b new-feature
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for branch creation with -b, got %d", len(f))
+	}
+}
+
+func TestGL026_GitCWithSHACheckout_NoFinding(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone https://github.com/org/tools.git
+    - git -C tools checkout `+sha40+`
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for git -C checkout with SHA, got %d", len(f))
+	}
+}
+
+func TestGL026_NoBranchFlagWithMutableBranchClone(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone --branch main https://github.com/org/tools.git
+    - git clone https://github.com/org/other.git
+    - git -C other checkout `+sha40+`
+`)
+	// Only the --branch main clone should be flagged; bare clone has SHA checkout.
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL026_NoGitCommands_NoFinding(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - go build ./...
+    - go test ./...
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-git script, got %d", len(f))
+	}
+}
+
+func TestGL026_LineNumber(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone --branch main https://github.com/org/tools.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/testdata/fixtures/gl026-git-clone-pinning.yml
+++ b/testdata/fixtures/gl026-git-clone-pinning.yml
@@ -1,0 +1,10 @@
+stages:
+  - build
+
+build:
+  stage: build
+  script:
+    - git clone --branch main https://github.com/org/tools.git
+    - git clone --depth 1 --branch v2.3 https://github.com/org/lib.git
+    - git clone https://github.com/org/shared-scripts.git
+    - git checkout develop


### PR DESCRIPTION
Closes #82

## What
Adds GL026, which flags `git clone` and `git checkout` invocations in job scripts that reference a mutable ref (branch name, tag, or implicit HEAD) instead of a full 40-character commit SHA. Mutable refs can be silently updated between pipeline runs; a compromised upstream repository can inject malicious code without any change to the `.gitlab-ci.yml`.

Analogous to GL001 (mutable image tag) and GL003 (mutable `include:` ref) at the script level.

## Detection logic

**`git clone`:**
- Has `--branch`/`-b` with a non-SHA value → flagged (explicit mutable ref)
- No `--branch`/`-b` at all AND no SHA-pinned `git checkout` in the same job → flagged (defaults to HEAD)
- No `--branch`/`-b` but the same job has a `git checkout <40-sha>` → not flagged (safe clone+pin pattern)

**`git checkout`:**
- Contains a 40-char hex SHA → not flagged
- Has `-b`/`--orphan` → not flagged (local branch creation, not a dependency checkout)
- Otherwise → flagged

## Tests (13 cases)
`--branch main`, `--branch v2.3`, `-b develop`; bare clone without SHA checkout; bare clone paired with SHA checkout (no finding); `--branch <sha>` (no finding); `git checkout main`; `git checkout <sha>` (no finding); `git checkout -b` (no finding); `git -C <dir> checkout <sha>` (no finding); mixed scenario with one flagged and one safe clone; no git commands; non-zero line number.