### PR TITLE
feat: flag composer require without version constraint (GL022)

### DIFF
--- a/rules/gl022.go
+++ b/rules/gl022.go
@@ -67,6 +67,12 @@ var (
 			pinned:  regexp.MustCompile(`(?:--version|--vers)\s+\d`),
 			skip:    nil,
 		},
+		{
+			manager: "composer require",
+			trigger: regexp.MustCompile(`\bcomposer\s+require\b`),
+			pinned:  regexp.MustCompile(`:\S`),
+			skip:    nil,
+		},
 	}
 
 	pmUpdateChecks = []pmUpdateCheck{

--- a/rules/gl022_test.go
+++ b/rules/gl022_test.go
@@ -291,3 +291,63 @@ build:
 		t.Error("expected non-zero line number")
 	}
 }
+
+// --- composer require ---
+
+func TestGL022_ComposerRequireUnpinned(t *testing.T) {
+	f := findings022(t, `
+api:
+  script:
+    - composer require guzzlehttp/guzzle --no-interaction
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL022_ComposerRequireUnpinnedWithDevFlag(t *testing.T) {
+	f := findings022(t, `
+api:
+  script:
+    - composer require --dev phpunit/phpunit --no-interaction --no-scripts
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --dev without version, got %d", len(f))
+	}
+}
+
+func TestGL022_ComposerRequirePinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+api:
+  script:
+    - composer require guzzlehttp/guzzle:^7.0 --no-interaction
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned version, got %d", len(f))
+	}
+}
+
+func TestGL022_ComposerRequirePinnedQuoted_NoFinding(t *testing.T) {
+	f := findings022(t, `
+api:
+  script:
+    - composer require "guzzlehttp/guzzle:>=7.0" --no-interaction
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for quoted pinned version, got %d", len(f))
+	}
+}
+
+func TestGL022_ComposerInstall_NoFinding(t *testing.T) {
+	f := findings022(t, `
+api:
+  script:
+    - composer install --no-interaction
+`)
+	if len(f) != 0 {
+		t.Errorf("composer install reads lockfile — expected no finding, got %d", len(f))
+	}
+}

--- a/testdata/fixtures/gl022-unpinned-packages.yml
+++ b/testdata/fixtures/gl022-unpinned-packages.yml
@@ -8,3 +8,4 @@ build:
     - pip install ansible
     - npm install -g @angular/cli
     - apt-get install -y jq
+    - composer require guzzlehttp/guzzle --no-interaction


### PR DESCRIPTION
## What changed

Extended GL022 with a new `pmInstallCheck` entry for `composer require`. A line matching `composer require` is flagged unless it contains a version constraint (`:` followed by a non-whitespace character, e.g. `vendor/pkg:^1.2` or `"vendor/pkg:>=7.0"`).

`composer install` is intentionally not flagged — it reads `composer.lock` and is reproducible.

## Examples

```yaml
# flagged — no version constraint
- composer require guzzlehttp/guzzle --no-interaction
- composer require --dev phpunit/phpunit --no-scripts

# not flagged — version constraint present
- composer require guzzlehttp/guzzle:^7.0
- composer require "guzzlehttp/guzzle:>=7.0"

# not flagged — reads lockfile
- composer install --no-interaction
```

Closes #115