### PR TITLE
fix: check error return of f.Close in suppress package

### DIFF
--- a/internal/suppress/suppress.go
+++ b/internal/suppress/suppress.go
@@ -103,7 +103,7 @@ func LoadIgnoreFile(ignorePath, targetFile string) Map {
 	if err != nil {
 		return m
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/internal/suppress/suppress_test.go
+++ b/internal/suppress/suppress_test.go
@@ -118,7 +118,7 @@ func TestLoadIgnoreFile_Basic(t *testing.T) {
 	if _, err := f.WriteString(content); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	m := LoadIgnoreFile(f.Name(), ".gitlab-ci.yml")
 	if !m.IsSuppressed(7, "GL001") {


### PR DESCRIPTION
Fixes errcheck lint failures on main introduced in #98. `defer f.Close()` → `defer func() { _ = f.Close() }()` in production code; `f.Close()` → `_ = f.Close()` in test.