### PR TITLE
feat: GL031 – DOCKER_TLS_CERTDIR empty string disables Docker daemon TLS

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -75,3 +75,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL007](rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
 | [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL024](rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
+| [GL031](rules/GL031.md) | `error` | `DOCKER_TLS_CERTDIR: ""` disables Docker daemon TLS — exposes port 2375 unauthenticated on the runner network |

--- a/docs/rules/GL031.md
+++ b/docs/rules/GL031.md
@@ -1,0 +1,39 @@
+# GL031 — `DOCKER_TLS_CERTDIR` set to empty string disables Docker daemon TLS
+
+**Severity:** `error`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)
+
+## What glsec checks
+
+glsec flags any `variables:` block — top-level or job-level — where `DOCKER_TLS_CERTDIR` is set to an empty string. This disables TLS between the Docker client and the `docker:dind` service, which then listens on unencrypted TCP port 2375. Any process on the same network segment — including other jobs on a shared runner — can issue arbitrary commands to the Docker daemon. GitLab's own documentation notes: *"This is insecure and gives root access on the machine to everyone who has access to your network."*
+
+This pattern originates from the Testcontainers GitLab CI documentation and has been copied into many projects as a result.
+
+## Trigger example
+
+```yaml
+variables:
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_TLS_CERTDIR: ""   # disables TLS — Docker daemon is unauthenticated on the runner network
+
+services:
+  - docker:dind
+```
+
+## Safe alternative
+
+```yaml
+variables:
+  DOCKER_HOST: tcp://docker:2376
+  DOCKER_TLS_CERTDIR: "/certs"
+
+services:
+  - name: docker:dind
+    variables:
+      DOCKER_TLS_CERTDIR: "/certs"
+```
+
+## References
+
+- [GitLab docs: Use Docker to build Docker images — TLS](https://docs.gitlab.com/ee/ci/docker/using_docker_build/#docker-in-docker-with-tls-enabled-in-the-docker-executor)
+- [Testcontainers GitLab CI guide](https://java.testcontainers.org/supported_docker_environment/continuous_integration/gitlab_ci/) (source of widespread propagation)

--- a/rules/all.go
+++ b/rules/all.go
@@ -31,6 +31,7 @@ func All() []rule.Rule {
 		GL025,
 		GL026,
 		GL027,
+		GL031,
 		GL033,
 		GL038,
 	}

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -29,6 +29,7 @@ var cweIDs = map[string]string{
 	"GL025": "CWE-441",
 	"GL026": "CWE-829",
 	"GL027": "CWE-532",
+	"GL031": "CWE-319",
 	"GL033": "CWE-532",
 	"GL038": "CWE-798",
 }

--- a/rules/gl031.go
+++ b/rules/gl031.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl031 struct{}
+
+var GL031 = &gl031{}
+
+func (r *gl031) ID() string { return "GL031" }
+
+func (r *gl031) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	if f := checkDockerTLS(parser.FindKey(mapping, "variables"), file, ""); f != nil {
+		findings = append(findings, *f)
+	}
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		if f := checkDockerTLS(parser.FindKey(def, "variables"), file, ""); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if f := checkDockerTLS(parser.FindKey(job, "variables"), file, name.Value); f != nil {
+			findings = append(findings, *f)
+		}
+	})
+
+	return findings
+}
+
+func checkDockerTLS(node *yaml.Node, file, job string) *finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		val := node.Content[i+1]
+		if key.Value != "DOCKER_TLS_CERTDIR" {
+			continue
+		}
+		scalar := resolveScalar(val)
+		if scalar == nil || scalar.Value != "" {
+			continue
+		}
+		f := finding.Finding{
+			RuleID:   "GL031",
+			Severity: finding.Error,
+			Job:      job,
+			Message:  "DOCKER_TLS_CERTDIR set to empty string — disables TLS on the Docker daemon (port 2375), exposing it to any process on the runner network; set it to \"/certs\" and use port 2376",
+			File:     file,
+			Line:     key.Line,
+			Col:      key.Column,
+		}
+		return &f
+	}
+	return nil
+}

--- a/rules/gl031_test.go
+++ b/rules/gl031_test.go
@@ -1,0 +1,73 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL031(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "top-level DOCKER_TLS_CERTDIR empty string",
+			yaml: `variables:
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_TLS_CERTDIR: ""`,
+			wantHits: 1,
+		},
+		{
+			name: "job-level DOCKER_TLS_CERTDIR empty string",
+			yaml: `build:
+  services:
+    - docker:dind
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - docker build .`,
+			wantHits: 1,
+		},
+		{
+			name: "DOCKER_TLS_CERTDIR set to /certs — safe",
+			yaml: `variables:
+  DOCKER_TLS_CERTDIR: "/certs"`,
+			wantHits: 0,
+		},
+		{
+			name: "no DOCKER_TLS_CERTDIR — safe",
+			yaml: `variables:
+  SOME_VAR: "value"`,
+			wantHits: 0,
+		},
+		{
+			name: "top-level and job-level both empty — two findings",
+			yaml: `variables:
+  DOCKER_TLS_CERTDIR: ""
+build:
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - docker build .`,
+			wantHits: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL031.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -30,6 +30,7 @@ var owaspCategories = map[string][]string{
 	"GL025": {"CICD-SEC-9"},
 	"GL026": {"CICD-SEC-3"},
 	"GL027": {"CICD-SEC-6"},
+	"GL031": {"CICD-SEC-7"},
 	"GL033": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
 }

--- a/testdata/fixtures/gl031-docker-tls-certdir-empty.yml
+++ b/testdata/fixtures/gl031-docker-tls-certdir-empty.yml
@@ -1,0 +1,10 @@
+variables:
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_TLS_CERTDIR: ""
+
+services:
+  - docker:dind
+
+build:
+  script:
+    - docker build .


### PR DESCRIPTION
## Summary

- Adds **GL031** (`error`): flags `DOCKER_TLS_CERTDIR: ""` in any `variables:` block (top-level, `default:`, or job-level)
- Empty string disables TLS between Docker client and `docker:dind`, exposing the daemon unauthenticated on TCP port 2375
- Pattern originates from Testcontainers GitLab CI docs and is widely copy-pasted
- OWASP: CICD-SEC-7, CWE-319

Closes #104

## Test plan

- [ ] `go test ./rules/ -run TestGL031` — all 5 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL031` — consistency check passes
- [ ] `go test ./...` — full suite green