### PR TITLE
feat: GL034 – trigger: job without strategy: depend

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -59,6 +59,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | ID | Severity | Description |
 |----|----------|-------------|
 | [GL008](rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
+| [GL034](rules/GL034.md) | `warn`  | `trigger:` job without `strategy: depend` — child pipeline failures are silently ignored |
 | [GL009](rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL012](rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
 | [GL013](rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |

--- a/docs/rules/GL034.md
+++ b/docs/rules/GL034.md
@@ -1,0 +1,38 @@
+# GL034 — `trigger:` job without `strategy: depend`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
+
+## What glsec checks
+
+glsec flags `trigger:` jobs that do not set `strategy: depend`. Without it, the trigger job completes immediately with success, regardless of whether the triggered child or downstream pipeline succeeds or fails. Security scans, test suites, and builds that run in child pipelines will not block the parent — deployments can proceed even when critical checks fail.
+
+This is GitLab's default behavior. Many projects add `trigger:` jobs without realising that `strategy: depend` is required for the gate to be meaningful.
+
+## Trigger example
+
+```yaml
+run-security-scan:
+  stage: test
+  trigger:
+    include:
+      - local: .gitlab/ci/security.gitlab-ci.yml
+    # strategy: depend absent — scan failures are silently ignored
+```
+
+## Safe alternative
+
+```yaml
+run-security-scan:
+  stage: test
+  trigger:
+    include:
+      - local: .gitlab/ci/security.gitlab-ci.yml
+    strategy: depend   # parent waits and mirrors child pipeline status
+```
+
+## References
+
+- [GitLab docs: Downstream pipelines — trigger strategy](https://docs.gitlab.com/ee/ci/pipelines/downstream_pipelines.html#mirror-status-of-a-downstream-pipeline-in-the-trigger-job)
+- GL008: `allow_failure: true` on a security scan job
+- GL010: `trigger: forward: pipeline_variables: true` leaks secrets downstream

--- a/rules/all.go
+++ b/rules/all.go
@@ -37,6 +37,7 @@ func All() []rule.Rule {
 		GL031,
 		GL032,
 		GL033,
+		GL034,
 		GL038,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -35,6 +35,7 @@ var cweIDs = map[string]string{
 	"GL031": "CWE-319",
 	"GL032": "CWE-532",
 	"GL033": "CWE-532",
+	"GL034": "CWE-691",
 	"GL038": "CWE-798",
 }
 

--- a/rules/gl034.go
+++ b/rules/gl034.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl034 struct{}
+
+var GL034 = &gl034{}
+
+func (r *gl034) ID() string { return "GL034" }
+
+func (r *gl034) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		triggerNode := parser.FindKey(job, "trigger")
+		if triggerNode == nil {
+			return
+		}
+
+		// Scalar trigger (e.g. "trigger: other/project") — cannot carry strategy: depend.
+		if triggerNode.Kind == yaml.ScalarNode {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL034",
+				Severity: finding.Warn,
+				Job:      name.Value,
+				Message:  "trigger: job has no strategy: depend — child/downstream pipeline failures are silently ignored; add strategy: depend to mirror the child pipeline status",
+				File:     file,
+				Line:     triggerNode.Line,
+				Col:      triggerNode.Column,
+			})
+			return
+		}
+
+		if triggerNode.Kind != yaml.MappingNode {
+			return
+		}
+
+		strategyNode := parser.FindKey(triggerNode, "strategy")
+		if strategyNode != nil && strategyNode.Value == "depend" {
+			return
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL034",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message:  "trigger: job has no strategy: depend — child/downstream pipeline failures are silently ignored; add strategy: depend to mirror the child pipeline status",
+			File:     file,
+			Line:     triggerNode.Line,
+			Col:      triggerNode.Column,
+		})
+	})
+
+	return findings
+}

--- a/rules/gl034_test.go
+++ b/rules/gl034_test.go
@@ -1,0 +1,92 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL034(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "trigger mapping without strategy: depend",
+			yaml: `run-security-scan:
+  stage: test
+  trigger:
+    include:
+      - local: .gitlab/ci/security.gitlab-ci.yml`,
+			wantHits: 1,
+		},
+		{
+			name: "trigger mapping with strategy: depend — safe",
+			yaml: `run-security-scan:
+  stage: test
+  trigger:
+    include:
+      - local: .gitlab/ci/security.gitlab-ci.yml
+    strategy: depend`,
+			wantHits: 0,
+		},
+		{
+			name: "scalar trigger without strategy",
+			yaml: `downstream:
+  trigger: other/project`,
+			wantHits: 1,
+		},
+		{
+			name: "trigger with project key but no strategy",
+			yaml: `downstream:
+  trigger:
+    project: other/project
+    branch: main`,
+			wantHits: 1,
+		},
+		{
+			name: "trigger with project and strategy: depend — safe",
+			yaml: `downstream:
+  trigger:
+    project: other/project
+    strategy: depend`,
+			wantHits: 0,
+		},
+		{
+			name: "no trigger job — safe",
+			yaml: `build:
+  script:
+    - make build`,
+			wantHits: 0,
+		},
+		{
+			name: "two trigger jobs both missing strategy",
+			yaml: `child-a:
+  trigger:
+    include:
+      - local: .gitlab/ci/a.yml
+child-b:
+  trigger:
+    include:
+      - local: .gitlab/ci/b.yml`,
+			wantHits: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL034.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -36,6 +36,7 @@ var owaspCategories = map[string][]string{
 	"GL031": {"CICD-SEC-7"},
 	"GL032": {"CICD-SEC-6"},
 	"GL033": {"CICD-SEC-6"},
+	"GL034": {"CICD-SEC-1"},
 	"GL038": {"CICD-SEC-6"},
 }
 

--- a/testdata/fixtures/gl034-trigger-no-strategy-depend.yml
+++ b/testdata/fixtures/gl034-trigger-no-strategy-depend.yml
@@ -1,0 +1,5 @@
+run-security-scan:
+  stage: test
+  trigger:
+    include:
+      - local: .gitlab/ci/security.gitlab-ci.yml


### PR DESCRIPTION
## Summary

- Adds **GL034** (`warn`): flags `trigger:` jobs (both mapping and scalar form) that lack `strategy: depend`
- Without it, the trigger job always succeeds immediately — failing child pipelines (security scans, tests, builds) do not block the parent
- OWASP: CICD-SEC-1, CWE-691

Closes #107

## Test plan

- [ ] `go test ./rules/ -run TestGL034` — all 7 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL034` — consistency check passes
- [ ] `go test ./...` — full suite green