### PR TITLE
feat: include job name in findings output

### DIFF
--- a/internal/finding/finding.go
+++ b/internal/finding/finding.go
@@ -11,6 +11,7 @@ const (
 type Finding struct {
 	RuleID   string
 	Severity Severity
+	Job      string
 	Message  string
 	File     string
 	Line     int

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -39,12 +39,23 @@ func Write(w io.Writer, format Format, findings []finding.Finding) error {
 
 func writeText(w io.Writer, findings []finding.Finding) error {
 	for _, f := range findings {
-		_, err := fmt.Fprintf(w, "%-6s %s:%d  %s  %s\n",
-			strings.ToUpper(string(f.Severity)),
-			f.File, f.Line,
-			f.RuleID,
-			f.Message,
-		)
+		var err error
+		if f.Job != "" {
+			_, err = fmt.Fprintf(w, "%-6s %s:%d  %s  [%s]  %s\n",
+				strings.ToUpper(string(f.Severity)),
+				f.File, f.Line,
+				f.RuleID,
+				f.Job,
+				f.Message,
+			)
+		} else {
+			_, err = fmt.Fprintf(w, "%-6s %s:%d  %s  %s\n",
+				strings.ToUpper(string(f.Severity)),
+				f.File, f.Line,
+				f.RuleID,
+				f.Message,
+			)
+		}
 		if err != nil {
 			return err
 		}
@@ -55,6 +66,7 @@ func writeText(w io.Writer, findings []finding.Finding) error {
 type jsonFinding struct {
 	Rule     string `json:"rule"`
 	Severity string `json:"severity"`
+	Job      string `json:"job,omitempty"`
 	File     string `json:"file"`
 	Line     int    `json:"line"`
 	Message  string `json:"message"`
@@ -70,6 +82,7 @@ func writeJSON(w io.Writer, findings []finding.Finding) error {
 		out.Findings = append(out.Findings, jsonFinding{
 			Rule:     f.RuleID,
 			Severity: string(f.Severity),
+			Job:      f.Job,
 			File:     f.File,
 			Line:     f.Line,
 			Message:  f.Message,

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -14,6 +14,12 @@ var testFindings = []finding.Finding{
 	{RuleID: "GL002", Severity: finding.Warn, File: "ci.yml", Line: 12, Message: "Unquoted variable $CI_COMMIT_REF_NAME"},
 }
 
+var testFindingsWithJob = []finding.Finding{
+	{RuleID: "GL024", Severity: finding.Warn, Job: "phpmd", File: ".gitlab-ci.yml", Line: 52, Message: "script uses a pipe without set -o pipefail"},
+	{RuleID: "GL024", Severity: finding.Warn, Job: "e2e", File: ".gitlab-ci.yml", Line: 170, Message: "script uses a pipe without set -o pipefail"},
+	{RuleID: "GL001", Severity: finding.Error, File: ".gitlab-ci.yml", Line: 1, Message: `image "node:latest" uses mutable tag`},
+}
+
 func TestWriteText(t *testing.T) {
 	var buf bytes.Buffer
 	if err := Write(&buf, FormatText, testFindings); err != nil {
@@ -101,6 +107,46 @@ func TestWriteSARIF(t *testing.T) {
 	loc := results[0].Locations[0].PhysicalLocation
 	if loc.ArtifactLocation.URI != "ci.yml" || loc.Region.StartLine != 4 {
 		t.Errorf("unexpected location: %+v", loc)
+	}
+}
+
+func TestWriteText_WithJob(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatText, testFindingsWithJob); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "[phpmd]") {
+		t.Errorf("expected [phpmd] in output: %q", got)
+	}
+	if !strings.Contains(got, "[e2e]") {
+		t.Errorf("expected [e2e] in output: %q", got)
+	}
+	// Finding without a job should not contain brackets around a job name.
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	last := lines[len(lines)-1]
+	if strings.Contains(last, "[") && strings.Contains(last, "]") {
+		t.Errorf("finding without job should not render brackets, got: %q", last)
+	}
+}
+
+func TestWriteJSON_WithJob(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatJSON, testFindingsWithJob); err != nil {
+		t.Fatal(err)
+	}
+	var out jsonOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if out.Findings[0].Job != "phpmd" {
+		t.Errorf("expected job=phpmd, got %q", out.Findings[0].Job)
+	}
+	if out.Findings[1].Job != "e2e" {
+		t.Errorf("expected job=e2e, got %q", out.Findings[1].Job)
+	}
+	if out.Findings[2].Job != "" {
+		t.Errorf("expected empty job for no-job finding, got %q", out.Findings[2].Job)
 	}
 }
 

--- a/rules/gl001.go
+++ b/rules/gl001.go
@@ -27,9 +27,15 @@ func (r *gl001) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, checkServicesNode(parser.FindKey(def, "services"), file)...)
 	}
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
-		findings = append(findings, checkImageNode(parser.FindKey(job, "image"), file)...)
-		findings = append(findings, checkServicesNode(parser.FindKey(job, "services"), file)...)
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range checkImageNode(parser.FindKey(job, "image"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+		for _, f := range checkServicesNode(parser.FindKey(job, "services"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
 	})
 
 	return findings

--- a/rules/gl002.go
+++ b/rules/gl002.go
@@ -60,10 +60,13 @@ func (r *gl002) Check(doc *yaml.Node, file string) []finding.Finding {
 	}
 
 	// per-job script blocks
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkScriptNode(node, file)...)
+				for _, f := range checkScriptNode(node, file) {
+					f.Job = name.Value
+					findings = append(findings, f)
+				}
 			}
 		}
 	})

--- a/rules/gl004.go
+++ b/rules/gl004.go
@@ -39,10 +39,13 @@ func (r *gl004) Check(doc *yaml.Node, file string) []finding.Finding {
 		}
 	}
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, scanScriptForToken(node, file)...)
+				for _, f := range scanScriptForToken(node, file) {
+					f.Job = name.Value
+					findings = append(findings, f)
+				}
 			}
 		}
 	})

