### PR TITLE
feat: GL037 – trigger: job without inherit: variables: false

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -16,6 +16,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL006](rules/GL006.md) | `error` | Hardcoded secret in `variables:` block |
 | [GL036](rules/GL036.md) | `warn`  | Connection string with embedded credentials (`scheme://user:pass@host`) in `variables:` block |
 | [GL010](rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |
+| [GL037](rules/GL037.md) | `warn`  | `trigger:` job without `inherit: variables: false` — top-level secrets implicitly forwarded to downstream |
 | [GL014](rules/GL014.md) | `warn`  | `dotenv` artifact captures all environment variables including secrets (GitLab ≥ 12.9) |
 | [GL018](rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
 | [GL021](rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |

--- a/docs/rules/GL037.md
+++ b/docs/rules/GL037.md
@@ -1,0 +1,44 @@
+# GL037 — `trigger:` job without `inherit: variables: false`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags `trigger:` jobs that lack `inherit: variables: false` when the pipeline has top-level `variables:` with secret-like names (same suffix heuristic as GL006/GL027: `_TOKEN`, `_SECRET`, `_PASSWORD`, `_KEY`, etc.). By default, GitLab forwards all top-level pipeline variables to downstream pipelines — the downstream project receives secrets it was never explicitly granted.
+
+The finding is suppressed when:
+- No top-level variables with secret-like names exist, or
+- `inherit: variables: false` is set on the trigger job
+
+## Trigger example
+
+```yaml
+variables:
+  DEPLOY_TOKEN: $DEPLOY_TOKEN   # top-level — forwarded to all trigger: jobs by default
+
+deploy-to-k8s:
+  trigger:
+    project: myorg/k8s-deployer
+    branch: main
+    # inherit: variables: false absent — DEPLOY_TOKEN forwarded implicitly
+```
+
+## Safe alternative
+
+```yaml
+deploy-to-k8s:
+  trigger:
+    project: myorg/k8s-deployer
+    branch: main
+  inherit:
+    variables: false   # opt out of implicit forwarding
+  variables:
+    DEPLOY_ENV: production   # pass only what the downstream actually needs
+```
+
+## References
+
+- [GitLab docs: `inherit:variables`](https://docs.gitlab.com/ee/ci/yaml/#inheritvariables)
+- GL010: `trigger: forward: pipeline_variables: true` explicitly enables secret forwarding
+- GL034: `trigger:` job without `strategy: depend`

--- a/rules/all.go
+++ b/rules/all.go
@@ -40,6 +40,7 @@ func All() []rule.Rule {
 		GL034,
 		GL035,
 		GL036,
+		GL037,
 		GL038,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -38,6 +38,7 @@ var cweIDs = map[string]string{
 	"GL034": "CWE-691",
 	"GL035": "CWE-522",
 	"GL036": "CWE-798",
+	"GL037": "CWE-522",
 	"GL038": "CWE-798",
 }
 

--- a/rules/gl037.go
+++ b/rules/gl037.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl037 struct{}
+
+var GL037 = &gl037{}
+
+func (r *gl037) ID() string { return "GL037" }
+
+func (r *gl037) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+
+	// Only flag when top-level variables: has at least one secret-like name.
+	if !topLevelHasSecretVars(parser.FindKey(mapping, "variables")) {
+		return nil
+	}
+
+	var findings []finding.Finding
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if parser.FindKey(job, "trigger") == nil {
+			return
+		}
+		if inheritVarsFalse(parser.FindKey(job, "inherit")) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL037",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message:  "trigger: job has no inherit: variables: false — top-level secret variables are implicitly forwarded to the downstream pipeline; add inherit: variables: false and pass only what the downstream needs",
+			File:     file,
+			Line:     name.Line,
+			Col:      name.Column,
+		})
+	})
+	return findings
+}
+
+// topLevelHasSecretVars returns true when any variable key in the node has a secret-like suffix.
+func topLevelHasSecretVars(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if hasSecretSuffix(node.Content[i].Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// inheritVarsFalse returns true when the inherit: block explicitly sets variables: false.
+func inheritVarsFalse(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	v := parser.FindKey(node, "variables")
+	return v != nil && v.Value == "false"
+}

--- a/rules/gl037_test.go
+++ b/rules/gl037_test.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL037(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "trigger job without inherit: variables: false and secret top-level var",
+			yaml: `variables:
+  DEPLOY_TOKEN: $DEPLOY_TOKEN
+
+deploy:
+  trigger:
+    project: myorg/k8s-deployer
+    branch: main`,
+			wantHits: 1,
+		},
+		{
+			name: "trigger job with inherit: variables: false — safe",
+			yaml: `variables:
+  DEPLOY_TOKEN: $DEPLOY_TOKEN
+
+deploy:
+  trigger:
+    project: myorg/k8s-deployer
+  inherit:
+    variables: false`,
+			wantHits: 0,
+		},
+		{
+			name: "trigger job but no secret top-level vars — safe",
+			yaml: `variables:
+  APP_ENV: production
+  LOG_LEVEL: debug
+
+deploy:
+  trigger:
+    project: myorg/k8s-deployer`,
+			wantHits: 0,
+		},
+		{
+			name: "no top-level variables at all — safe",
+			yaml: `deploy:
+  trigger:
+    project: myorg/k8s-deployer`,
+			wantHits: 0,
+		},
+		{
+			name: "two trigger jobs both missing inherit: variables: false",
+			yaml: `variables:
+  API_KEY: $API_KEY
+
+child-a:
+  trigger:
+    include:
+      - local: .gitlab/ci/a.yml
+child-b:
+  trigger:
+    include:
+      - local: .gitlab/ci/b.yml`,
+			wantHits: 2,
+		},
+		{
+			name: "inherit block present but variables not false",
+			yaml: `variables:
+  DB_PASSWORD: $DB_PASSWORD
+
+deploy:
+  trigger:
+    project: myorg/deployer
+  inherit:
+    default: false`,
+			wantHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL037.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -39,6 +39,7 @@ var owaspCategories = map[string][]string{
 	"GL034": {"CICD-SEC-1"},
 	"GL035": {"CICD-SEC-6"},
 	"GL036": {"CICD-SEC-6"},
+	"GL037": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
 }
 

--- a/testdata/fixtures/gl037-trigger-no-inherit-variables-false.yml
+++ b/testdata/fixtures/gl037-trigger-no-inherit-variables-false.yml
@@ -1,0 +1,7 @@
+variables:
+  DEPLOY_TOKEN: $DEPLOY_TOKEN
+
+deploy-to-k8s:
+  trigger:
+    project: myorg/k8s-deployer
+    branch: main


### PR DESCRIPTION
## Summary

- Adds **GL037** (`warn`): flags `trigger:` jobs missing `inherit: variables: false` when the pipeline has secret-like top-level variables
- GitLab's default forwards all top-level variables to downstream pipelines — downstream projects receive secrets they were never explicitly granted
- Only fires when top-level `variables:` contains at least one key matching the secret-name heuristic (`_TOKEN`, `_KEY`, `_PASSWORD`, etc.)
- Suppressed when `inherit: variables: false` is present
- OWASP: CICD-SEC-6, CWE-522

Closes #110

## Test plan

- [ ] `go test ./rules/ -run TestGL037` — all 6 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL037` — consistency check passes
- [ ] `go test ./...` — full suite green