### PR TITLE
feat: GL032 – SSH private key written to file via echo

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,6 +18,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL014](rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 | [GL018](rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
 | [GL021](rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
+| [GL032](rules/GL032.md) | `warn`  | SSH private key written to file via `echo` — key appears in job logs when debug tracing is active |
 | [GL033](rules/GL033.md) | `error` | `CI_DEBUG_TRACE: "true"` committed — shell tracing dumps all variable values including secrets to job logs |
 | [GL029](rules/GL029.md) | `warn`  | `docker login -p` exposes password in process table — use `--password-stdin` instead |
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |

--- a/docs/rules/GL032.md
+++ b/docs/rules/GL032.md
@@ -1,0 +1,35 @@
+# GL032 — SSH private key written to file via `echo`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags script lines that use `echo` or `printf` to write what appears to be an SSH private key to a file — specifically: lines that redirect or pipe to a `.ssh/` path, or that reference a CI variable whose name contains `PRIVATE` or `_KEY`. When debug tracing is active (`set -x` or `CI_DEBUG_TRACE`), the shell prints the expanded variable value — including the full private key — to the job log. GitLab explicitly warns: *"Never run a command like `cat` or `tee` on the variable because the SSH key is not masked if it appears in the job log."*
+
+## Trigger example
+
+```yaml
+before_script:
+  - echo "$DEPLOY_SERVER_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/id_rsa
+  - chmod 600 ~/.ssh/id_rsa
+```
+
+## Safe alternative
+
+Use `ssh-add` with stdin — the key is added to the agent without being written to a file or appearing in logs:
+
+```yaml
+before_script:
+  - eval $(ssh-agent -s)
+  - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
+```
+
+Alternatively, use a [GitLab file-type variable](https://docs.gitlab.com/ee/ci/variables/#use-file-type-cicd-variables) — GitLab injects it as a file path without shell expansion.
+
+## References
+
+- [GitLab docs: Using SSH keys with GitLab CI/CD](https://docs.gitlab.com/ee/ci/ssh_keys/)
+- GL021: secret variable printed to log via `echo`/`printf`
+- GL030: `ssh-keyscan` executed dynamically (MITM risk)
+- GL033: `CI_DEBUG_TRACE` enabled in committed pipeline YAML

--- a/rules/all.go
+++ b/rules/all.go
@@ -35,6 +35,7 @@ func All() []rule.Rule {
 		GL029,
 		GL030,
 		GL031,
+		GL032,
 		GL033,
 		GL038,
 	}

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -33,6 +33,7 @@ var cweIDs = map[string]string{
 	"GL029": "CWE-214",
 	"GL030": "CWE-295",
 	"GL031": "CWE-319",
+	"GL032": "CWE-532",
 	"GL033": "CWE-532",
 	"GL038": "CWE-798",
 }

--- a/rules/gl032.go
+++ b/rules/gl032.go
@@ -1,0 +1,81 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl032 struct{}
+
+var GL032 = &gl032{}
+
+func (r *gl032) ID() string { return "GL032" }
+
+// sshKeyEchoRe matches echo/printf piping or redirecting to an SSH key file path,
+// or echoing a variable with a key-like name to any destination.
+var sshKeyEchoRe = regexp.MustCompile(
+	`\b(?:echo|printf)\b` +
+		`.*` +
+		`(?:` +
+		// redirect or pipe to ssh key file
+		`[|>].*\.ssh/` +
+		`|` +
+		// variable name contains KEY or PRIVATE
+		`\$(?:\{[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*\}|[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*)` +
+		`)`,
+)
+
+func (r *gl032) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkSSHKeyEcho(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkSSHKeyEcho(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkSSHKeyEcho(node, file, name.Value)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkSSHKeyEcho(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if sshKeyEchoRe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL032",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "SSH private key written to file via echo — key value appears in job logs when debug tracing is active; use ssh-add with stdin instead: echo \"$KEY\" | ssh-add -",
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl032_test.go
+++ b/rules/gl032_test.go
@@ -1,0 +1,79 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL032(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "echo key variable to .ssh/ path",
+			yaml: `before_script:
+  - echo "$DEPLOY_SERVER_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/id_rsa`,
+			wantHits: 1,
+		},
+		{
+			name: "echo variable with PRIVATE in name",
+			yaml: `before_script:
+  - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -`,
+			wantHits: 1,
+		},
+		{
+			name: "echo variable with _KEY suffix",
+			yaml: `deploy:
+  script:
+    - echo "$DEPLOY_KEY" > /tmp/key`,
+			wantHits: 1,
+		},
+		{
+			name: "ssh-add from stdin without echo to file — counted because var has PRIVATE",
+			yaml: `before_script:
+  - eval $(ssh-agent -s)
+  - echo "$SSH_PRIVATE_KEY" | ssh-add -`,
+			wantHits: 1,
+		},
+		{
+			name: "safe ssh-add without echo of key name",
+			yaml: `before_script:
+  - eval $(ssh-agent -s)
+  - ssh-add ~/.ssh/id_rsa`,
+			wantHits: 0,
+		},
+		{
+			name: "echo unrelated variable — safe",
+			yaml: `build:
+  script:
+    - echo "$BUILD_VERSION" > version.txt`,
+			wantHits: 0,
+		},
+		{
+			name: "echo to .ssh/ path with key content",
+			yaml: `before_script:
+  - echo "$ID_RSA" > ~/.ssh/id_rsa
+  - chmod 600 ~/.ssh/id_rsa`,
+			wantHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL032.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -34,6 +34,7 @@ var owaspCategories = map[string][]string{
 	"GL029": {"CICD-SEC-6"},
 	"GL030": {"CICD-SEC-7"},
 	"GL031": {"CICD-SEC-7"},
+	"GL032": {"CICD-SEC-6"},
 	"GL033": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
 }

--- a/testdata/fixtures/gl032-ssh-key-echo.yml
+++ b/testdata/fixtures/gl032-ssh-key-echo.yml
@@ -1,0 +1,4 @@
+before_script:
+  - eval $(ssh-agent -s)
+  - echo "$DEPLOY_SERVER_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/id_rsa
+  - chmod 600 ~/.ssh/id_rsa


### PR DESCRIPTION
## Summary

- Adds **GL032** (`warn`): flags `echo`/`printf` lines that write SSH private key material to a file
- Detected patterns: redirect/pipe to `.ssh/` path, or CI variable with `PRIVATE` or `_KEY` in the name
- When debug tracing is active, the expanded key value appears in job logs
- Fix: use `echo "$KEY" | ssh-add -` to add the key to the SSH agent without writing it to a file
- OWASP: CICD-SEC-6, CWE-532

Closes #105

## Test plan

- [ ] `go test ./rules/ -run TestGL032` — all 7 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL032` — consistency check passes
- [ ] `go test ./...` — full suite green