### PR TITLE
feat: --strict and --no-exit-codes flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,16 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 
 | Code | Meaning |
 |------|---------|
-| 0 | No findings |
-| 1 | One or more findings |
+| 0 | No `error`-severity findings (warn-only findings exit 0 by default) |
+| 1 | One or more `error` findings; or any finding when `--strict` is set |
 | 2 | Usage error or file could not be parsed |
+
+Use `--strict` to treat `warn` findings as hard failures (exit 1). Use `--no-exit-codes` to always exit 0 regardless of findings (advisory/informational mode). Both flags can also be set in `.glsec.yml`:
+
+```yaml
+strict: true        # warn findings cause exit 1
+no-exit-codes: true # never exit 1 (overrides strict)
+```
 
 ## Rules
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -27,8 +27,10 @@ func main() {
 	configFlag := flag.String("config", config.DefaultFile, "path to .glsec.yml config file")
 	versionFlag := flag.Bool("version", false, "print version and exit")
 	gitlabVersionFlag := flag.String("gitlab-version", "", "target GitLab version, e.g. 16.0 (skips rules not available in that version)")
+	strictFlag := flag.Bool("strict", false, "treat warn findings as errors for the exit code (output severity is unchanged)")
+	noExitCodesFlag := flag.Bool("no-exit-codes", false, "always exit 0 on successful execution, regardless of findings")
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] [--config .glsec.yml] [--gitlab-version 16.0] [file]")
+		fmt.Fprintln(os.Stderr, "usage: glsec [--format text|json|sarif] [--config .glsec.yml] [--gitlab-version 16.0] [--strict] [--no-exit-codes] [file]")
 		fmt.Fprintln(os.Stderr, "       If no file is given, glsec looks for .gitlab-ci.yml in the current directory.")
 		flag.PrintDefaults()
 	}
@@ -54,6 +56,14 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(2)
+	}
+
+	// CLI flags take precedence over config file values.
+	if *strictFlag {
+		cfg.Strict = true
+	}
+	if *noExitCodesFlag {
+		cfg.NoExitCodes = true
 	}
 
 	rules.GL016.SetTrustedHosts(cfg.TrustedHosts)
@@ -123,7 +133,15 @@ func main() {
 		os.Exit(2)
 	}
 
-	if len(findings) > 0 {
-		os.Exit(1)
+	if cfg.NoExitCodes {
+		return
+	}
+	for _, f := range findings {
+		if f.Severity == finding.Error {
+			os.Exit(1)
+		}
+		if cfg.Strict && f.Severity == finding.Warn {
+			os.Exit(1)
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,11 @@ type Config struct {
 	GitLabVersion string `yaml:"gitlab-version"`
 	// TrustedHosts is a list of hostnames or CIDRs whose HTTP URLs are never flagged.
 	TrustedHosts []string `yaml:"trusted-hosts"`
+	// Strict makes warn findings count as errors for exit-code purposes.
+	Strict bool `yaml:"strict"`
+	// NoExitCodes makes glsec always exit 0 on successful execution,
+	// regardless of findings. Useful for advisory runs.
+	NoExitCodes bool `yaml:"no-exit-codes"`
 }
 
 // Default returns a Config with no overrides.
@@ -122,6 +127,8 @@ var allowedTopLevelKeys = map[string]bool{
 	"min-severity":   true,
 	"gitlab-version": true,
 	"trusted-hosts":  true,
+	"strict":         true,
+	"no-exit-codes":  true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -189,6 +189,27 @@ func TestParse_GitLabVersion_Absent(t *testing.T) {
 	}
 }
 
+func TestParse_Strict(t *testing.T) {
+	cfg := parseStr(t, `strict: true`)
+	if !cfg.Strict {
+		t.Error("expected Strict to be true")
+	}
+}
+
+func TestParse_NoExitCodes(t *testing.T) {
+	cfg := parseStr(t, `no-exit-codes: true`)
+	if !cfg.NoExitCodes {
+		t.Error("expected NoExitCodes to be true")
+	}
+}
+
+func TestParse_StrictAndNoExitCodes_UnknownKey(t *testing.T) {
+	_, err := parse([]byte("strictmode: true\n"), "test.yml")
+	if err == nil {
+		t.Error("expected error for unknown top-level key 'strictmode'")
+	}
+}
+
 func TestLoad_FromFile(t *testing.T) {
 	dir := t.TempDir()
 	content := []byte("rules:\n  GL001: off\nmin-severity: warn\n")


### PR DESCRIPTION
Closes #84

## What
Adds two new CLI flags (and matching `.glsec.yml` keys) that control exit-code behaviour.

### `--strict`
Treat `warn` findings as hard failures for the exit code. The displayed severity in output stays `warn`.

```sh
glsec --strict .gitlab-ci.yml   # exits 1 on any error or warn finding
```

### `--no-exit-codes`
Always exit 0 on successful execution, regardless of findings. Useful for advisory/onboarding runs where you want to see output without blocking the pipeline.

```sh
glsec --no-exit-codes .gitlab-ci.yml   # exits 0 even with findings; exits 2 only on parse errors
```

Both flags can be set in `.glsec.yml` as `strict: true` / `no-exit-codes: true`. CLI flags always take precedence.

## Exit-code behaviour change

| Condition | Before | After |
|-----------|--------|-------|
| Error findings only | exit 1 | exit 1 |
| Warn findings only | exit 1 | exit 0 (exit 1 with `--strict`) |
| No findings | exit 0 | exit 0 |
| `--no-exit-codes` + findings | — | exit 0 |

The default is now more adoption-friendly: `warn`-only findings don't break the pipeline unless `--strict` is explicitly set. This mirrors ansible-lint's behaviour.

## Implementation
- `Config` gains `Strict bool` and `NoExitCodes bool` fields (validated via `allowedTopLevelKeys`)
- `main.go` exit-code loop: exit 1 on `error` always; exit 1 on `warn` only when `cfg.Strict`; skip entirely when `cfg.NoExitCodes`
- README exit-codes table updated

## Tests added (config package)
`strict: true` parses correctly; `no-exit-codes: true` parses correctly; unknown key `strictmode` rejected.