### PR TITLE
feat: GL033 – CI_DEBUG_TRACE enabled in committed pipeline YAML

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,6 +18,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL014](rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 | [GL018](rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
 | [GL021](rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
+| [GL033](rules/GL033.md) | `error` | `CI_DEBUG_TRACE: "true"` committed — shell tracing dumps all variable values including secrets to job logs |
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |
 
 ---

--- a/docs/rules/GL033.md
+++ b/docs/rules/GL033.md
@@ -1,0 +1,35 @@
+# GL033 — `CI_DEBUG_TRACE` enabled in committed pipeline YAML
+
+**Severity:** `error`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags any `variables:` block — top-level or job-level — where `CI_DEBUG_TRACE` is set to `"true"`. When enabled, GitLab activates `set -x` shell tracing for the entire job, which prints every command with fully-expanded arguments to the job log, including the values of all CI variables — protected and masked alike. Committing this setting creates a persistent secret-dumping configuration accessible to anyone who can retry the pipeline.
+
+## Trigger example
+
+```yaml
+variables:
+  CI_DEBUG_TRACE: "true"   # dumps all CI variable values to the job log
+```
+
+Or at job level:
+
+```yaml
+deploy:
+  variables:
+    CI_DEBUG_TRACE: "true"
+  script:
+    - ./deploy.sh
+```
+
+## Safe alternative
+
+Remove `CI_DEBUG_TRACE` from the committed YAML. Use the GitLab UI **Run pipeline** dialog to pass it as a transient variable for a single run — it will not persist in the repository.
+
+## References
+
+- [GitLab docs: Debug CI/CD pipelines with CI_DEBUG_TRACE](https://docs.gitlab.com/ee/ci/variables/#debug-logging)
+- GL021: secret variable value printed to job log via `echo`/`printf`
+- GL027: secret-like variable missing `masked: true`

--- a/rules/all.go
+++ b/rules/all.go
@@ -31,6 +31,7 @@ func All() []rule.Rule {
 		GL025,
 		GL026,
 		GL027,
+		GL033,
 		GL038,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -29,6 +29,7 @@ var cweIDs = map[string]string{
 	"GL025": "CWE-441",
 	"GL026": "CWE-829",
 	"GL027": "CWE-532",
+	"GL033": "CWE-532",
 	"GL038": "CWE-798",
 }
 

--- a/rules/gl033.go
+++ b/rules/gl033.go
@@ -1,0 +1,67 @@
+package rules
+
+import (
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl033 struct{}
+
+var GL033 = &gl033{}
+
+func (r *gl033) ID() string { return "GL033" }
+
+func (r *gl033) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	if f := checkDebugTrace(parser.FindKey(mapping, "variables"), file, ""); f != nil {
+		findings = append(findings, *f)
+	}
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		if f := checkDebugTrace(parser.FindKey(def, "variables"), file, ""); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if f := checkDebugTrace(parser.FindKey(job, "variables"), file, name.Value); f != nil {
+			findings = append(findings, *f)
+		}
+	})
+
+	return findings
+}
+
+func checkDebugTrace(node *yaml.Node, file, job string) *finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		val := node.Content[i+1]
+		if key.Value != "CI_DEBUG_TRACE" {
+			continue
+		}
+		scalar := resolveScalar(val)
+		if scalar == nil {
+			continue
+		}
+		if scalar.Value != "true" {
+			continue
+		}
+		f := finding.Finding{
+			RuleID:   "GL033",
+			Severity: finding.Error,
+			Job:      job,
+			Message:  "CI_DEBUG_TRACE: \"true\" is committed — shell tracing dumps all variable values including secrets to the job log; remove it and use the GitLab UI run-pipeline dialog for transient debugging",
+			File:     file,
+			Line:     key.Line,
+			Col:      key.Column,
+		}
+		return &f
+	}
+	return nil
+}

--- a/rules/gl033_test.go
+++ b/rules/gl033_test.go
@@ -1,0 +1,70 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL033(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "top-level CI_DEBUG_TRACE true",
+			yaml: `variables:
+  CI_DEBUG_TRACE: "true"`,
+			wantHits: 1,
+		},
+		{
+			name: "job-level CI_DEBUG_TRACE true",
+			yaml: `deploy:
+  variables:
+    CI_DEBUG_TRACE: "true"
+  script:
+    - ./deploy.sh`,
+			wantHits: 1,
+		},
+		{
+			name: "CI_DEBUG_TRACE false — safe",
+			yaml: `variables:
+  CI_DEBUG_TRACE: "false"`,
+			wantHits: 0,
+		},
+		{
+			name: "no CI_DEBUG_TRACE — safe",
+			yaml: `variables:
+  SOME_VAR: "value"`,
+			wantHits: 0,
+		},
+		{
+			name: "CI_DEBUG_TRACE in top-level and job — two findings",
+			yaml: `variables:
+  CI_DEBUG_TRACE: "true"
+deploy:
+  variables:
+    CI_DEBUG_TRACE: "true"
+  script:
+    - ./deploy.sh`,
+			wantHits: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL033.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -30,6 +30,7 @@ var owaspCategories = map[string][]string{
 	"GL025": {"CICD-SEC-9"},
 	"GL026": {"CICD-SEC-3"},
 	"GL027": {"CICD-SEC-6"},
+	"GL033": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
 }
 

--- a/testdata/fixtures/gl033-ci-debug-trace-enabled.yml
+++ b/testdata/fixtures/gl033-ci-debug-trace-enabled.yml
@@ -1,0 +1,2 @@
+variables:
+  CI_DEBUG_TRACE: "true"


### PR DESCRIPTION
## Summary

- Adds **GL033** (`error`): flags `CI_DEBUG_TRACE: "true"` in any `variables:` block (top-level, `default:`, or job-level)
- When committed, enables `set -x` shell tracing for the entire job — dumps all variable values including protected/masked secrets to job logs
- Checks all three variable scopes; reports job name in findings
- OWASP: CICD-SEC-6, CWE-532

Closes #106

## Test plan

- [ ] `go test ./rules/ -run TestGL033` — all 5 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL033` — consistency check passes
- [ ] `go test ./...` — full suite green