### PR TITLE
feat: GL027 – flag secret-like variables missing masked: true

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -11,6 +11,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | ID | Severity | Description |
 |----|----------|-------------|
 | [GL002](rules/GL002.md) | `warn`  | User-controlled CI variable used unquoted in script |
+| [GL027](rules/GL027.md) | `warn`  | Secret-like variable defined without `masked: true` |
 | [GL004](rules/GL004.md) | `warn`  | `CI_JOB_TOKEN` forwarded to a non-GitLab host |
 | [GL006](rules/GL006.md) | `error` | Hardcoded secret in `variables:` block |
 | [GL010](rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |

--- a/docs/rules/GL027.md
+++ b/docs/rules/GL027.md
@@ -1,0 +1,38 @@
+# GL027 — Secret-like variable missing `masked: true`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags variables defined in long-form (`value:` / `description:` mapping) whose name ends with a secret-like suffix (`_TOKEN`, `_SECRET`, `_PASSWORD`, `_PASSWD`, `_PASS`, `_PWD`, `_KEY`, `_CREDENTIAL`, `_CERT`, `_API_KEY`) but lack `masked: true`. Without masking, GitLab echoes the variable's value to the job log whenever it expands the variable, making it readable by anyone with log access.
+
+Only the long-form syntax is flagged — plain scalars (`MY_TOKEN: "abc"`) cannot carry `masked: true` and are therefore out of scope for this rule.
+
+Complements GL021 (deliberate `echo` of a secret) — GL027 catches passive leaking through missing masking configuration.
+
+## Trigger example
+
+```yaml
+variables:
+  DEPLOY_TOKEN:
+    value: "glpat-xxxxxxxxxxxxxxxxxxxx"
+    description: "GitLab deploy token"
+    # masked: true absent — value appears in CI logs
+```
+
+## Safe alternative
+
+```yaml
+variables:
+  DEPLOY_TOKEN:
+    value: "glpat-xxxxxxxxxxxxxxxxxxxx"
+    description: "GitLab deploy token"
+    masked: true
+```
+
+## References
+
+- [GitLab docs: Mask a CI/CD variable](https://docs.gitlab.com/ee/ci/variables/#mask-a-cicd-variable)
+- GL021: secret variable printed to job log via `echo`/`printf`
+- GL006: hardcoded secret value in `variables:` block

--- a/rules/all.go
+++ b/rules/all.go
@@ -30,5 +30,6 @@ func All() []rule.Rule {
 		GL024,
 		GL025,
 		GL026,
+		GL027,
 	}
 }

--- a/rules/consistency_test.go
+++ b/rules/consistency_test.go
@@ -11,6 +11,8 @@ import (
 var ruleIDPattern = regexp.MustCompile(`^GL\d{3}$`)
 
 func TestRuleConsistency(t *testing.T) {
+	rulesOverview := loadRulesOverview(t)
+
 	for _, r := range All() {
 		r := r
 		t.Run(r.ID(), func(t *testing.T) {
@@ -22,6 +24,9 @@ func TestRuleConsistency(t *testing.T) {
 
 			checkDocFile(t, id)
 			checkFixture(t, id)
+			checkOWASPMapping(t, id)
+			checkCWEMapping(t, id)
+			checkRulesOverview(t, id, rulesOverview)
 		})
 	}
 }
@@ -48,5 +53,35 @@ func checkFixture(t *testing.T, id string) {
 	}
 	if len(matches) == 0 {
 		t.Errorf("no fixture in testdata/fixtures/ matching %s*.yml", prefix)
+	}
+}
+
+func checkOWASPMapping(t *testing.T, id string) {
+	t.Helper()
+	if len(OWASPCategories(id)) == 0 {
+		t.Errorf("no OWASP category mapping for %s (add to rules/owasp.go)", id)
+	}
+}
+
+func checkCWEMapping(t *testing.T, id string) {
+	t.Helper()
+	if CWEID(id) == "" {
+		t.Errorf("no CWE mapping for %s (add to rules/cwe.go)", id)
+	}
+}
+
+func loadRulesOverview(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "docs", "rules.md"))
+	if err != nil {
+		t.Fatalf("could not read docs/rules.md: %v", err)
+	}
+	return string(data)
+}
+
+func checkRulesOverview(t *testing.T, id, overview string) {
+	t.Helper()
+	if !strings.Contains(overview, id) {
+		t.Errorf("%s is not listed in docs/rules.md", id)
 	}
 }

