### PR TITLE
feat: GL038 – hardcoded credential literal in script line

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,6 +18,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL014](rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 | [GL018](rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
 | [GL021](rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
+| [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |
 
 ---
 

--- a/docs/rules/GL038.md
+++ b/docs/rules/GL038.md
@@ -1,0 +1,46 @@
+# GL038 — Hardcoded credential literal in script line
+
+**Severity:** `error`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags script lines that pass a literal (non-variable) credential to a known CLI tool via a flag or environment variable:
+
+| Tool | Detected pattern |
+|------|-----------------|
+| sqlcmd | `-P <literal>` |
+| mysql / mysqldump / mysqlpump | `-p<literal>` or `--password=<literal>` |
+| psql | `PGPASSWORD=<literal>` |
+| mongosh / mongodump / mongorestore | `--password <literal>` |
+| sed | URL rewrite `s/user:[^@]*@/user:<literal>@/` |
+
+A value is considered hardcoded when it does not begin with `$` (i.e. is not a CI variable reference).
+
+## Trigger example
+
+```yaml
+restore-db:
+  script:
+    - sqlcmd -S localhost -U SA -P "ExampleP4ss!" -Q "RESTORE DATABASE [app] FROM DISK = '/backup/app.bak'"
+    - sed -i "s/sa:[^@]*@/sa:ExampleP4ss!@/" .env
+```
+
+## Safe alternative
+
+```yaml
+restore-db:
+  script:
+    - sqlcmd -S localhost -U SA -P "$MSSQL_SA_PASSWORD" -Q "RESTORE DATABASE [app] FROM DISK = '/backup/app.bak'"
+    - sed -i "s/sa:[^@]*@/sa:${MSSQL_SA_PASSWORD}@/" .env
+```
+
+Store the password as a masked, protected CI/CD variable in GitLab project or group settings.
+
+## References
+
+- [GitLab docs: Add a CI/CD variable](https://docs.gitlab.com/ee/ci/variables/#add-a-cicd-variable-to-a-project)
+- [GitLab docs: Mask a CI/CD variable](https://docs.gitlab.com/ee/ci/variables/#mask-a-cicd-variable)
+- GL006: hardcoded secret value in `variables:` block
+- GL035: git URL with embedded credentials in script
+- GL036: connection string with embedded credentials in `variables:` block

--- a/rules/all.go
+++ b/rules/all.go
@@ -31,5 +31,6 @@ func All() []rule.Rule {
 		GL025,
 		GL026,
 		GL027,
+		GL038,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -29,6 +29,7 @@ var cweIDs = map[string]string{
 	"GL025": "CWE-441",
 	"GL026": "CWE-829",
 	"GL027": "CWE-532",
+	"GL038": "CWE-798",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl038.go
+++ b/rules/gl038.go
@@ -1,0 +1,112 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl038 struct{}
+
+var GL038 = &gl038{}
+
+func (r *gl038) ID() string { return "GL038" }
+
+type credCheck struct {
+	tool string
+	re   *regexp.Regexp
+	msg  string
+}
+
+var credChecks = []credCheck{
+	{
+		tool: "sqlcmd",
+		re:   regexp.MustCompile(`\bsqlcmd\b.*-P\s+["']?[^$"'\s]`),
+		msg:  "script passes hardcoded credential to sqlcmd via -P flag — use a masked CI variable instead",
+	},
+	{
+		tool: "mysql",
+		re:   regexp.MustCompile(`\bmysql(?:dump|pump)?\b.*\s-p[A-Za-z0-9!@#%^&*()\[\]{}<>]`),
+		msg:  "script passes hardcoded credential to mysql via -p flag — use a masked CI variable instead",
+	},
+	{
+		tool: "mysql",
+		re:   regexp.MustCompile(`\bmysql(?:dump|pump)?\b.*--password=[^$'"\s]`),
+		msg:  "script passes hardcoded credential to mysql via --password flag — use a masked CI variable instead",
+	},
+	{
+		tool: "psql/PGPASSWORD",
+		re:   regexp.MustCompile(`PGPASSWORD=[^$'"\s]`),
+		msg:  "script passes hardcoded credential via PGPASSWORD — use a masked CI variable instead",
+	},
+	{
+		tool: "mongosh",
+		re:   regexp.MustCompile(`\bmongo(?:sh|dump|restore|import|export)?\b.*--password\s+[^$\s"']`),
+		msg:  "script passes hardcoded credential via --password flag — use a masked CI variable instead",
+	},
+	{
+		tool: "sed",
+		re:   regexp.MustCompile(`\bsed\b.+s/[^/]+/[^/:]*:[^$][^@]*@/`),
+		msg:  "script rewrites URL with hardcoded password literal via sed — use a masked CI variable instead",
+	},
+}
+
+func (r *gl038) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkHardcodedCredScript(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkHardcodedCredScript(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				for _, f := range checkHardcodedCredScript(node, file, name.Value) {
+					findings = append(findings, f)
+				}
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkHardcodedCredScript(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		for _, check := range credChecks {
+			if check.re.MatchString(item.Value) {
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL038",
+					Severity: finding.Error,
+					Job:      job,
+					Message:  fmt.Sprintf("[%s] %s", check.tool, check.msg),
+					File:     file,
+					Line:     item.Line,
+					Col:      item.Column,
+				})
+				break
+			}
+		}
+	}
+	return findings
+}

--- a/rules/gl038_test.go
+++ b/rules/gl038_test.go
@@ -1,0 +1,110 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL038(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "sqlcmd -P with quoted literal",
+			yaml: `job:
+  script:
+    - sqlcmd -S localhost -U SA -P "ExampleP4ss!" -Q "SELECT 1"`,
+			wantHits: 1,
+		},
+		{
+			name: "sqlcmd -P with variable — safe",
+			yaml: `job:
+  script:
+    - sqlcmd -S localhost -U SA -P "$MSSQL_PASSWORD" -Q "SELECT 1"`,
+			wantHits: 0,
+		},
+		{
+			name: "mysql -p with literal",
+			yaml: `job:
+  script:
+    - mysql -u root -pExampleP4ss! -e "SELECT 1"`,
+			wantHits: 1,
+		},
+		{
+			name: "mysql --password= with literal",
+			yaml: `job:
+  script:
+    - mysqldump --password=ExampleP4ss! mydb > dump.sql`,
+			wantHits: 1,
+		},
+		{
+			name: "mysql --password= with variable — safe",
+			yaml: `job:
+  script:
+    - mysql --password=$DB_PASSWORD -e "SELECT 1"`,
+			wantHits: 0,
+		},
+		{
+			name: "PGPASSWORD with literal",
+			yaml: `job:
+  script:
+    - PGPASSWORD=ExampleP4ss! psql -U admin -c "SELECT 1"`,
+			wantHits: 1,
+		},
+		{
+			name: "PGPASSWORD with variable — safe",
+			yaml: `job:
+  script:
+    - PGPASSWORD=$DB_PASSWORD psql -U admin -c "SELECT 1"`,
+			wantHits: 0,
+		},
+		{
+			name: "mongosh --password with literal",
+			yaml: `job:
+  script:
+    - mongosh --username admin --password ExampleP4ss! mydb`,
+			wantHits: 1,
+		},
+		{
+			name: "sed URL rewrite with hardcoded password",
+			yaml: `job:
+  script:
+    - sed -i "s/sa:[^@]*@/sa:ExampleP4ss!@/" .env`,
+			wantHits: 1,
+		},
+		{
+			name: "sed URL rewrite with variable — safe",
+			yaml: `job:
+  script:
+    - sed -i "s/sa:[^@]*@/sa:${DB_PASS}@/" .env`,
+			wantHits: 0,
+		},
+		{
+			name: "multiple violations in one job",
+			yaml: `job:
+  script:
+    - sqlcmd -P "ExampleP4ss!" -Q "SELECT 1"
+    - mysql -pExampleP4ss!`,
+			wantHits: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL038.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -30,6 +30,7 @@ var owaspCategories = map[string][]string{
 	"GL025": {"CICD-SEC-9"},
 	"GL026": {"CICD-SEC-3"},
 	"GL027": {"CICD-SEC-6"},
+	"GL038": {"CICD-SEC-6"},
 }
 
 // OWASPCategories returns the OWASP CI/CD security categories for a rule ID.

--- a/testdata/fixtures/gl038-hardcoded-credential-in-script.yml
+++ b/testdata/fixtures/gl038-hardcoded-credential-in-script.yml
@@ -1,0 +1,4 @@
+restore-db:
+  script:
+    - sqlcmd -S localhost -U SA -P "ExampleP4ss!" -Q "RESTORE DATABASE [app] FROM DISK = '/backup/app.bak'"
+    - sed -i "s/sa:[^@]*@/sa:ExampleP4ss!@/" .env


### PR DESCRIPTION
## Summary

- Adds **GL038** (`error`): detects hardcoded credential literals passed to CLI tools in `script:` blocks
- Detected patterns: `sqlcmd -P <literal>`, `mysql -p<literal>` / `--password=<literal>`, `PGPASSWORD=<literal>`, `mongosh --password <literal>`, `sed` URL rewrite with embedded password
- A value is considered hardcoded when it does not begin with `$`
- Checks `script:`, `before_script:`, `after_script:` in jobs and top-level `default:`
- OWASP: CICD-SEC-6, CWE-798

Closes #113

## Test plan

- [ ] `go test ./rules/ -run TestGL038` — all 11 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL038` — consistency check passes
- [ ] `go test ./...` — full suite green