### PR TITLE
feat: GL039 – security check silenced with || true

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -63,6 +63,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 |----|----------|-------------|
 | [GL008](rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
 | [GL034](rules/GL034.md) | `warn`  | `trigger:` job without `strategy: depend` — child pipeline failures are silently ignored |
+| [GL039](rules/GL039.md) | `warn`  | Security audit tool silenced with `\|\| true` — failures discarded, pipeline always green |
 | [GL009](rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL012](rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
 | [GL013](rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |

--- a/docs/rules/GL039.md
+++ b/docs/rules/GL039.md
@@ -1,0 +1,41 @@
+# GL039 — Security-check command silenced with `|| true`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
+
+## What glsec checks
+
+glsec flags script lines where a known security audit tool is followed by `|| true` or `|| exit 0`. These constructs force exit code 0 regardless of whether vulnerabilities were found, making the job always green and silently discarding the audit result. The pipeline continues as if no findings exist.
+
+Detected tools: `npm audit`, `composer audit`, `trivy`, `grype`, `snyk`, `osv-scanner`, `retire`, `safety check/scan`, `anchore-cli`, `inspector check`, `syft`.
+
+## Trigger example
+
+```yaml
+security:
+  script:
+    - npm audit --audit-level=high || true    # CVEs silently ignored
+    - trivy image myapp:latest || true        # vulnerabilities discarded
+```
+
+## Safe alternatives
+
+**Remove the silencing and fix the findings:**
+```yaml
+security:
+  script:
+    - npm audit --audit-level=high
+```
+
+**If the pipeline must stay green while the backlog is being cleared, use job-level `allow_failure:` — this keeps the signal visible in the UI:**
+```yaml
+security:
+  allow_failure: true
+  script:
+    - npm audit --audit-level=high
+```
+
+## References
+
+- GL008: `allow_failure: true` on a GitLab security scan job
+- GL024: shell pipe without `set -o pipefail`

--- a/rules/all.go
+++ b/rules/all.go
@@ -42,5 +42,6 @@ func All() []rule.Rule {
 		GL036,
 		GL037,
 		GL038,
+		GL039,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -40,6 +40,7 @@ var cweIDs = map[string]string{
 	"GL036": "CWE-798",
 	"GL037": "CWE-522",
 	"GL038": "CWE-798",
+	"GL039": "CWE-390",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl039.go
+++ b/rules/gl039.go
@@ -1,0 +1,99 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl039 struct{}
+
+var GL039 = &gl039{}
+
+func (r *gl039) ID() string { return "GL039" }
+
+// silencedRe matches "|| true" or "|| exit 0" at end of a pipeline segment.
+var silencedRe = regexp.MustCompile(`\|\|\s*(?:true|exit\s+0)\b`)
+
+type auditTool struct {
+	name string
+	re   *regexp.Regexp
+}
+
+var auditTools = []auditTool{
+	{name: "npm audit", re: regexp.MustCompile(`\bnpm\s+audit\b`)},
+	{name: "composer audit", re: regexp.MustCompile(`\bcomposer\s+audit\b`)},
+	{name: "trivy", re: regexp.MustCompile(`\btrivy\b`)},
+	{name: "grype", re: regexp.MustCompile(`\bgrype\b`)},
+	{name: "snyk", re: regexp.MustCompile(`\bsnyk\b`)},
+	{name: "osv-scanner", re: regexp.MustCompile(`\bosv-scanner\b`)},
+	{name: "retire", re: regexp.MustCompile(`\bretire\b`)},
+	{name: "safety check", re: regexp.MustCompile(`\bsafety\s+(?:check|scan)\b`)},
+	{name: "anchore-cli", re: regexp.MustCompile(`\banchore-cli\b`)},
+	{name: "inspector check", re: regexp.MustCompile(`\binspector\s+check\b`)},
+	{name: "syft", re: regexp.MustCompile(`\bsyft\b`)},
+}
+
+func (r *gl039) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkAuditSilenced(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkAuditSilenced(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkAuditSilenced(node, file, name.Value)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkAuditSilenced(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if !silencedRe.MatchString(item.Value) {
+			continue
+		}
+		for _, tool := range auditTools {
+			if tool.re.MatchString(item.Value) {
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL039",
+					Severity: finding.Warn,
+					Job:      job,
+					Message: fmt.Sprintf(
+						"security check %q silenced with \"|| true\" — failures are discarded; use allow_failure: true at job level to keep the signal visible in the pipeline UI",
+						tool.name,
+					),
+					File: file,
+					Line: item.Line,
+					Col:  item.Column,
+				})
+				break
+			}
+		}
+	}
+	return findings
+}

--- a/rules/gl039_test.go
+++ b/rules/gl039_test.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL039(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "npm audit silenced with || true",
+			yaml: `security:
+  script:
+    - npm audit --audit-level=high || true`,
+			wantHits: 1,
+		},
+		{
+			name: "composer audit silenced",
+			yaml: `security:
+  script:
+    - composer audit || true`,
+			wantHits: 1,
+		},
+		{
+			name: "trivy silenced",
+			yaml: `scan:
+  script:
+    - trivy image myapp:latest || true`,
+			wantHits: 1,
+		},
+		{
+			name: "snyk silenced with || exit 0",
+			yaml: `security:
+  script:
+    - snyk test || exit 0`,
+			wantHits: 1,
+		},
+		{
+			name: "npm audit without silencing — safe",
+			yaml: `security:
+  script:
+    - npm audit --audit-level=high`,
+			wantHits: 0,
+		},
+		{
+			name: "unrelated command silenced — safe",
+			yaml: `build:
+  script:
+    - make lint || true`,
+			wantHits: 0,
+		},
+		{
+			name: "multiple tools silenced",
+			yaml: `security:
+  script:
+    - npm audit || true
+    - trivy image myapp || true
+    - snyk test`,
+			wantHits: 2,
+		},
+		{
+			name: "inspector check silenced",
+			yaml: `security:
+  script:
+    - inspector check soup.json || true`,
+			wantHits: 1,
+		},
+		{
+			name: "osv-scanner silenced",
+			yaml: `security:
+  script:
+    - osv-scanner --lockfile package-lock.json || true`,
+			wantHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL039.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -41,6 +41,7 @@ var owaspCategories = map[string][]string{
 	"GL036": {"CICD-SEC-6"},
 	"GL037": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
+	"GL039": {"CICD-SEC-1"},
 }
 
 // OWASPCategories returns the OWASP CI/CD security categories for a rule ID.

--- a/testdata/fixtures/gl039-security-check-silenced.yml
+++ b/testdata/fixtures/gl039-security-check-silenced.yml
@@ -1,0 +1,4 @@
+security:
+  script:
+    - inspector check soup.json || true
+    - npm audit --audit-level=high || true


### PR DESCRIPTION
## Summary

- Adds **GL039** (`warn`): flags known security audit tools followed by `|| true` or `|| exit 0`
- Silencing forces exit 0 regardless of findings — the pipeline stays green while vulnerabilities are ignored
- Detected tools: npm audit, composer audit, trivy, grype, snyk, osv-scanner, retire, safety, anchore-cli, inspector check, syft
- OWASP: CICD-SEC-1, CWE-390

Closes #114

## Test plan

- [ ] `go test ./rules/ -run TestGL039` — all 9 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL039` — consistency check passes
- [ ] `go test ./...` — full suite green