### PR TITLE
feat: severity remapping per rule via nested config syntax

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,10 +13,44 @@ import (
 
 const DefaultFile = ".glsec.yml"
 
+// RuleConfig holds per-rule overrides. It can be specified as either a plain
+// severity string or a mapping:
+//
+//	GL001: warn                  # flat form
+//	GL001:                       # nested form
+//	  severity: warn
+type RuleConfig struct {
+	Severity string // "error", "warn", "info", or "off"; empty = use rule default
+}
+
+// UnmarshalYAML allows RuleConfig to accept both a plain scalar ("warn") and a
+// mapping ({ severity: warn }) in the config file.
+func (r *RuleConfig) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		r.Severity = value.Value
+		return nil
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(value.Content); i += 2 {
+			key := value.Content[i].Value
+			val := value.Content[i+1].Value
+			switch key {
+			case "severity":
+				r.Severity = val
+			default:
+				return fmt.Errorf("unknown rule config key %q", key)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("rule config must be a string or mapping")
+	}
+}
+
 // Config holds the parsed contents of a .glsec.yml file.
 type Config struct {
-	// Rules maps rule ID to a severity override or "off".
-	Rules map[string]string `yaml:"rules"`
+	// Rules maps rule ID to a per-rule override.
+	Rules map[string]RuleConfig `yaml:"rules"`
 	// MinSeverity filters out findings below this level.
 	MinSeverity string `yaml:"min-severity"`
 	// GitLabVersion is the target GitLab version (e.g. "16.0").
@@ -29,7 +63,7 @@ type Config struct {
 // Default returns a Config with no overrides.
 func Default() *Config {
 	return &Config{
-		Rules:       map[string]string{},
+		Rules:       map[string]RuleConfig{},
 		MinSeverity: "",
 	}
 }
@@ -74,7 +108,7 @@ func parse(data []byte, path string) (*Config, error) {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
 	if cfg.Rules == nil {
-		cfg.Rules = map[string]string{}
+		cfg.Rules = map[string]RuleConfig{}
 	}
 
 	if err := cfg.validate(path); err != nil {
@@ -108,12 +142,12 @@ var validSeverities = map[string]bool{
 }
 
 func (c *Config) validate(path string) error {
-	for id, sev := range c.Rules {
+	for id, rc := range c.Rules {
 		if !strings.HasPrefix(id, "GL") {
 			return fmt.Errorf("%s: rules: invalid rule ID %q (must start with GL)", path, id)
 		}
-		if !validSeverities[sev] {
-			return fmt.Errorf("%s: rules.%s: invalid severity %q (use error, warn, info, or off)", path, id, sev)
+		if !validSeverities[rc.Severity] {
+			return fmt.Errorf("%s: rules.%s: invalid severity %q (use error, warn, info, or off)", path, id, rc.Severity)
 		}
 	}
 	if c.MinSeverity != "" {
@@ -131,18 +165,18 @@ func (c *Config) validate(path string) error {
 
 // RuleEnabled returns false if the rule is set to "off" in the config.
 func (c *Config) RuleEnabled(id string) bool {
-	sev, ok := c.Rules[id]
-	return !ok || sev != "off"
+	rc, ok := c.Rules[id]
+	return !ok || rc.Severity != "off"
 }
 
 // ApplySeverity returns the effective severity for a finding, applying any
 // rule-level override from the config.
 func (c *Config) ApplySeverity(f finding.Finding) finding.Finding {
-	sev, ok := c.Rules[f.RuleID]
-	if !ok || sev == "off" {
+	rc, ok := c.Rules[f.RuleID]
+	if !ok || rc.Severity == "" || rc.Severity == "off" {
 		return f
 	}
-	f.Severity = finding.Severity(sev)
+	f.Severity = finding.Severity(rc.Severity)
 	return f
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,7 +66,7 @@ rules:
 	}
 }
 
-func TestParse_SeverityOverride(t *testing.T) {
+func TestParse_SeverityOverride_Flat(t *testing.T) {
 	cfg := parseStr(t, `rules:
   GL001: warn
 `)
@@ -74,6 +74,49 @@ func TestParse_SeverityOverride(t *testing.T) {
 	got := cfg.ApplySeverity(f)
 	if got.Severity != finding.Warn {
 		t.Errorf("expected warn, got %s", got.Severity)
+	}
+}
+
+func TestParse_SeverityOverride_Nested(t *testing.T) {
+	cfg := parseStr(t, `
+rules:
+  GL001:
+    severity: warn
+  GL011:
+    severity: error
+`)
+	f1 := finding.Finding{RuleID: "GL001", Severity: finding.Error}
+	if got := cfg.ApplySeverity(f1); got.Severity != finding.Warn {
+		t.Errorf("GL001: expected warn, got %s", got.Severity)
+	}
+	f2 := finding.Finding{RuleID: "GL011", Severity: finding.Warn}
+	if got := cfg.ApplySeverity(f2); got.Severity != finding.Error {
+		t.Errorf("GL011: expected error, got %s", got.Severity)
+	}
+}
+
+func TestParse_SeverityOverride_Nested_Off(t *testing.T) {
+	cfg := parseStr(t, `
+rules:
+  GL001:
+    severity: off
+`)
+	if cfg.RuleEnabled("GL001") {
+		t.Error("GL001 should be disabled via nested severity: off")
+	}
+}
+
+func TestParse_SeverityOverride_Nested_UnknownKey(t *testing.T) {
+	_, err := parse([]byte("rules:\n  GL001:\n    severity: warn\n    unknown: value\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for unknown key inside rule config mapping")
+	}
+}
+
+func TestParse_SeverityOverride_Nested_InvalidSeverity(t *testing.T) {
+	_, err := parse([]byte("rules:\n  GL001:\n    severity: critical\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for invalid severity in nested form")
 	}
 }
 


### PR DESCRIPTION
Closes #83

## What
Extends the `rules:` config block to accept either the existing flat string form or a new nested mapping form, matching the syntax requested in the issue.

**Flat form (unchanged, still works):**
```yaml
rules:
  GL001: warn
  GL011: off
```

**Nested form (new):**
```yaml
rules:
  GL001:
    severity: warn    # downgrade error → warn
  GL011:
    severity: error   # upgrade warn → error
```

Both forms are equivalent. The nested form is more extensible (additional per-rule keys can be added later without a breaking change).

## Implementation
- Added `RuleConfig` struct with a custom `UnmarshalYAML` that accepts either a scalar or a mapping node.
- `Config.Rules` changed from `map[string]string` to `map[string]RuleConfig`; all internal usages updated.
- `RuleEnabled` and `ApplySeverity` behaviour is unchanged — the remapped severity flows through filtering, output, exit code, and SARIF.
- Unknown keys inside a rule mapping (e.g. `GL001: { severity: warn, typo: x }`) are rejected with a clear error.

## Tests added
- Nested form: severity downgrade + upgrade
- Nested `severity: off` disables the rule
- Unknown key inside nested mapping → error
- Invalid severity in nested form → error