### PR TITLE
feat: GL035 – git URL with embedded credentials in script

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,6 +21,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL032](rules/GL032.md) | `warn`  | SSH private key written to file via `echo` — key appears in job logs when debug tracing is active |
 | [GL033](rules/GL033.md) | `error` | `CI_DEBUG_TRACE: "true"` committed — shell tracing dumps all variable values including secrets to job logs |
 | [GL029](rules/GL029.md) | `warn`  | `docker login -p` exposes password in process table — use `--password-stdin` instead |
+| [GL035](rules/GL035.md) | `warn`  | `git` command uses URL with embedded credentials (`user:token@host`) — token appears in job logs |
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |
 
 ---

--- a/docs/rules/GL035.md
+++ b/docs/rules/GL035.md
@@ -1,0 +1,42 @@
+# GL035 — git URL with embedded credentials (`user:token@host`) in script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags script lines where a `git clone`, `git push`, `git fetch`, `git pull`, or `git remote` command uses a URL containing embedded userinfo credentials in the form `https://user:token@host`. This pattern causes the token to appear in:
+
+- Job logs (Git prints the remote URL when pushing/fetching)
+- Shell trace output when `set -x` or `CI_DEBUG_TRACE` is active
+- `.git/config` inside the container, which may be archived by `artifacts: untracked: true`
+
+Even when the token comes from a CI variable (not hardcoded), the fully-expanded URL including the token value appears in the log.
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - git push https://ci:${TRANSLATION_TOKEN}@gitlab.com/org/repo.git HEAD:main
+```
+
+## Safe alternative
+
+Use `git remote set-url` to configure the remote, then push without embedding credentials in the command that Git logs:
+
+```yaml
+deploy:
+  script:
+    - git remote set-url origin "https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+    - git push origin HEAD:main
+```
+
+Or use SSH remotes with a key stored in a protected CI variable (see GL030, GL032).
+
+## References
+
+- [GitLab docs: Using CI_JOB_TOKEN for authentication](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html)
+- GL004: `CI_JOB_TOKEN` forwarded to a non-GitLab host
+- GL032: SSH private key written to file via `echo`
+- GL036: connection string with embedded credentials in `variables:` block

--- a/rules/all.go
+++ b/rules/all.go
@@ -38,6 +38,7 @@ func All() []rule.Rule {
 		GL032,
 		GL033,
 		GL034,
+		GL035,
 		GL038,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -36,6 +36,7 @@ var cweIDs = map[string]string{
 	"GL032": "CWE-532",
 	"GL033": "CWE-532",
 	"GL034": "CWE-691",
+	"GL035": "CWE-522",
 	"GL038": "CWE-798",
 }
 

--- a/rules/gl035.go
+++ b/rules/gl035.go
@@ -1,0 +1,72 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl035 struct{}
+
+var GL035 = &gl035{}
+
+func (r *gl035) ID() string { return "GL035" }
+
+// gitCredURLRe matches a git command followed by a URL with embedded userinfo credentials.
+var gitCredURLRe = regexp.MustCompile(
+	`\bgit\s+(?:clone|push|fetch|pull|remote\s+\S+)\b.*https?://[^\s@]+:[^\s@]+@`,
+)
+
+func (r *gl035) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkGitCredURL(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkGitCredURL(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkGitCredURL(node, file, name.Value)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkGitCredURL(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if gitCredURLRe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL035",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "git command uses URL with embedded credentials (user:token@host) — the expanded URL including the token appears in job logs; use a credential helper or CI_JOB_TOKEN without embedding it in the URL",
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl035_test.go
+++ b/rules/gl035_test.go
@@ -1,0 +1,81 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL035(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "git push with embedded token",
+			yaml: `deploy:
+  script:
+    - git push https://ci:${TRANSLATION_TOKEN}@gitlab.com/org/repo.git`,
+			wantHits: 1,
+		},
+		{
+			name: "git clone with embedded credentials",
+			yaml: `build:
+  script:
+    - git clone https://user:password@github.com/org/repo.git`,
+			wantHits: 1,
+		},
+		{
+			name: "git fetch with embedded token",
+			yaml: `sync:
+  script:
+    - git fetch https://oauth2:$ACCESS_TOKEN@gitlab.com/org/repo.git`,
+			wantHits: 1,
+		},
+		{
+			name: "git remote set-url with embedded token",
+			yaml: `deploy:
+  script:
+    - git remote set-url origin https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git`,
+			wantHits: 1,
+		},
+		{
+			name: "git push without credentials — safe",
+			yaml: `deploy:
+  script:
+    - git push origin HEAD:main`,
+			wantHits: 0,
+		},
+		{
+			name: "git clone with SSH URL — safe",
+			yaml: `build:
+  script:
+    - git clone git@github.com:org/repo.git`,
+			wantHits: 0,
+		},
+		{
+			name: "unrelated https URL — safe",
+			yaml: `build:
+  script:
+    - curl https://user:pass@api.example.com/endpoint`,
+			wantHits: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL035.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -37,6 +37,7 @@ var owaspCategories = map[string][]string{
 	"GL032": {"CICD-SEC-6"},
 	"GL033": {"CICD-SEC-6"},
 	"GL034": {"CICD-SEC-1"},
+	"GL035": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
 }
 

--- a/testdata/fixtures/gl035-git-url-embedded-credentials.yml
+++ b/testdata/fixtures/gl035-git-url-embedded-credentials.yml
@@ -1,0 +1,3 @@
+deploy:
+  script:
+    - git push https://ci:${TRANSLATION_TOKEN}@gitlab.com/org/repo.git HEAD:main


### PR DESCRIPTION
## Summary

- Adds **GL035** (`warn`): flags `git clone/push/fetch/pull/remote` commands that use a URL of the form `https://user:token@host`
- The token appears in job logs (Git prints the remote URL), shell trace output, and `.git/config` inside the container
- Affects CI variable tokens too, not just hardcoded values
- OWASP: CICD-SEC-6, CWE-522

Closes #108

## Test plan

- [ ] `go test ./rules/ -run TestGL035` — all 7 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL035` — consistency check passes
- [ ] `go test ./...` — full suite green