### PR TITLE
feat: GL041 – include component without pinned version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,13 @@ exclude_paths:
 
 ## Rules
 
-40 rules across 5 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+41 rules across 6 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039 |
 | Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -43,6 +43,16 @@ Mutable references that allow silent substitution of images, templates, or packa
 
 ---
 
+## Component & Third-Party Integrity — [CICD-SEC-4](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) / [CICD-SEC-8](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-08-Ungoverned-Usage-of-3rd-Party-Services)
+
+Mutable or unversioned component includes that allow silent substitution of pipeline templates.
+
+| ID | Severity | Description |
+|----|----------|-------------|
+| [GL041](rules/GL041.md) | `warn`  | `include: component:` without a pinned semver tag or commit SHA |
+
+---
+
 ## Supply Chain Integrity — [CICD-SEC-9](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation)
 
 Downloads and executions that bypass integrity checks, enabling tampering mid-pipeline.

--- a/docs/rules/GL041.md
+++ b/docs/rules/GL041.md
@@ -1,0 +1,45 @@
+# GL041 — `include: component:` without pinned version
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) / [CICD-SEC-8 – Ungoverned Usage of 3rd-Party Services](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-08-Ungoverned-Usage-of-3rd-Party-Services)
+
+## What glsec checks
+
+glsec flags `include: component:` entries that use a mutable or missing version specifier. GitLab CI components are versioned via an `@<ref>` suffix. When the ref is a branch name (`@main`), a tilde-latest (`@~latest`), `@latest`, or omitted entirely, the exact pipeline template executed can change between runs — a compromised or updated component can silently alter your pipeline's security controls.
+
+Only the following refs are considered pinned:
+
+- **Exact semver tag:** `1.0.0`, `v2.1.3`, `2.0`
+- **Full 40-character hex commit SHA:** `a3f1e9b2c4d5678901234567890abcdef1234567`
+
+## Trigger example
+
+```yaml
+include:
+  - component: gitlab.com/components/sast           # missing @<version>
+  - component: gitlab.com/components/dast@latest    # mutable alias
+  - component: gitlab.com/components/fuzz@~latest   # tilde-latest — still mutable
+  - component: gitlab.com/components/iast@main      # branch name — mutable
+```
+
+## Safe alternatives
+
+**Pin to a semver tag:**
+```yaml
+include:
+  - component: gitlab.com/components/sast@1.3.0
+  - component: gitlab.com/components/dast@2.0.1
+```
+
+**Pin to a commit SHA (highest integrity):**
+```yaml
+include:
+  - component: gitlab.com/components/sast@a3f1e9b2c4d5678901234567890abcdef1234567
+```
+
+## Notes
+
+- Semver tags (`1.0.0`, `v1.2.3`) are considered pinned because they are immutable once published to the GitLab component catalog.
+- Tilde-version (`@~latest`, `@~1`) is GitLab's syntax for "latest compatible version" and remains mutable across pipeline runs.
+- This rule complements GL003, which flags mutable `ref:` values in `include: project:` entries. GL003 uses a denylist of known branch names; GL041 uses an allowlist approach specific to component versioning.
+- Suppress false positives with: `# glsec:ignore GL041 -- component version is intentionally floating`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -44,5 +44,6 @@ func All() []rule.Rule {
 		GL038,
 		GL039,
 		GL040,
+		GL041,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -42,6 +42,7 @@ var cweIDs = map[string]string{
 	"GL038": "CWE-798",
 	"GL039": "CWE-390",
 	"GL040": "CWE-319",
+	"GL041": "CWE-1104",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl041.go
+++ b/rules/gl041.go
@@ -1,0 +1,90 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl041 struct{}
+
+var GL041 = &gl041{}
+
+func (r *gl041) ID() string { return "GL041" }
+
+var (
+	// componentSHARe matches a full 40-character lowercase hex commit SHA.
+	componentSHARe = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+	// componentSemverRe matches a semver tag, optionally prefixed with "v".
+	// Requires at least two dot-separated numeric segments (e.g. 1.0, v1.2.3).
+	componentSemverRe = regexp.MustCompile(`^v?\d+\.\d+`)
+)
+
+func (r *gl041) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+	includeNode := parser.FindKey(mapping, "include")
+	if includeNode == nil || includeNode.Kind != yaml.SequenceNode {
+		return nil
+	}
+
+	var findings []finding.Finding
+	for _, item := range includeNode.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		component := parser.FindKey(item, "component")
+		if component == nil {
+			continue
+		}
+		if f := checkComponentVersion(component, file); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	return findings
+}
+
+func checkComponentVersion(node *yaml.Node, file string) *finding.Finding {
+	val := node.Value
+	at := strings.LastIndex(val, "@")
+	if at < 0 {
+		return &finding.Finding{
+			RuleID:   "GL041",
+			Severity: finding.Warn,
+			Message:  fmt.Sprintf("component include %q has no version — add @<semver-tag> or @<sha> to pin it", val),
+			File:     file,
+			Line:     node.Line,
+			Col:      node.Column,
+		}
+	}
+	ref := val[at+1:]
+
+	// Strip leading ~ (e.g. ~latest, ~1.0.0 — tilde prefix means "latest compatible" which is still mutable)
+	if strings.HasPrefix(ref, "~") {
+		return &finding.Finding{
+			RuleID:   "GL041",
+			Severity: finding.Warn,
+			Message:  fmt.Sprintf("component include %q uses tilde version %q — pin to an exact semver tag or commit SHA", val, ref),
+			File:     file,
+			Line:     node.Line,
+			Col:      node.Column,
+		}
+	}
+
+	if componentSHARe.MatchString(ref) || componentSemverRe.MatchString(ref) {
+		return nil
+	}
+
+	return &finding.Finding{
+		RuleID:   "GL041",
+		Severity: finding.Warn,
+		Message:  fmt.Sprintf("component include %q uses mutable ref %q — pin to a semver tag (e.g. 1.0.0) or a full commit SHA", val, ref),
+		File:     file,
+		Line:     node.Line,
+		Col:      node.Column,
+	}
+}

--- a/rules/gl041_test.go
+++ b/rules/gl041_test.go
@@ -1,0 +1,109 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL041(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "component without version",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast`,
+			wantHits: 1,
+		},
+		{
+			name: "component with @latest",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@latest`,
+			wantHits: 1,
+		},
+		{
+			name: "component with @~latest",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@~latest`,
+			wantHits: 1,
+		},
+		{
+			name: "component with @main (branch name)",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@main`,
+			wantHits: 1,
+		},
+		{
+			name: "component with @feature-branch (branch slug, no dots)",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@feature-branch`,
+			wantHits: 1,
+		},
+		{
+			name: "component with semver tag — safe",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@1.0.0`,
+			wantHits: 0,
+		},
+		{
+			name: "component with v-prefixed semver tag — safe",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@v1.2.3`,
+			wantHits: 0,
+		},
+		{
+			name: "component with two-segment semver — safe",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@2.1`,
+			wantHits: 0,
+		},
+		{
+			name: "component with full SHA — safe",
+			yaml: `include:
+  - component: gitlab.com/org/security-scan/sast@a3f1e9b2c4d5678901234567890abcdef1234567`,
+			wantHits: 0,
+		},
+		{
+			name: "multiple components mixed",
+			yaml: `include:
+  - component: gitlab.com/org/sast@1.0.0
+  - component: gitlab.com/org/dast@latest
+  - component: gitlab.com/org/fuzz`,
+			wantHits: 2,
+		},
+		{
+			name: "project include — not flagged by GL041",
+			yaml: `include:
+  - project: org/templates
+    ref: main
+    file: /ci/build.yml`,
+			wantHits: 0,
+		},
+		{
+			name: "no include block — safe",
+			yaml: `build:
+  script:
+    - make build`,
+			wantHits: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL041.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -43,6 +43,7 @@ var owaspCategories = map[string][]string{
 	"GL038": {"CICD-SEC-6"},
 	"GL039": {"CICD-SEC-1"},
 	"GL040": {"CICD-SEC-6"},
+	"GL041": {"CICD-SEC-4", "CICD-SEC-8"},
 }
 
 // OWASPCategories returns the OWASP CI/CD security categories for a rule ID.

--- a/testdata/fixtures/gl041-component-unpinned.yml
+++ b/testdata/fixtures/gl041-component-unpinned.yml
@@ -1,0 +1,3 @@
+include:
+  - component: gitlab.com/components/sast@latest
+  - component: gitlab.com/components/dast


### PR DESCRIPTION
Closes #139

## What changed

Adds **GL041** — a `warn`-severity rule that flags `include: component:` entries in `.gitlab-ci.yml` that use a mutable or missing version specifier.

### Pinning logic (allowlist approach)

Only the following refs are considered safe:

| Pattern | Example | Safe? |
|---------|---------|-------|
| Exact semver (2+ segments) | `1.0.0`, `v2.1`, `v1.2.3` | ✓ |
| Full 40-char hex SHA | `a3f1e9b2c4...` | ✓ |
| Missing `@` | `gitlab.com/org/sast` | ✗ |
| `@latest` | `...@latest` | ✗ |
| `@~latest` / `@~1` | `...@~latest` | ✗ |
| Branch name / slug (no dots) | `...@main`, `...@feature-branch` | ✗ |

This is stricter than GL003, which uses a denylist of known branch names for component refs. GL041 catches everything GL003 misses (e.g. `@~latest`, custom branch slugs).

### OWASP coverage

- **CICD-SEC-4** (Poisoned Pipeline Execution) — mutable component templates can alter pipeline security controls silently
- **CICD-SEC-8** (Ungoverned Usage of 3rd-Party Services) — floating component versions allow uncontrolled third-party updates

This adds two previously uncovered OWASP CICD-SEC categories.

## Files

| File | Purpose |
|------|---------|
| `rules/gl041.go` | Rule implementation |
| `rules/gl041_test.go` | 12 unit test cases |
| `testdata/fixtures/gl041-component-unpinned.yml` | Consistency-test fixture |
| `docs/rules/GL041.md` | Rule documentation |
| `docs/rules.md` | New "Component & Third-Party Integrity" section |
| `README.md` | Updated count (40→41) and category table |
| `rules/all.go`, `owasp.go`, `cwe.go` | Registrations |

## How to test

```sh
go test ./rules/ -run TestGL041 -v
go test ./rules/ -run TestRuleConsistency
go test ./...
```

All pass.

## Example output

```
WARN  .gitlab-ci.yml:2  GL041  component include "gitlab.com/components/sast@latest" uses mutable ref "latest" — pin to a semver tag (e.g. 1.0.0) or a full commit SHA
WARN  .gitlab-ci.yml:3  GL041  component include "gitlab.com/components/dast" has no version — add @<semver-tag> or @<sha> to pin it
```