--- a/rules/gl005.go
+++ b/rules/gl005.go
@@ -33,12 +33,15 @@ var sensitivePatterns = []string{
 func (r *gl005) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		artifactsNode := parser.FindKey(job, "artifacts")
 		if artifactsNode == nil {
 			return
 		}
-		findings = append(findings, checkArtifacts(artifactsNode, file)...)
+		for _, f := range checkArtifacts(artifactsNode, file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
 	})
 
 	return findings

--- a/rules/gl006.go
+++ b/rules/gl006.go
@@ -44,8 +44,11 @@ func (r *gl006) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, checkVariablesNode(parser.FindKey(def, "variables"), file)...)
 	}
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
-		findings = append(findings, checkVariablesNode(parser.FindKey(job, "variables"), file)...)
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range checkVariablesNode(parser.FindKey(job, "variables"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
 	})
 
 	return findings

--- a/rules/gl007.go
+++ b/rules/gl007.go
@@ -41,9 +41,15 @@ func (r *gl007) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, checkServicesVarInjection(parser.FindKey(def, "services"), file)...)
 	}
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
-		findings = append(findings, checkImageVarInjection(parser.FindKey(job, "image"), file)...)
-		findings = append(findings, checkServicesVarInjection(parser.FindKey(job, "services"), file)...)
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range checkImageVarInjection(parser.FindKey(job, "image"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+		for _, f := range checkServicesVarInjection(parser.FindKey(job, "services"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
 	})
 
 	return findings

--- a/rules/gl008.go
+++ b/rules/gl008.go
@@ -47,6 +47,7 @@ func (r *gl008) Check(doc *yaml.Node, file string) []finding.Finding {
 			findings = append(findings, finding.Finding{
 				RuleID:   "GL008",
 				Severity: finding.Warn,
+				Job:      name.Value,
 				Message: fmt.Sprintf(
 					"security scan job %q has allow_failure: true — scan failures are silently ignored and security results may not be ingested by GitLab",
 					name.Value,

--- a/rules/gl009.go
+++ b/rules/gl009.go
@@ -19,7 +19,7 @@ func (r *gl009) ID() string { return "GL009" }
 func (r *gl009) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		idTokens := parser.FindKey(job, "id_tokens")
 		if idTokens == nil || idTokens.Kind != yaml.MappingNode {
 			return
@@ -34,7 +34,10 @@ func (r *gl009) Check(doc *yaml.Node, file string) []finding.Finding {
 			if audNode == nil {
 				continue
 			}
-			findings = append(findings, checkAudNode(audNode, file)...)
+			for _, f := range checkAudNode(audNode, file) {
+				f.Job = name.Value
+				findings = append(findings, f)
+			}
 		}
 	})
 

--- a/rules/gl010.go
+++ b/rules/gl010.go
@@ -33,6 +33,7 @@ func (r *gl010) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, finding.Finding{
 			RuleID:   "GL010",
 			Severity: finding.Warn,
+			Job:      name.Value,
 			Message: fmt.Sprintf(
 				"trigger job %q forwards all pipeline variables to the downstream pipeline — masked variables are not re-masked and may be exposed in downstream job logs",
 				name.Value,

--- a/rules/gl011.go
+++ b/rules/gl011.go
@@ -41,10 +41,13 @@ func (r *gl011) Check(doc *yaml.Node, file string) []finding.Finding {
 		}
 	}
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkScriptDownloadExecute(node, file)...)
+				for _, f := range checkScriptDownloadExecute(node, file) {
+					f.Job = name.Value
+					findings = append(findings, f)
+				}
 			}
 		}
 	})

--- a/rules/gl012.go
+++ b/rules/gl012.go
@@ -50,6 +50,7 @@ func (r *gl012) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, finding.Finding{
 			RuleID:   "GL012",
 			Severity: finding.Warn,
+			Job:      name.Value,
 			Message: fmt.Sprintf(
 				"deploy job %q has when: always — it will run even if upstream tests or security scans failed, bypassing quality gates",
 				name.Value,

--- a/rules/gl013.go
+++ b/rules/gl013.go
@@ -38,6 +38,7 @@ func (r *gl013) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, finding.Finding{
 			RuleID:   "GL013",
 			Severity: finding.Warn,
+			Job:      name.Value,
 			Message: fmt.Sprintf(
 				"job %q deploys to %q but has no rules: or only: clause — any branch can trigger this deployment",
 				name.Value, envName,

--- a/rules/gl014.go
+++ b/rules/gl014.go
@@ -42,6 +42,7 @@ func (r *gl014) Check(doc *yaml.Node, file string) []finding.Finding {
 					findings = append(findings, finding.Finding{
 						RuleID:   "GL014",
 						Severity: finding.Warn,
+						Job:      name.Value,
 						Message: fmt.Sprintf(
 							"job %q dumps all environment variables to a dotenv artifact — CI_JOB_TOKEN and masked secrets are included and downloadable by any pipeline viewer",
 							name.Value,

--- a/rules/gl015.go
+++ b/rules/gl015.go
@@ -44,10 +44,13 @@ func (r *gl015) Check(doc *yaml.Node, file string) []finding.Finding {
 		}
 	}
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkScriptDockerTags(node, file)...)
+				for _, f := range checkScriptDockerTags(node, file) {
+					f.Job = name.Value
+					findings = append(findings, f)
+				}
 			}
 		}
 	})

--- a/rules/gl016.go
+++ b/rules/gl016.go
@@ -49,11 +49,17 @@ func (r *gl016) Check(doc *yaml.Node, file string) []finding.Finding {
 	findings = append(findings, r.checkVariablesHTTP(parser.FindKey(mapping, "variables"), file)...)
 
 	// per-job
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
-		findings = append(findings, r.checkVariablesHTTP(parser.FindKey(job, "variables"), file)...)
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range r.checkVariablesHTTP(parser.FindKey(job, "variables"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, r.checkScriptHTTP(node, file)...)
+				for _, f := range r.checkScriptHTTP(node, file) {
+					f.Job = name.Value
+					findings = append(findings, f)
+				}
 			}
 		}
 	})

--- a/rules/gl017.go
+++ b/rules/gl017.go
@@ -32,6 +32,7 @@ func (r *gl017) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, finding.Finding{
 			RuleID:   "GL017",
 			Severity: finding.Warn,
+			Job:      name.Value,
 			Message: fmt.Sprintf(
 				"job %q deploys or publishes but has no tags: — it can run on any available runner, including untrusted self-hosted runners",
 				name.Value,

--- a/rules/gl019.go
+++ b/rules/gl019.go
@@ -27,6 +27,7 @@ func (r *gl019) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, finding.Finding{
 			RuleID:   "GL019",
 			Severity: finding.Warn,
+			Job:      name.Value,
 			Message: fmt.Sprintf(
 				"job %q deploys or publishes but has no resource_group: — concurrent pipeline runs can cause race conditions or partial deploys",
 				name.Value,

--- a/rules/gl020.go
+++ b/rules/gl020.go
@@ -54,6 +54,7 @@ func (r *gl020) Check(doc *yaml.Node, file string) []finding.Finding {
 		findings = append(findings, finding.Finding{
 			RuleID:   "GL020",
 			Severity: finding.Warn,
+			Job:      name.Value,
 			Message:  "job downloads a file with curl/wget but no checksum verification (sha256sum, gpg --verify, etc.) found in script",
 			File:     file,
 			Line:     downloadLine.Line,

--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -30,7 +30,7 @@ var (
 func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"before_script", "script", "after_script"} {
 			node := parser.FindKey(job, key)
 			if node == nil || node.Kind != yaml.SequenceNode {
@@ -55,6 +55,7 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 				findings = append(findings, finding.Finding{
 					RuleID:   "GL021",
 					Severity: finding.Warn,
+					Job:      name.Value,
 					Message:  fmt.Sprintf("script prints secret variable %s — value may appear in job logs", match),
 					File:     file,
 					Line:     item.Line,

--- a/rules/gl022.go
+++ b/rules/gl022.go
@@ -84,10 +84,11 @@ var (
 func (r *gl022) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		lines := collectScriptLines(job)
 		for _, l := range lines {
 			if f := checkPMLine(l.Value, file, l.Line, l.Column); f != nil {
+				f.Job = name.Value
 				findings = append(findings, *f)
 			}
 		}

--- a/rules/gl023.go
+++ b/rules/gl023.go
@@ -61,10 +61,11 @@ var lockfileChecks = []lockfileCheck{
 func (r *gl023) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		lines := collectScriptLines(job)
 		for _, l := range lines {
 			if f := checkLockfileLine(l.Value, file, l.Line, l.Column); f != nil {
+				f.Job = name.Value
 				findings = append(findings, *f)
 			}
 		}

--- a/rules/gl024.go
+++ b/rules/gl024.go
@@ -26,7 +26,7 @@ var (
 func (r *gl024) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		lines := collectScriptLines(job)
 		if len(lines) == 0 {
 			return
@@ -45,6 +45,7 @@ func (r *gl024) Check(doc *yaml.Node, file string) []finding.Finding {
 				findings = append(findings, finding.Finding{
 					RuleID:   "GL024",
 					Severity: finding.Warn,
+					Job:      name.Value,
 					Message:  "script uses a pipe without set -o pipefail — failures in all but the last command are silently ignored",
 					File:     file,
 					Line:     l.Line,

--- a/rules/gl025.go
+++ b/rules/gl025.go
@@ -26,7 +26,7 @@ var curlWgetRe = regexp.MustCompile(`\b(?:curl|wget)\b`)
 func (r *gl025) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, l := range collectScriptLines(job) {
 			if !curlWgetRe.MatchString(l.Value) {
 				continue
@@ -38,6 +38,7 @@ func (r *gl025) Check(doc *yaml.Node, file string) []finding.Finding {
 			findings = append(findings, finding.Finding{
 				RuleID:   "GL025",
 				Severity: finding.Warn,
+				Job:      name.Value,
 				Message:  "curl/wget uses user-controlled variable " + m + " — attacker can redirect the request to an arbitrary host",
 				File:     file,
 				Line:     l.Line,

--- a/rules/gl026.go
+++ b/rules/gl026.go
@@ -34,7 +34,7 @@ var (
 func (r *gl026) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		lines := collectScriptLines(job)
 		if len(lines) == 0 {
 			return
@@ -61,6 +61,7 @@ func (r *gl026) Check(doc *yaml.Node, file string) []finding.Finding {
 						findings = append(findings, finding.Finding{
 							RuleID:   "GL026",
 							Severity: finding.Warn,
+							Job:      name.Value,
 							Message:  "git clone uses mutable ref \"" + ref + "\" — pin to a full commit SHA with git checkout after cloning",
 							File:     file,
 							Line:     l.Line,
@@ -71,6 +72,7 @@ func (r *gl026) Check(doc *yaml.Node, file string) []finding.Finding {
 					findings = append(findings, finding.Finding{
 						RuleID:   "GL026",
 						Severity: finding.Warn,
+						Job:      name.Value,
 						Message:  "git clone without --branch clones HEAD of the default branch — follow with git checkout <sha> to pin the revision",
 						File:     file,
 						Line:     l.Line,
@@ -90,6 +92,7 @@ func (r *gl026) Check(doc *yaml.Node, file string) []finding.Finding {
 				findings = append(findings, finding.Finding{
 					RuleID:   "GL026",
 					Severity: finding.Warn,
+					Job:      name.Value,
 					Message:  "git checkout uses a mutable ref — pin to a full 40-character commit SHA",
 					File:     file,
 					Line:     l.Line,


### PR DESCRIPTION
## What changed

Added a `Job` field to `finding.Finding`. All rules that iterate jobs via `parser.EachJob` now populate it with the job name. Hidden jobs and templates (names starting with `.`) are included as-is — since the yaml.v3 Node API does not auto-resolve YAML merge keys (`<<: *anchor`), findings fire on the template itself rather than on concrete jobs that inherit via merge, avoiding duplicates.

### Text output

When `Job` is non-empty, the job name appears in brackets between the rule ID and message:

```
WARN   .gitlab-ci.yml:52   GL024  [phpmd]          script uses a pipe without set -o pipefail
WARN   .gitlab-ci.yml:170  GL024  [e2e]             script uses a pipe without set -o pipefail
WARN   .gitlab-ci.yml:192  GL024  [.robot-template] script uses a pipe without set -o pipefail
```

Findings without a job context (e.g. top-level `variables:` checks) render unchanged.

### JSON output

A `job` field is added to each finding object (`omitempty` — absent when empty).

### SARIF output

Unchanged — job context does not map cleanly to the SARIF schema.

## How to test

Run glsec against any `.gitlab-ci.yml` with multiple jobs triggering the same rule (e.g. GL024 on a file with several jobs using pipes without `pipefail`).

Closes #112