### PR TITLE
feat: GL028 – artifacts:untracked:true without path restriction

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -75,4 +75,5 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL007](rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
 | [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL024](rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
+| [GL028](rules/GL028.md) | `warn`  | `artifacts: untracked: true` without `paths:` or `exclude:` may archive `.env`, keys, and other sensitive files |
 | [GL031](rules/GL031.md) | `error` | `DOCKER_TLS_CERTDIR: ""` disables Docker daemon TLS — exposes port 2375 unauthenticated on the runner network |

--- a/docs/rules/GL028.md
+++ b/docs/rules/GL028.md
@@ -1,0 +1,53 @@
+# GL028 — `artifacts: untracked: true` without path restriction
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)
+
+## What glsec checks
+
+glsec flags jobs that set `artifacts: untracked: true` without also setting `artifacts: paths:` or `artifacts: exclude:`. Without a restriction, GitLab archives every file that git does not track — including `.env` files, generated private keys, temporary credential files, `.git/config` with embedded tokens, and build outputs containing secrets. These artifacts are stored by GitLab and downloadable by anyone with project access.
+
+The finding is suppressed when either `paths:` (restricts what is uploaded) or `exclude:` (explicitly filters sensitive patterns) is present alongside `untracked: true`.
+
+Complements GL005, which flags sensitive file patterns already present in `artifacts: paths:`.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - make build
+  artifacts:
+    untracked: true   # archives everything git doesn't track, including .env, *.key, etc.
+```
+
+## Safe alternatives
+
+**Restrict to explicit paths (preferred):**
+
+```yaml
+build:
+  artifacts:
+    paths:
+      - dist/
+      - build/
+    expire_in: 1 week
+```
+
+**If `untracked: true` is required, add an exclude list:**
+
+```yaml
+build:
+  artifacts:
+    untracked: true
+    exclude:
+      - "**/.env"
+      - "**/*.key"
+      - "**/*.pem"
+      - "**/credentials*"
+```
+
+## References
+
+- [GitLab docs: `artifacts:untracked`](https://docs.gitlab.com/ee/ci/yaml/#artifactsuntracked)
+- GL005: sensitive file patterns already listed in `artifacts: paths:`

--- a/rules/all.go
+++ b/rules/all.go
@@ -31,6 +31,7 @@ func All() []rule.Rule {
 		GL025,
 		GL026,
 		GL027,
+		GL028,
 		GL031,
 		GL033,
 		GL038,

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -29,6 +29,7 @@ var cweIDs = map[string]string{
 	"GL025": "CWE-441",
 	"GL026": "CWE-829",
 	"GL027": "CWE-532",
+	"GL028": "CWE-538",
 	"GL031": "CWE-319",
 	"GL033": "CWE-532",
 	"GL038": "CWE-798",

--- a/rules/gl028.go
+++ b/rules/gl028.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl028 struct{}
+
+var GL028 = &gl028{}
+
+func (r *gl028) ID() string { return "GL028" }
+
+func (r *gl028) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		artifactsNode := parser.FindKey(job, "artifacts")
+		if artifactsNode == nil || artifactsNode.Kind != yaml.MappingNode {
+			return
+		}
+
+		untrackedNode := parser.FindKey(artifactsNode, "untracked")
+		if untrackedNode == nil || untrackedNode.Value != "true" {
+			return
+		}
+
+		// Safe if paths: is set (restricts what is uploaded).
+		if pathsNode := parser.FindKey(artifactsNode, "paths"); pathsNode != nil {
+			return
+		}
+		// Safe if exclude: is set (user has explicitly filtered sensitive patterns).
+		if excludeNode := parser.FindKey(artifactsNode, "exclude"); excludeNode != nil {
+			return
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL028",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message:  "artifacts:untracked:true without paths: or exclude: — archives all untracked files including .env, *.key, and other sensitive files; restrict with paths: or add an exclude: list",
+			File:     file,
+			Line:     untrackedNode.Line,
+			Col:      untrackedNode.Column,
+		})
+	})
+
+	return findings
+}

--- a/rules/gl028_test.go
+++ b/rules/gl028_test.go
@@ -1,0 +1,96 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL028(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "untracked true without restriction",
+			yaml: `build:
+  script:
+    - make build
+  artifacts:
+    untracked: true`,
+			wantHits: 1,
+		},
+		{
+			name: "untracked true with paths — safe",
+			yaml: `build:
+  script:
+    - make build
+  artifacts:
+    untracked: true
+    paths:
+      - dist/`,
+			wantHits: 0,
+		},
+		{
+			name: "untracked true with exclude — safe",
+			yaml: `build:
+  script:
+    - make build
+  artifacts:
+    untracked: true
+    exclude:
+      - "**/.env"
+      - "**/*.key"`,
+			wantHits: 0,
+		},
+		{
+			name: "untracked false — safe",
+			yaml: `build:
+  script:
+    - make build
+  artifacts:
+    untracked: false`,
+			wantHits: 0,
+		},
+		{
+			name: "no artifacts block — safe",
+			yaml: `build:
+  script:
+    - make build`,
+			wantHits: 0,
+		},
+		{
+			name: "multiple jobs — only one flagged",
+			yaml: `build:
+  script:
+    - make build
+  artifacts:
+    untracked: true
+test:
+  script:
+    - make test
+  artifacts:
+    untracked: true
+    paths:
+      - reports/`,
+			wantHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL028.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -30,6 +30,7 @@ var owaspCategories = map[string][]string{
 	"GL025": {"CICD-SEC-9"},
 	"GL026": {"CICD-SEC-3"},
 	"GL027": {"CICD-SEC-6"},
+	"GL028": {"CICD-SEC-7"},
 	"GL031": {"CICD-SEC-7"},
 	"GL033": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},

--- a/testdata/fixtures/gl028-artifacts-untracked-no-restriction.yml
+++ b/testdata/fixtures/gl028-artifacts-untracked-no-restriction.yml
@@ -1,0 +1,5 @@
+build:
+  script:
+    - make build
+  artifacts:
+    untracked: true


### PR DESCRIPTION
## Summary

- Adds **GL028** (`warn`): flags jobs with `artifacts: untracked: true` that have neither `paths:` nor `exclude:`
- Without a restriction, GitLab archives every untracked file — including `.env`, private keys, credential files, and build outputs containing secrets
- Suppressed when `paths:` or `exclude:` is present (user has already constrained the upload)
- OWASP: CICD-SEC-7, CWE-538

Closes #101

## Test plan

- [ ] `go test ./rules/ -run TestGL028` — all 6 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL028` — consistency check passes
- [ ] `go test ./...` — full suite green