### PR TITLE
feat: GL029 – docker login -p flag exposes password in process table

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -19,6 +19,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL018](rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
 | [GL021](rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
 | [GL033](rules/GL033.md) | `error` | `CI_DEBUG_TRACE: "true"` committed — shell tracing dumps all variable values including secrets to job logs |
+| [GL029](rules/GL029.md) | `warn`  | `docker login -p` exposes password in process table — use `--password-stdin` instead |
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |
 
 ---

--- a/docs/rules/GL029.md
+++ b/docs/rules/GL029.md
@@ -1,0 +1,32 @@
+# GL029 — `docker login` with `-p` flag instead of `--password-stdin`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags script lines that run `docker login` with the `-p` (short password) flag. Passing the password as a command-line argument makes it visible in the process table (`ps aux`) for the lifetime of the command, readable by any other process on the same runner host. Shell history and CI debug traces may also capture it.
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+```
+
+## Safe alternative
+
+```yaml
+deploy:
+  script:
+    - echo "$CI_REGISTRY_PASSWORD" | docker login --password-stdin -u $CI_REGISTRY_USER $CI_REGISTRY
+```
+
+`--password-stdin` reads the password from stdin, keeping it out of the process table and shell history.
+
+## References
+
+- [Docker docs: `docker login --password-stdin`](https://docs.docker.com/reference/cli/docker/login/#password-stdin)
+- GL006: hardcoded secret in `variables:` block
+- GL027: secret-like variable missing `masked: true`

--- a/rules/all.go
+++ b/rules/all.go
@@ -32,6 +32,7 @@ func All() []rule.Rule {
 		GL026,
 		GL027,
 		GL028,
+		GL029,
 		GL031,
 		GL033,
 		GL038,

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -30,6 +30,7 @@ var cweIDs = map[string]string{
 	"GL026": "CWE-829",
 	"GL027": "CWE-532",
 	"GL028": "CWE-538",
+	"GL029": "CWE-214",
 	"GL031": "CWE-319",
 	"GL033": "CWE-532",
 	"GL038": "CWE-798",
@@ -38,6 +39,7 @@ var cweIDs = map[string]string{
 // cweNames maps CWE IDs to their short names.
 var cweNames = map[string]string{
 	"CWE-78":   "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+	"CWE-214":  "Invocation of Process Using Visible Sensitive Information",
 	"CWE-284":  "Improper Access Control",
 	"CWE-319":  "Cleartext Transmission of Sensitive Information",
 	"CWE-362":  "Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')",

--- a/rules/gl027.go
+++ b/rules/gl027.go
@@ -25,9 +25,7 @@ func (r *gl027) Check(doc *yaml.Node, file string) []finding.Finding {
 	}
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, f := range checkMaskedVariables(parser.FindKey(job, "variables"), file, name.Value) {
-			findings = append(findings, f)
-		}
+		findings = append(findings, checkMaskedVariables(parser.FindKey(job, "variables"), file, name.Value)...)
 	})
 
 	return findings

--- a/rules/gl029.go
+++ b/rules/gl029.go
@@ -37,9 +37,7 @@ func (r *gl029) Check(doc *yaml.Node, file string) []finding.Finding {
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range checkDockerLoginPassword(node, file, name.Value) {
-					findings = append(findings, f)
-				}
+				findings = append(findings, checkDockerLoginPassword(node, file, name.Value)...)
 			}
 		}
 	})

--- a/rules/gl029.go
+++ b/rules/gl029.go
@@ -1,0 +1,72 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl029 struct{}
+
+var GL029 = &gl029{}
+
+func (r *gl029) ID() string { return "GL029" }
+
+// dockerLoginPasswordRe matches "docker login" with the short -p flag (not --password-stdin).
+var dockerLoginPasswordRe = regexp.MustCompile(`\bdocker\s+login\b.*\s-p\s`)
+
+func (r *gl029) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkDockerLoginPassword(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkDockerLoginPassword(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				for _, f := range checkDockerLoginPassword(node, file, name.Value) {
+					findings = append(findings, f)
+				}
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkDockerLoginPassword(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if dockerLoginPasswordRe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL029",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "docker login uses -p flag — password is visible in the process table; use --password-stdin instead: echo \"$PASSWORD\" | docker login --password-stdin",
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl029_test.go
+++ b/rules/gl029_test.go
@@ -1,0 +1,66 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL029(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "docker login with -p flag",
+			yaml: `deploy:
+  script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY`,
+			wantHits: 1,
+		},
+		{
+			name: "docker login with --password-stdin — safe",
+			yaml: `deploy:
+  script:
+    - echo "$CI_REGISTRY_PASSWORD" | docker login --password-stdin -u $CI_REGISTRY_USER $CI_REGISTRY`,
+			wantHits: 0,
+		},
+		{
+			name: "docker login without password flag — safe",
+			yaml: `deploy:
+  script:
+    - docker login $CI_REGISTRY`,
+			wantHits: 0,
+		},
+		{
+			name: "unrelated docker command — safe",
+			yaml: `build:
+  script:
+    - docker build -t myimage .`,
+			wantHits: 0,
+		},
+		{
+			name: "-p in before_script",
+			yaml: `before_script:
+  - docker login -u user -p pass registry.example.com`,
+			wantHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL029.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/gl038.go
+++ b/rules/gl038.go
@@ -74,9 +74,7 @@ func (r *gl038) Check(doc *yaml.Node, file string) []finding.Finding {
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range checkHardcodedCredScript(node, file, name.Value) {
-					findings = append(findings, f)
-				}
+				findings = append(findings, checkHardcodedCredScript(node, file, name.Value)...)
 			}
 		}
 	})

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -31,6 +31,7 @@ var owaspCategories = map[string][]string{
 	"GL026": {"CICD-SEC-3"},
 	"GL027": {"CICD-SEC-6"},
 	"GL028": {"CICD-SEC-7"},
+	"GL029": {"CICD-SEC-6"},
 	"GL031": {"CICD-SEC-7"},
 	"GL033": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},

--- a/testdata/fixtures/gl029-docker-login-password-flag.yml
+++ b/testdata/fixtures/gl029-docker-login-password-flag.yml
@@ -1,0 +1,4 @@
+deploy:
+  script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker push $CI_REGISTRY_IMAGE


### PR DESCRIPTION
## Summary

- Adds **GL029** (`warn`): flags `docker login -p <value>` in any script block
- Password passed as CLI argument is visible in `ps aux` for the lifetime of the process and may appear in shell history or CI debug traces
- Fix: pipe via `--password-stdin` to keep the password off the command line
- OWASP: CICD-SEC-6, CWE-214

Closes #102

## Test plan

- [ ] `go test ./rules/ -run TestGL029` — all 5 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL029` — consistency check passes
- [ ] `go test ./...` — full suite green