### PR TITLE
feat: filter rules by OWASP CICD-SEC category in config

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -129,6 +129,9 @@ func main() {
 		if !cfg.RuleEnabled(rule.ID()) {
 			continue
 		}
+		if !cfg.OWASPEnabled(rules.OWASPCategories(rule.ID())) {
+			continue
+		}
 		if !rules.EnabledFor(rule.ID(), gitlabVersion) {
 			continue
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,12 @@ type Config struct {
 	// ExcludePaths is a list of file globs to skip entirely.
 	// Supports filepath.Match patterns and directory suffixes (/ or /**).
 	ExcludePaths []string `yaml:"exclude_paths"`
+	// OWASP is an allowlist of OWASP CICD-SEC category IDs. When non-empty,
+	// only rules belonging to one of these categories are run.
+	OWASP []string `yaml:"owasp"`
+	// OWASPExclude is a denylist of OWASP CICD-SEC category IDs. Rules
+	// belonging to any listed category are skipped.
+	OWASPExclude []string `yaml:"owasp_exclude"`
 }
 
 // Default returns a Config with no overrides.
@@ -133,6 +139,8 @@ var allowedTopLevelKeys = map[string]bool{
 	"strict":         true,
 	"no-exit-codes":  true,
 	"exclude_paths":  true,
+	"owasp":          true,
+	"owasp_exclude":  true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {
@@ -171,8 +179,22 @@ func (c *Config) validate(path string) error {
 			return fmt.Errorf("%s: gitlab-version: %w", path, err)
 		}
 	}
+	for _, cat := range append(c.OWASP, c.OWASPExclude...) {
+		if !validOWASPCategory(cat) {
+			return fmt.Errorf("%s: invalid OWASP category %q (expected CICD-SEC-1 through CICD-SEC-10)", path, cat)
+		}
+	}
 	return nil
 }
+
+var validOWASPCategories = map[string]bool{
+	"CICD-SEC-1": true, "CICD-SEC-2": true, "CICD-SEC-3": true,
+	"CICD-SEC-4": true, "CICD-SEC-5": true, "CICD-SEC-6": true,
+	"CICD-SEC-7": true, "CICD-SEC-8": true, "CICD-SEC-9": true,
+	"CICD-SEC-10": true,
+}
+
+func validOWASPCategory(s string) bool { return validOWASPCategories[s] }
 
 // RuleEnabled returns false if the rule is set to "off" in the config.
 func (c *Config) RuleEnabled(id string) bool {
@@ -196,6 +218,31 @@ var severityLevel = map[finding.Severity]int{
 	finding.Error: 3,
 	finding.Warn:  2,
 	finding.Info:  1,
+}
+
+// OWASPEnabled returns false if categories indicates the rule should be
+// skipped based on the owasp / owasp_exclude config fields.
+// categories is the list of OWASP categories for the rule (from rules.OWASPCategories).
+func (c *Config) OWASPEnabled(categories []string) bool {
+	if len(c.OWASP) > 0 {
+		for _, cat := range categories {
+			for _, allowed := range c.OWASP {
+				if cat == allowed {
+					goto allowlistOK
+				}
+			}
+		}
+		return false
+	allowlistOK:
+	}
+	for _, cat := range categories {
+		for _, excluded := range c.OWASPExclude {
+			if cat == excluded {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // AboveMinSeverity returns true if f meets or exceeds the configured

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -242,3 +242,62 @@ func TestLoad_FromFile(t *testing.T) {
 		t.Errorf("expected min-severity warn, got %q", cfg.MinSeverity)
 	}
 }
+
+func TestOWASPEnabled_Allowlist(t *testing.T) {
+	cfg := parseStr(t, `
+owasp:
+  - CICD-SEC-6
+`)
+	if !cfg.OWASPEnabled([]string{"CICD-SEC-6"}) {
+		t.Error("CICD-SEC-6 should be enabled when in allowlist")
+	}
+	if cfg.OWASPEnabled([]string{"CICD-SEC-3"}) {
+		t.Error("CICD-SEC-3 should be disabled when not in allowlist")
+	}
+	if !cfg.OWASPEnabled([]string{"CICD-SEC-3", "CICD-SEC-6"}) {
+		t.Error("rule with multiple categories should pass if any is in allowlist")
+	}
+}
+
+func TestOWASPEnabled_Denylist(t *testing.T) {
+	cfg := parseStr(t, `
+owasp_exclude:
+  - CICD-SEC-7
+`)
+	if cfg.OWASPEnabled([]string{"CICD-SEC-7"}) {
+		t.Error("CICD-SEC-7 should be disabled when in denylist")
+	}
+	if !cfg.OWASPEnabled([]string{"CICD-SEC-6"}) {
+		t.Error("CICD-SEC-6 should be enabled when not in denylist")
+	}
+}
+
+func TestOWASPEnabled_Empty(t *testing.T) {
+	cfg := Default()
+	if !cfg.OWASPEnabled([]string{"CICD-SEC-6"}) {
+		t.Error("all categories should be enabled with no filter set")
+	}
+	if !cfg.OWASPEnabled(nil) {
+		t.Error("rule with no category should be enabled with no filter set")
+	}
+}
+
+func TestOWASPEnabled_AllowlistWithNoCategory(t *testing.T) {
+	cfg := parseStr(t, `
+owasp:
+  - CICD-SEC-6
+`)
+	if cfg.OWASPEnabled(nil) {
+		t.Error("rule with no category should be excluded when allowlist is set")
+	}
+}
+
+func TestParse_InvalidOWASPCategory(t *testing.T) {
+	_, err := parse([]byte(`
+owasp:
+  - CICD-SEC-99
+`), "test.yml")
+	if err == nil {
+		t.Error("expected error for invalid OWASP category")
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -1,0 +1,37 @@
+package rules
+
+// owaspCategories maps each rule ID to the OWASP CI/CD security categories it
+// addresses. A rule may belong to more than one category.
+var owaspCategories = map[string][]string{
+	"GL001": {"CICD-SEC-3"},
+	"GL002": {"CICD-SEC-6"},
+	"GL003": {"CICD-SEC-3"},
+	"GL004": {"CICD-SEC-6"},
+	"GL005": {"CICD-SEC-7"},
+	"GL006": {"CICD-SEC-6"},
+	"GL007": {"CICD-SEC-7"},
+	"GL008": {"CICD-SEC-1"},
+	"GL009": {"CICD-SEC-5"},
+	"GL010": {"CICD-SEC-6"},
+	"GL011": {"CICD-SEC-9"},
+	"GL012": {"CICD-SEC-1"},
+	"GL013": {"CICD-SEC-1"},
+	"GL014": {"CICD-SEC-6"},
+	"GL015": {"CICD-SEC-3"},
+	"GL016": {"CICD-SEC-7"},
+	"GL017": {"CICD-SEC-5"},
+	"GL018": {"CICD-SEC-6"},
+	"GL019": {"CICD-SEC-1"},
+	"GL020": {"CICD-SEC-9"},
+	"GL021": {"CICD-SEC-6"},
+	"GL022": {"CICD-SEC-3"},
+	"GL023": {"CICD-SEC-3"},
+	"GL024": {"CICD-SEC-7"},
+	"GL025": {"CICD-SEC-9"},
+	"GL026": {"CICD-SEC-3"},
+}
+
+// OWASPCategories returns the OWASP CI/CD security categories for a rule ID.
+func OWASPCategories(id string) []string {
+	return owaspCategories[id]
+}


### PR DESCRIPTION
## What changed

- Added `rules/owasp.go` — maps each of the 26 rules to its OWASP CI/CD security category
- Extended `.glsec.yml` with two new optional fields: `owasp` (allowlist) and `owasp_exclude` (denylist)
- Filter is applied in `main.go` alongside the existing per-rule `rules.<ID>: off` toggle (individual overrides still take precedence)
- Invalid category IDs (anything outside CICD-SEC-1 through CICD-SEC-10) are rejected at parse time

## Config syntax

Run only credential hygiene and supply chain rules:
```yaml
owasp:
  - CICD-SEC-6
  - CICD-SEC-9
```

Skip insecure-configuration rules:
```yaml
owasp_exclude:
  - CICD-SEC-7
```

Both can coexist with per-rule overrides. Rules belonging to multiple categories pass the allowlist check if **any** of their categories matches.

## How to test

```bash
# only CICD-SEC-6 rules should fire
echo "owasp: [CICD-SEC-6]" > .glsec.yml
glsec .gitlab-ci.yml
```

Closes #119