### PR TITLE
feat: add CWE mappings and expose via SARIF taxa

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -156,7 +156,13 @@ func main() {
 		return // exit 0
 	}
 
-	if err := output.Write(os.Stdout, format, findings); err != nil {
+	var writeErr error
+	if format == output.FormatSARIF {
+		writeErr = output.WriteSARIF(os.Stdout, findings, rules.CWEID, rules.CWEName)
+	} else {
+		writeErr = output.Write(os.Stdout, format, findings)
+	}
+	if err := writeErr; err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(2)
 	}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -31,7 +31,7 @@ func Write(w io.Writer, format Format, findings []finding.Finding) error {
 	case FormatJSON:
 		return writeJSON(w, findings)
 	case FormatSARIF:
-		return writeSARIF(w, findings)
+		return writeSARIF(w, findings, nil, nil)
 	default:
 		return writeText(w, findings)
 	}
@@ -101,8 +101,9 @@ type sarifLog struct {
 }
 
 type sarifRun struct {
-	Tool    sarifTool     `json:"tool"`
-	Results []sarifResult `json:"results"`
+	Tool       sarifTool        `json:"tool"`
+	Taxonomies []sarifTaxonomy  `json:"taxonomies,omitempty"`
+	Results    []sarifResult    `json:"results"`
 }
 
 type sarifTool struct {
@@ -110,8 +111,40 @@ type sarifTool struct {
 }
 
 type sarifDriver struct {
-	Name           string `json:"name"`
-	InformationURI string `json:"informationUri"`
+	Name           string       `json:"name"`
+	InformationURI string       `json:"informationUri"`
+	Rules          []sarifRule  `json:"rules,omitempty"`
+}
+
+type sarifRule struct {
+	ID            string                  `json:"id"`
+	Relationships []sarifRelationship     `json:"relationships,omitempty"`
+}
+
+type sarifRelationship struct {
+	Target sarifRelationshipTarget `json:"target"`
+	Kinds  []string                `json:"kinds"`
+}
+
+type sarifRelationshipTarget struct {
+	ID            string                    `json:"id"`
+	ToolComponent sarifToolComponentRef     `json:"toolComponent"`
+}
+
+type sarifToolComponentRef struct {
+	Name string `json:"name"`
+}
+
+type sarifTaxonomy struct {
+	Name             string      `json:"name"`
+	Version          string      `json:"version"`
+	Organization     string      `json:"organization"`
+	Taxa             []sarifTaxon `json:"taxa"`
+}
+
+type sarifTaxon struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type sarifResult struct {
@@ -153,7 +186,15 @@ func severityToSARIFLevel(s finding.Severity) string {
 	}
 }
 
-func writeSARIF(w io.Writer, findings []finding.Finding) error {
+// WriteSARIF writes SARIF output enriched with CWE metadata.
+// cweID maps a rule ID to its CWE identifier (e.g. "CWE-798").
+// cweName maps a CWE identifier to its human-readable name.
+// Pass nil for either to omit CWE data.
+func WriteSARIF(w io.Writer, findings []finding.Finding, cweID func(string) string, cweName func(string) string) error {
+	return writeSARIF(w, findings, cweID, cweName)
+}
+
+func writeSARIF(w io.Writer, findings []finding.Finding, cweID func(string) string, cweName func(string) string) error {
 	results := make([]sarifResult, 0, len(findings))
 	for _, f := range findings {
 		results = append(results, sarifResult{
@@ -168,16 +209,57 @@ func writeSARIF(w io.Writer, findings []finding.Finding) error {
 			}},
 		})
 	}
+
+	run := sarifRun{
+		Tool: sarifTool{Driver: sarifDriver{
+			Name:           "glsec",
+			InformationURI: "https://github.com/glsec/glsec",
+		}},
+		Results: results,
+	}
+
+	if cweID != nil && cweName != nil {
+		seenRules := map[string]bool{}
+		seenCWEs := map[string]bool{}
+		for _, f := range findings {
+			if seenRules[f.RuleID] {
+				continue
+			}
+			seenRules[f.RuleID] = true
+			cwe := cweID(f.RuleID)
+			if cwe == "" {
+				continue
+			}
+			run.Tool.Driver.Rules = append(run.Tool.Driver.Rules, sarifRule{
+				ID: f.RuleID,
+				Relationships: []sarifRelationship{{
+					Target: sarifRelationshipTarget{
+						ID:            cwe,
+						ToolComponent: sarifToolComponentRef{Name: "CWE"},
+					},
+					Kinds: []string{"superset"},
+				}},
+			})
+			seenCWEs[cwe] = true
+		}
+		if len(seenCWEs) > 0 {
+			taxa := make([]sarifTaxon, 0, len(seenCWEs))
+			for cwe := range seenCWEs {
+				taxa = append(taxa, sarifTaxon{ID: cwe, Name: cweName(cwe)})
+			}
+			run.Taxonomies = []sarifTaxonomy{{
+				Name:         "CWE",
+				Version:      "4.14",
+				Organization: "MITRE",
+				Taxa:         taxa,
+			}}
+		}
+	}
+
 	log := sarifLog{
 		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
 		Version: "2.1.0",
-		Runs: []sarifRun{{
-			Tool: sarifTool{Driver: sarifDriver{
-				Name:           "glsec",
-				InformationURI: "https://github.com/glsec/glsec",
-			}},
-			Results: results,
-		}},
+		Runs:    []sarifRun{run},
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -168,3 +168,64 @@ func TestParseFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteSARIF_WithCWE(t *testing.T) {
+	cweID := func(id string) string {
+		if id == "GL001" {
+			return "CWE-1104"
+		}
+		return ""
+	}
+	cweName := func(id string) string {
+		if id == "CWE-1104" {
+			return "Use of Unmaintained Third-Party Components"
+		}
+		return ""
+	}
+
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, testFindings, cweID, cweName); err != nil {
+		t.Fatal(err)
+	}
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid SARIF JSON: %v", err)
+	}
+
+	run := log.Runs[0]
+
+	if len(run.Tool.Driver.Rules) != 1 {
+		t.Fatalf("expected 1 rule descriptor (GL001 has CWE, GL002 does not), got %d", len(run.Tool.Driver.Rules))
+	}
+	rule := run.Tool.Driver.Rules[0]
+	if rule.ID != "GL001" {
+		t.Errorf("expected rule GL001, got %q", rule.ID)
+	}
+	if len(rule.Relationships) != 1 || rule.Relationships[0].Target.ID != "CWE-1104" {
+		t.Errorf("unexpected CWE relationship: %+v", rule.Relationships)
+	}
+
+	if len(run.Taxonomies) != 1 || run.Taxonomies[0].Name != "CWE" {
+		t.Fatalf("expected CWE taxonomy, got %+v", run.Taxonomies)
+	}
+	if len(run.Taxonomies[0].Taxa) != 1 || run.Taxonomies[0].Taxa[0].ID != "CWE-1104" {
+		t.Errorf("unexpected taxa: %+v", run.Taxonomies[0].Taxa)
+	}
+}
+
+func TestWriteSARIF_NoCWE(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, testFindings, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid SARIF JSON: %v", err)
+	}
+	if len(log.Runs[0].Tool.Driver.Rules) != 0 {
+		t.Error("expected no rule descriptors when CWE lookup is nil")
+	}
+	if len(log.Runs[0].Taxonomies) != 0 {
+		t.Error("expected no taxonomies when CWE lookup is nil")
+	}
+}

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -1,0 +1,56 @@
+package rules
+
+// cweIDs maps each rule ID to its CWE identifier.
+var cweIDs = map[string]string{
+	"GL001": "CWE-1104",
+	"GL002": "CWE-78",
+	"GL003": "CWE-829",
+	"GL004": "CWE-522",
+	"GL005": "CWE-538",
+	"GL006": "CWE-798",
+	"GL007": "CWE-829",
+	"GL008": "CWE-390",
+	"GL009": "CWE-284",
+	"GL010": "CWE-522",
+	"GL011": "CWE-494",
+	"GL012": "CWE-691",
+	"GL013": "CWE-284",
+	"GL014": "CWE-522",
+	"GL015": "CWE-829",
+	"GL016": "CWE-319",
+	"GL017": "CWE-284",
+	"GL018": "CWE-522",
+	"GL019": "CWE-362",
+	"GL020": "CWE-494",
+	"GL021": "CWE-532",
+	"GL022": "CWE-1104",
+	"GL023": "CWE-1104",
+	"GL024": "CWE-390",
+	"GL025": "CWE-441",
+	"GL026": "CWE-829",
+}
+
+// cweNames maps CWE IDs to their short names.
+var cweNames = map[string]string{
+	"CWE-78":   "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+	"CWE-284":  "Improper Access Control",
+	"CWE-319":  "Cleartext Transmission of Sensitive Information",
+	"CWE-362":  "Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')",
+	"CWE-390":  "Detection of Error Condition Without Action",
+	"CWE-441":  "Unintended Proxy or Intermediary ('Confused Deputy')",
+	"CWE-494":  "Download of Code Without Integrity Check",
+	"CWE-522":  "Insufficiently Protected Credentials",
+	"CWE-532":  "Insertion of Sensitive Information into Log File",
+	"CWE-538":  "Insertion of Sensitive Information into Externally-Accessible File or Directory",
+	"CWE-691":  "Insufficient Control Flow Management",
+	"CWE-798":  "Use of Hard-coded Credentials",
+	"CWE-829":  "Inclusion of Functionality from Untrusted Control Sphere",
+	"CWE-1104": "Use of Unmaintained Third-Party Components",
+}
+
+// CWEID returns the CWE identifier for a rule, e.g. "CWE-798".
+// Returns an empty string if the rule has no mapping.
+func CWEID(ruleID string) string { return cweIDs[ruleID] }
+
+// CWEName returns the human-readable name for a CWE identifier.
+func CWEName(cweID string) string { return cweNames[cweID] }


### PR DESCRIPTION
## What changed

- Added `rules/cwe.go` — maps all 26 rules to CWE identifiers and provides human-readable CWE names
- Extended the SARIF output with `driver.rules[].relationships` (CWE reference per rule) and `taxonomies[]` (CWE taxon entries for every CWE that appears in the findings)
- Added `output.WriteSARIF(w, findings, cweID, cweName)` — public function that accepts lookup callbacks so the output package stays free of rule-package imports
- `main.go` calls `WriteSARIF` with `rules.CWEID` / `rules.CWEName` when `--format sarif` is used; `Write` (used in tests and other callers) passes `nil` and produces CWE-free SARIF as before

## SARIF output example

```json
{
  "tool": {
    "driver": {
      "rules": [
        {
          "id": "GL006",
          "relationships": [{ "target": { "id": "CWE-798", "toolComponent": { "name": "CWE" } }, "kinds": ["superset"] }]
        }
      ]
    }
  },
  "taxonomies": [{ "name": "CWE", "version": "4.14", "organization": "MITRE", "taxa": [{ "id": "CWE-798", "name": "Use of Hard-coded Credentials" }] }]
}
```

GitLab SAST and GitHub Code Scanning both read this structure and surface CWE IDs in their Security Dashboards.

Closes #121