### PR TITLE
fix: show correct version when installed via go install

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/glsec/glsec/internal/config"
@@ -45,7 +46,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Printf("glsec %s (commit %s, built %s)\n", version, commit, date)
+		fmt.Printf("glsec %s (commit %s, built %s)\n", resolvedVersion(), commit, date)
 		return
 	}
 
@@ -168,6 +169,16 @@ func main() {
 			os.Exit(1)
 		}
 	}
+}
+
+func resolvedVersion() string {
+	if version != "dev" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
 }
 
 // matchesExclude returns true if file matches any of the given patterns.


### PR DESCRIPTION
## What changed

Added a `resolvedVersion()` helper in `cmd/glsec/main.go` that falls back to `runtime/debug.ReadBuildInfo()` when the `version` ldflag is still at its default value `"dev"`.

## Why

When users run `go install github.com/glsec/glsec@v0.2.0`, the Go toolchain embeds the module version in the binary. Previously this was ignored and the binary always reported `glsec dev (commit none, built unknown)`.

## Behaviour after this fix

| Install method | Output |
|---|---|
| GoReleaser (ldflags) | unchanged — uses injected value |
| `go install github.com/glsec/glsec@v0.2.0` | shows `v0.2.0` from build info |
| `go install .` (local, no tag) | falls back to `dev` |

## How to test

```bash
go install github.com/glsec/glsec@<tag>
glsec --version   # should now show the tag
```

Closes #111