### PR TITLE
feat: GL040 – script downloads over plain FTP

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -81,6 +81,7 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL005](rules/GL005.md) | `warn`  | Sensitive file patterns in `artifacts:` or missing `expire_in` |
 | [GL007](rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
 | [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
+| [GL040](rules/GL040.md) | `warn`  | Script uses plain `ftp://` — credentials and content transmitted unencrypted |
 | [GL024](rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
 | [GL028](rules/GL028.md) | `warn`  | `artifacts: untracked: true` without `paths:` or `exclude:` may archive `.env`, keys, and other sensitive files |
 | [GL030](rules/GL030.md) | `warn`  | `ssh-keyscan` at runtime blindly trusts the remote host key — MITM risk on shared runner networks |

--- a/docs/rules/GL040.md
+++ b/docs/rules/GL040.md
@@ -1,0 +1,44 @@
+# GL040 — Script downloads over plain FTP
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags script lines that contain an `ftp://` URL. Plain FTP transmits both credentials (`--ftp-user`, `--ftp-password`, or userinfo in the URL) and file contents in cleartext. Any network observer between the runner and the server can capture passwords and downloaded files.
+
+Not flagged:
+- `ftps://` — FTP over TLS (encrypted)
+- `sftp://` — SSH file transfer (encrypted)
+- `curl --ssl-reqd ... ftp://` — curl's explicit TLS upgrade
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - wget --ftp-user="$FTP_USER" --ftp-password="$FTP_PASSWORD" ftp://ftp.example.com/assets.zip
+```
+
+## Safe alternatives
+
+| Instead of | Use |
+|-----------|-----|
+| `ftp://` | `ftps://` (FTP over TLS) |
+| `ftp://` | `sftp://` (SSH-based) |
+| `ftp://` | `https://` if the server supports it |
+| `curl ftp://` | `curl --ssl-reqd ftp://` (explicit TLS) |
+
+```yaml
+deploy:
+  script:
+    - wget ftps://ftp.example.com/assets.zip
+    # or
+    - curl --ssl-reqd -u "$FTP_USER:$FTP_PASSWORD" ftp://ftp.example.com/assets.zip
+```
+
+## References
+
+- [RFC 4217 — Securing FTP with TLS](https://www.rfc-editor.org/rfc/rfc4217)
+- GL016: HTTP instead of HTTPS in `include:remote`, scripts, variables
+- GL038: hardcoded credential literals in script commands

--- a/rules/all.go
+++ b/rules/all.go
@@ -43,5 +43,6 @@ func All() []rule.Rule {
 		GL037,
 		GL038,
 		GL039,
+		GL040,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -41,6 +41,7 @@ var cweIDs = map[string]string{
 	"GL037": "CWE-522",
 	"GL038": "CWE-798",
 	"GL039": "CWE-390",
+	"GL040": "CWE-319",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl040.go
+++ b/rules/gl040.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl040 struct{}
+
+var GL040 = &gl040{}
+
+func (r *gl040) ID() string { return "GL040" }
+
+// ftpURLRe matches ftp:// (case-insensitive) but not ftps:// or sftp://.
+// \bftp:// won't match sftp:// (no word boundary before ftp in sftp)
+// and won't match ftps:// because ftps != ftp followed by ://.
+var ftpURLRe = regexp.MustCompile(`(?i)\bftp://`)
+
+// sslReqdRe matches curl's --ssl-reqd flag which upgrades ftp:// to explicit TLS.
+var sslReqdRe = regexp.MustCompile(`--ssl-reqd`)
+
+func (r *gl040) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkFTPPlain(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkFTPPlain(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkFTPPlain(node, file, name.Value)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkFTPPlain(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if !ftpURLRe.MatchString(item.Value) {
+			continue
+		}
+		// curl --ssl-reqd with ftp:// uses explicit TLS — not plain FTP.
+		if sslReqdRe.MatchString(item.Value) {
+			continue
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL040",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "script uses plain ftp:// — credentials and content are transmitted unencrypted; use ftps://, sftp://, or curl with --ssl-reqd instead",
+			File:     file,
+			Line:     item.Line,
+			Col:      item.Column,
+		})
+	}
+	return findings
+}

--- a/rules/gl040_test.go
+++ b/rules/gl040_test.go
@@ -1,0 +1,88 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL040(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "wget with ftp:// URL",
+			yaml: `deploy:
+  script:
+    - wget -q --ftp-user="user" --ftp-password="$FTP_PASSWORD" ftp://ftp.example.com/assets.zip`,
+			wantHits: 1,
+		},
+		{
+			name: "curl with ftp:// URL",
+			yaml: `deploy:
+  script:
+    - curl -u "$FTP_USER:$FTP_PASSWORD" ftp://example.com/file.zip`,
+			wantHits: 1,
+		},
+		{
+			name: "curl with --ssl-reqd and ftp:// — safe (explicit TLS)",
+			yaml: `deploy:
+  script:
+    - curl --ssl-reqd -u "$FTP_USER:$FTP_PASSWORD" ftp://example.com/file.zip`,
+			wantHits: 0,
+		},
+		{
+			name: "ftps:// URL — safe",
+			yaml: `deploy:
+  script:
+    - wget ftps://ftp.example.com/file.zip`,
+			wantHits: 0,
+		},
+		{
+			name: "sftp:// URL — safe",
+			yaml: `deploy:
+  script:
+    - curl sftp://example.com/file.zip`,
+			wantHits: 0,
+		},
+		{
+			name: "https:// URL — safe",
+			yaml: `deploy:
+  script:
+    - curl https://example.com/file.zip`,
+			wantHits: 0,
+		},
+		{
+			name: "multiple ftp:// lines",
+			yaml: `deploy:
+  script:
+    - wget ftp://ftp.example.com/assets.zip
+    - wget ftp://ftp.example.com/documents.zip`,
+			wantHits: 2,
+		},
+		{
+			name: "ftp:// in before_script",
+			yaml: `before_script:
+  - wget ftp://files.example.com/config.tar.gz`,
+			wantHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL040.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -42,6 +42,7 @@ var owaspCategories = map[string][]string{
 	"GL037": {"CICD-SEC-6"},
 	"GL038": {"CICD-SEC-6"},
 	"GL039": {"CICD-SEC-1"},
+	"GL040": {"CICD-SEC-6"},
 }
 
 // OWASPCategories returns the OWASP CI/CD security categories for a rule ID.

--- a/testdata/fixtures/gl040-ftp-plain.yml
+++ b/testdata/fixtures/gl040-ftp-plain.yml
@@ -1,0 +1,3 @@
+deploy:
+  script:
+    - wget -q --ftp-user="user@example.com" --ftp-password="$FTP_PASSWORD" ftp://ftp.example.com/assets.zip


### PR DESCRIPTION
## Summary

- Adds **GL040** (`warn`): flags `ftp://` URLs in script lines — plain FTP transmits credentials and content in cleartext
- Not flagged: `ftps://`, `sftp://`, `curl --ssl-reqd ftp://` (all encrypted)
- OWASP: CICD-SEC-6, CWE-319

Closes #116

## Test plan

- [ ] `go test ./rules/ -run TestGL040` — all 8 cases pass
- [ ] `go test ./rules/ -run TestRuleConsistency/GL040` — consistency check passes
- [ ] `go test ./...` — full suite green