### PR TITLE
feat: GL030 – ssh-keyscan executed dynamically (MITM risk)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -77,4 +77,5 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL024](rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
 | [GL028](rules/GL028.md) | `warn`  | `artifacts: untracked: true` without `paths:` or `exclude:` may archive `.env`, keys, and other sensitive files |
+| [GL030](rules/GL030.md) | `warn`  | `ssh-keyscan` at runtime blindly trusts the remote host key — MITM risk on shared runner networks |
 | [GL031](rules/GL031.md) | `error` | `DOCKER_TLS_CERTDIR: ""` disables Docker daemon TLS — exposes port 2375 unauthenticated on the runner network |

--- a/docs/rules/GL030.md
+++ b/docs/rules/GL030.md
@@ -1,0 +1,36 @@
+# GL030 — `ssh-keyscan` executed dynamically in script (MITM risk)
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)
+
+## What glsec checks
+
+glsec flags any script line that invokes `ssh-keyscan`. Running `ssh-keyscan` at pipeline runtime blindly trusts whatever public key the remote host presents at that moment. If the network path is compromised — shared runner network, DNS poisoning, or a rogue router — the runner will accept a fraudulent host key and the attacker can intercept the SSH session, including any secrets transmitted over it.
+
+This pattern dominates GitLab CI SSH-deploy tutorials and is present in many real-world projects, despite GitLab's own SSH documentation explicitly warning against it.
+
+## Trigger example
+
+```yaml
+before_script:
+  - mkdir -p ~/.ssh
+  - ssh-keyscan -H 'deploy.example.com' >> ~/.ssh/known_hosts
+```
+
+## Safe alternative
+
+Store a pre-verified known-hosts entry in a protected, masked CI variable and write it directly — no network call needed:
+
+```yaml
+before_script:
+  - mkdir -p ~/.ssh
+  - echo "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+  - chmod 644 ~/.ssh/known_hosts
+```
+
+To obtain the entry: run `ssh-keyscan <host>` once from a trusted machine, verify the fingerprint out-of-band, then store the output as a CI variable named `SSH_KNOWN_HOSTS`.
+
+## References
+
+- [GitLab docs: Using SSH keys with GitLab CI/CD](https://docs.gitlab.com/ee/ci/ssh_keys/)
+- GL032: SSH private key written to file via `echo`

--- a/rules/all.go
+++ b/rules/all.go
@@ -33,6 +33,7 @@ func All() []rule.Rule {
 		GL027,
 		GL028,
 		GL029,
+		GL030,
 		GL031,
 		GL033,
 		GL038,

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -31,6 +31,7 @@ var cweIDs = map[string]string{
 	"GL027": "CWE-532",
 	"GL028": "CWE-538",
 	"GL029": "CWE-214",
+	"GL030": "CWE-295",
 	"GL031": "CWE-319",
 	"GL033": "CWE-532",
 	"GL038": "CWE-798",
@@ -40,6 +41,7 @@ var cweIDs = map[string]string{
 var cweNames = map[string]string{
 	"CWE-78":   "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
 	"CWE-214":  "Invocation of Process Using Visible Sensitive Information",
+	"CWE-295":  "Improper Certificate Validation",
 	"CWE-284":  "Improper Access Control",
 	"CWE-319":  "Cleartext Transmission of Sensitive Information",
 	"CWE-362":  "Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')",

--- a/rules/gl030.go
+++ b/rules/gl030.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl030 struct{}
+
+var GL030 = &gl030{}
+
+func (r *gl030) ID() string { return "GL030" }
+
+var sshKeyscanRe = regexp.MustCompile(`\bssh-keyscan\b`)
+
+func (r *gl030) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkSSHKeyscan(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkSSHKeyscan(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkSSHKeyscan(node, file, name.Value)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkSSHKeyscan(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if sshKeyscanRe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL030",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "ssh-keyscan trusts whatever key the remote host presents — store a pre-verified known-hosts entry in a protected CI variable instead: echo \"$SSH_KNOWN_HOSTS\" >> ~/.ssh/known_hosts",
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl030_test.go
+++ b/rules/gl030_test.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL030(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "ssh-keyscan in before_script",
+			yaml: `before_script:
+  - mkdir -p ~/.ssh
+  - ssh-keyscan -H 'deploy.example.com' >> ~/.ssh/known_hosts`,
+			wantHits: 1,
+		},
+		{
+			name: "ssh-keyscan in job script",
+			yaml: `deploy:
+  script:
+    - ssh-keyscan example.com >> ~/.ssh/known_hosts
+    - ssh user@example.com "deploy.sh"`,
+			wantHits: 1,
+		},
+		{
+			name: "known_hosts from variable — safe",
+			yaml: `before_script:
+  - mkdir -p ~/.ssh
+  - echo "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+  - chmod 644 ~/.ssh/known_hosts`,
+			wantHits: 0,
+		},
+		{
+			name: "no SSH commands — safe",
+			yaml: `build:
+  script:
+    - make build`,
+			wantHits: 0,
+		},
+		{
+			name: "ssh-keyscan in top-level and job — two findings",
+			yaml: `before_script:
+  - ssh-keyscan host1.example.com >> ~/.ssh/known_hosts
+deploy:
+  script:
+    - ssh-keyscan host2.example.com >> ~/.ssh/known_hosts`,
+			wantHits: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL030.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -32,6 +32,7 @@ var owaspCategories = map[string][]string{
 	"GL027": {"CICD-SEC-6"},
 	"GL028": {"CICD-SEC-7"},
 	"GL029": {"CICD-SEC-6"},
+	"GL030": {"CICD-SEC-7"},
 	"GL031": {"CICD-SEC-7"},
 	"GL033": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},

--- a/testdata/fixtures/gl030-ssh-keyscan.yml
+++ b/testdata/fixtures/gl030-ssh-keyscan.yml
@@ -1,0 +1,3 @@
+before_script:
+  - mkdir -p ~/.ssh
+  - ssh-keyscan -H 'deploy.example.com' >> ~/.ssh/known_hosts


### PR DESCRIPTION
## Summary

- Adds **GL030** (`warn`): flags `ssh-keyscan` in any script block
- Running `ssh-keyscan` at pipeline runtime blindly trusts the remote host key — on a shared runner network, a MITM attacker can intercept the SSH session and any secrets it carries
- Fix: store a pre-verified known-hosts entry in a protected CI variable and write it directly with `echo "$SSH_KNOWN_HOSTS"`
- OWASP: CICD-SEC-7, CWE-295

Closes #103

## Test plan

- [ ] `go test ./rules/ -run TestGL030` — all 5 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL030` — consistency check passes
- [ ] `go test ./...` — full suite green