### PR TITLE
feat: GL036 – connection string with embedded credentials in variables: block

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,6 +14,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL027](rules/GL027.md) | `warn`  | Secret-like variable defined without `masked: true` |
 | [GL004](rules/GL004.md) | `warn`  | `CI_JOB_TOKEN` forwarded to a non-GitLab host |
 | [GL006](rules/GL006.md) | `error` | Hardcoded secret in `variables:` block |
+| [GL036](rules/GL036.md) | `warn`  | Connection string with embedded credentials (`scheme://user:pass@host`) in `variables:` block |
 | [GL010](rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |
 | [GL014](rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 | [GL018](rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |

--- a/docs/rules/GL036.md
+++ b/docs/rules/GL036.md
@@ -1,0 +1,34 @@
+# GL036 — Connection string with embedded credentials in `variables:` block
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags variable *values* in any `variables:` block — top-level or job-level — that contain a URL with embedded userinfo credentials in the form `scheme://user:password@host`. The check is on the value, not the key name, covering database URLs (`DATABASE_URL`), search engine URLs (`ELASTIC_URL`), cache URLs (`REDIS_URL`), and any other service URL that embeds credentials.
+
+A value is only flagged when the password segment does not begin with `$` — variable references such as `${DB_PASSWORD}` are considered safe.
+
+Complements GL006, which detects hardcoded secrets via key-name heuristics.
+
+## Trigger example
+
+```yaml
+variables:
+  DATABASE_URL: "postgres://myapp:s3cr3t@postgres:5432/mydb"
+  ELASTIC_URL: "http://elastic:changeme@elasticsearch:9200"
+```
+
+## Safe alternative
+
+```yaml
+variables:
+  DATABASE_URL: "postgres://myapp:${DB_PASSWORD}@postgres:5432/mydb"
+  # DB_PASSWORD stored as a protected, masked CI variable
+```
+
+## References
+
+- GL006: hardcoded secret in `variables:` block (key-name heuristic)
+- GL035: git URL with embedded credentials in script
+- GL038: hardcoded credential literal passed to CLI tool in script

--- a/rules/all.go
+++ b/rules/all.go
@@ -39,6 +39,7 @@ func All() []rule.Rule {
 		GL033,
 		GL034,
 		GL035,
+		GL036,
 		GL038,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -37,6 +37,7 @@ var cweIDs = map[string]string{
 	"GL033": "CWE-532",
 	"GL034": "CWE-691",
 	"GL035": "CWE-522",
+	"GL036": "CWE-798",
 	"GL038": "CWE-798",
 }
 

--- a/rules/gl036.go
+++ b/rules/gl036.go
@@ -1,0 +1,72 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl036 struct{}
+
+var GL036 = &gl036{}
+
+func (r *gl036) ID() string { return "GL036" }
+
+// connStringRe matches a URL with embedded userinfo where the password does not start with $.
+// Handles both "user:pass@" and ":pass@" (empty username, common in Redis URLs).
+var connStringRe = regexp.MustCompile(
+	`[a-zA-Z][a-zA-Z0-9+\-.]*://[^\s@/]*:[^$\s@/][^\s@/]*@`,
+)
+
+func (r *gl036) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkConnStringVars(parser.FindKey(mapping, "variables"), file, "")...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkConnStringVars(parser.FindKey(def, "variables"), file, "")...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		findings = append(findings, checkConnStringVars(parser.FindKey(job, "variables"), file, name.Value)...)
+	})
+
+	return findings
+}
+
+func checkConnStringVars(node *yaml.Node, file, job string) []finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valNode := node.Content[i+1]
+
+		scalar := resolveScalar(valNode)
+		if scalar == nil {
+			continue
+		}
+		if !connStringRe.MatchString(scalar.Value) {
+			continue
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL036",
+			Severity: finding.Warn,
+			Job:      job,
+			Message: fmt.Sprintf(
+				"variable %q contains a connection string with embedded credentials — store the password in a masked CI variable and reference it: e.g. scheme://user:${PASSWORD}@host",
+				keyNode.Value,
+			),
+			File: file,
+			Line: keyNode.Line,
+			Col:  keyNode.Column,
+		})
+	}
+	return findings
+}

--- a/rules/gl036_test.go
+++ b/rules/gl036_test.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL036(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "postgres connection string with literal password",
+			yaml: `variables:
+  DATABASE_URL: "postgres://myapp:s3cr3t@postgres:5432/mydb"`,
+			wantHits: 1,
+		},
+		{
+			name: "elastic URL with literal credentials",
+			yaml: `variables:
+  ELASTIC_URL: "http://elastic:changeme@elasticsearch:9200"`,
+			wantHits: 1,
+		},
+		{
+			name: "redis URL with literal password",
+			yaml: `variables:
+  REDIS_URL: "redis://:mypassword@redis:6379/0"`,
+			wantHits: 1,
+		},
+		{
+			name: "connection string with variable password — safe",
+			yaml: `variables:
+  DATABASE_URL: "postgres://myapp:${DB_PASSWORD}@postgres:5432/mydb"`,
+			wantHits: 0,
+		},
+		{
+			name: "connection string with $VAR password — safe",
+			yaml: `variables:
+  DATABASE_URL: "postgres://myapp:$DB_PASSWORD@postgres:5432/mydb"`,
+			wantHits: 0,
+		},
+		{
+			name: "job-level variable with embedded credentials",
+			yaml: `test:
+  variables:
+    DATABASE_URL: "postgres://ci:password@localhost/testdb"
+  script:
+    - ./run-tests.sh`,
+			wantHits: 1,
+		},
+		{
+			name: "multiple credential URLs",
+			yaml: `variables:
+  DATABASE_URL: "postgres://app:secret@db:5432/prod"
+  ELASTIC_URL: "http://elastic:changeme@es:9200"`,
+			wantHits: 2,
+		},
+		{
+			name: "plain variable without URL — safe",
+			yaml: `variables:
+  APP_ENV: production
+  LOG_LEVEL: debug`,
+			wantHits: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL036.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -38,6 +38,7 @@ var owaspCategories = map[string][]string{
 	"GL033": {"CICD-SEC-6"},
 	"GL034": {"CICD-SEC-1"},
 	"GL035": {"CICD-SEC-6"},
+	"GL036": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
 }
 

--- a/testdata/fixtures/gl036-connection-string-credentials.yml
+++ b/testdata/fixtures/gl036-connection-string-credentials.yml
@@ -1,0 +1,3 @@
+variables:
+  DATABASE_URL: "postgres://myapp:s3cr3t@postgres:5432/mydb"
+  ELASTIC_URL: "http://elastic:changeme@elasticsearch:9200"


### PR DESCRIPTION
## Summary

- Adds **GL036** (`warn`): flags variable values in any `variables:` block that contain a URL with embedded credentials (`scheme://user:pass@host`)
- Detects database URLs, search/cache service URLs, and any other scheme — independent of key name
- Safe when the password segment starts with `$` (CI variable reference)
- OWASP: CICD-SEC-6, CWE-798

Closes #109

## Test plan

- [ ] `go test ./rules/ -run TestGL036` — all 8 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL036` — consistency check passes
- [ ] `go test ./...` — full suite green