--- a/rules/consistency_test.go
+++ b/rules/consistency_test.go
@@ -1,16 +1,21 @@
 package rules
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
 )
 
 var ruleIDPattern = regexp.MustCompile(`^GL\d{3}$`)
 
 func TestRuleConsistency(t *testing.T) {
+	checkNoDuplicateIDs(t)
+
 	rulesOverview := loadRulesOverview(t)
 
 	for _, r := range All() {
@@ -23,11 +28,22 @@ func TestRuleConsistency(t *testing.T) {
 			}
 
 			checkDocFile(t, id)
-			checkFixture(t, id)
+			checkFixtureFires(t, id)
 			checkOWASPMapping(t, id)
 			checkCWEMapping(t, id)
-			checkRulesOverview(t, id, rulesOverview)
+			checkRulesOverviewLink(t, id, rulesOverview)
 		})
+	}
+}
+
+func checkNoDuplicateIDs(t *testing.T) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, r := range All() {
+		if seen[r.ID()] {
+			t.Errorf("duplicate rule ID %q in All()", r.ID())
+		}
+		seen[r.ID()] = true
 	}
 }
 
@@ -44,7 +60,7 @@ func checkDocFile(t *testing.T, id string) {
 	}
 }
 
-func checkFixture(t *testing.T, id string) {
+func checkFixtureFires(t *testing.T, id string) {
 	t.Helper()
 	prefix := strings.ToLower(id) + "-"
 	matches, err := filepath.Glob(filepath.Join("..", "testdata", "fixtures", prefix+"*.yml"))
@@ -53,6 +69,35 @@ func checkFixture(t *testing.T, id string) {
 	}
 	if len(matches) == 0 {
 		t.Errorf("no fixture in testdata/fixtures/ matching %s*.yml", prefix)
+		return
+	}
+
+	var rule interface {
+		ID() string
+	}
+	for _, r := range All() {
+		if r.ID() == id {
+			rule = r
+			break
+		}
+	}
+
+	totalFindings := 0
+	for _, path := range matches {
+		doc, parseErr := parser.ParseFile(path)
+		if parseErr != nil {
+			t.Errorf("fixture %s failed to parse: %v", filepath.Base(path), parseErr)
+			continue
+		}
+		for _, r := range All() {
+			if r.ID() == rule.ID() {
+				totalFindings += len(r.Check(doc.Root, path))
+				break
+			}
+		}
+	}
+	if totalFindings == 0 {
+		t.Errorf("fixture(s) for %s produce no findings — fixture must trigger the rule", id)
 	}
 }
 
@@ -79,9 +124,10 @@ func loadRulesOverview(t *testing.T) string {
 	return string(data)
 }
 
-func checkRulesOverview(t *testing.T, id, overview string) {
+func checkRulesOverviewLink(t *testing.T, id, overview string) {
 	t.Helper()
-	if !strings.Contains(overview, id) {
-		t.Errorf("%s is not listed in docs/rules.md", id)
+	link := fmt.Sprintf("[%s](rules/%s.md)", id, id)
+	if !strings.Contains(overview, link) {
+		t.Errorf("%s has no proper link in docs/rules.md (expected %q)", id, link)
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -28,6 +28,7 @@ var cweIDs = map[string]string{
 	"GL024": "CWE-390",
 	"GL025": "CWE-441",
 	"GL026": "CWE-829",
+	"GL027": "CWE-532",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl018.go
+++ b/rules/gl018.go
@@ -19,7 +19,7 @@ func (r *gl018) ID() string { return "GL018" }
 // secretNameSuffixes identifies variable names that suggest secret content.
 var secretNameSuffixes = []string{
 	"_TOKEN", "_SECRET", "_PASSWORD", "_PASSWD", "_PASS", "_PWD",
-	"_KEY", "_CREDENTIAL", "_CERT",
+	"_KEY", "_CREDENTIAL", "_CERT", "_API_KEY",
 }
 
 // varRefRe matches a value that is (or starts with) a CI variable reference.

--- a/rules/gl027.go
+++ b/rules/gl027.go
@@ -1,0 +1,73 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl027 struct{}
+
+var GL027 = &gl027{}
+
+func (r *gl027) ID() string { return "GL027" }
+
+func (r *gl027) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkMaskedVariables(parser.FindKey(mapping, "variables"), file, "")...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkMaskedVariables(parser.FindKey(def, "variables"), file, "")...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range checkMaskedVariables(parser.FindKey(job, "variables"), file, name.Value) {
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func checkMaskedVariables(node *yaml.Node, file, job string) []finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		varName := node.Content[i].Value
+		val := node.Content[i+1]
+
+		// Only flag the long-form mapping — scalar form cannot carry masked: true.
+		if val.Kind != yaml.MappingNode {
+			continue
+		}
+		if !hasSecretSuffix(varName) {
+			continue
+		}
+
+		maskedNode := parser.FindKey(val, "masked")
+		if maskedNode != nil && maskedNode.Value == "true" {
+			continue
+		}
+
+		f := finding.Finding{
+			RuleID:   "GL027",
+			Severity: finding.Warn,
+			Job:      job,
+			Message: fmt.Sprintf(
+				"variable %q has a secret-like name but is missing \"masked: true\" — its value will appear in CI job logs",
+				varName,
+			),
+			File: file,
+			Line: node.Content[i].Line,
+			Col:  node.Content[i].Column,
+		}
+		findings = append(findings, f)
+	}
+	return findings
+}

--- a/rules/gl027_test.go
+++ b/rules/gl027_test.go
@@ -1,0 +1,130 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings027(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL027.Check(doc.Root, "test.yml")
+}
+
+func TestGL027_MissingMasked(t *testing.T) {
+	f := findings027(t, `
+variables:
+  DEPLOY_TOKEN:
+    value: "glpat-xxxx"
+    description: "deploy token"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL027_MaskedFalse(t *testing.T) {
+	f := findings027(t, `
+variables:
+  DEPLOY_TOKEN:
+    value: "glpat-xxxx"
+    masked: false
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for masked: false, got %d", len(f))
+	}
+}
+
+func TestGL027_MaskedTrue_NoFinding(t *testing.T) {
+	f := findings027(t, `
+variables:
+  DEPLOY_TOKEN:
+    value: "glpat-xxxx"
+    masked: true
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when masked: true, got %d", len(f))
+	}
+}
+
+func TestGL027_ScalarForm_NoFinding(t *testing.T) {
+	f := findings027(t, `
+variables:
+  DEPLOY_TOKEN: "glpat-xxxx"
+`)
+	if len(f) != 0 {
+		t.Errorf("scalar form cannot carry masked: true — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL027_NonSecretName_NoFinding(t *testing.T) {
+	f := findings027(t, `
+variables:
+  DEPLOY_ENV:
+    value: "production"
+`)
+	if len(f) != 0 {
+		t.Errorf("non-secret name should not be flagged, got %d", len(f))
+	}
+}
+
+func TestGL027_SecretSuffixes(t *testing.T) {
+	for _, name := range []string{
+		"MY_TOKEN", "MY_SECRET", "MY_PASSWORD", "MY_PASSWD", "MY_PASS",
+		"MY_PWD", "MY_KEY", "MY_CREDENTIAL", "MY_CERT", "MY_API_KEY",
+	} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			f := findings027(t, `
+variables:
+  `+name+`:
+    value: "abc123"
+`)
+			if len(f) != 1 {
+				t.Errorf("%s: expected 1 finding, got %d", name, len(f))
+			}
+		})
+	}
+}
+
+func TestGL027_JobLevel(t *testing.T) {
+	f := findings027(t, `
+deploy:
+  variables:
+    DB_PASSWORD:
+      value: "secret"
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for job-level variable, got %d", len(f))
+	}
+	if f[0].Job != "deploy" {
+		t.Errorf("expected job name 'deploy', got %q", f[0].Job)
+	}
+}
+
+func TestGL027_TopLevelMultiple(t *testing.T) {
+	f := findings027(t, `
+variables:
+  PLAIN_VAR: "hello"
+  API_TOKEN:
+    value: "secret"
+  DB_PASSWORD:
+    value: "pw"
+    masked: true
+  SSH_KEY:
+    value: "key"
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (API_TOKEN and SSH_KEY), got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -29,6 +29,7 @@ var owaspCategories = map[string][]string{
 	"GL024": {"CICD-SEC-7"},
 	"GL025": {"CICD-SEC-9"},
 	"GL026": {"CICD-SEC-3"},
+	"GL027": {"CICD-SEC-6"},
 }
 
 // OWASPCategories returns the OWASP CI/CD security categories for a rule ID.

--- a/testdata/fixtures/gl027-unmasked-secret-variable.yml
+++ b/testdata/fixtures/gl027-unmasked-secret-variable.yml
@@ -1,0 +1,5 @@
+variables:
+  DEPLOY_TOKEN:
+    value: "glpat-xxxxxxxxxxxxxxxxxxxx"
+    description: "GitLab deploy token"
+    # masked: true missing — value appears in CI logs


### PR DESCRIPTION
## What changed

New rule **GL027** flags variables defined in long-form syntax whose name has a secret-like suffix but lack `masked: true`. Without masking, GitLab echoes the value to the job log.

Detected suffixes: `_TOKEN`, `_SECRET`, `_PASSWORD`, `_PASSWD`, `_PASS`, `_PWD`, `_KEY`, `_CREDENTIAL`, `_CERT`, `_API_KEY`

Plain scalar form (`MY_TOKEN: "abc"`) is intentionally not flagged — it cannot carry `masked: true`.

Also extended `secretNameSuffixes` in GL018 with `_API_KEY` (was missing) so both rules share the same set.

## Example

```yaml
# flagged
variables:
  DEPLOY_TOKEN:
    value: "glpat-xxxx"
    description: "deploy token"   # masked: true absent

# not flagged
variables:
  DEPLOY_TOKEN:
    value: "glpat-xxxx"
    masked: true
```

Closes #100