### PR TITLE
feat: GL042 – TLS certificate verification disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ exclude_paths:
 
 ## Rules
 
-41 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+42 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -100,7 +100,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -96,3 +96,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL028](rules/GL028.md) | `warn`  | `artifacts: untracked: true` without `paths:` or `exclude:` may archive `.env`, keys, and other sensitive files |
 | [GL030](rules/GL030.md) | `warn`  | `ssh-keyscan` at runtime blindly trusts the remote host key — MITM risk on shared runner networks |
 | [GL031](rules/GL031.md) | `error` | `DOCKER_TLS_CERTDIR: ""` disables Docker daemon TLS — exposes port 2375 unauthenticated on the runner network |
+| [GL042](rules/GL042.md) | `warn`  | TLS certificate verification disabled (`curl -k`, `wget --no-check-certificate`, `GIT_SSL_NO_VERIFY`, etc.) |

--- a/docs/rules/GL042.md
+++ b/docs/rules/GL042.md
@@ -1,0 +1,65 @@
+# GL042 — TLS certificate verification disabled
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)
+
+## What glsec checks
+
+glsec flags script commands and variable assignments that explicitly disable TLS certificate verification. On shared or self-hosted runners, an attacker on the same network can perform a man-in-the-middle attack — intercepting and replacing downloaded artifacts, API responses, or git repository content without leaving any trace.
+
+Detected patterns:
+
+| Tool | Flag/Setting |
+|------|-------------|
+| `curl` | `-k`, `--insecure` |
+| `wget` | `--no-check-certificate` |
+| `git` | `-c http.sslVerify=false` |
+| `npm` | `--strict-ssl=false`, `npm config set strict-ssl false` |
+| env var | `GIT_SSL_NO_VERIFY=true` / `GIT_SSL_NO_VERIFY=1` (in `variables:` or inline) |
+
+## Trigger example
+
+```yaml
+build:
+  variables:
+    GIT_SSL_NO_VERIFY: "true"
+  script:
+    - curl -k https://internal.example.com/artifact.tar.gz
+    - wget --no-check-certificate https://internal.example.com/file.zip
+    - git -c http.sslVerify=false clone https://gitlab.example.com/org/repo.git
+    - npm install --strict-ssl=false
+```
+
+## Safe alternatives
+
+**Add the internal CA certificate to the trust store:**
+```yaml
+build:
+  before_script:
+    - cp /path/to/internal-ca.crt /usr/local/share/ca-certificates/
+    - update-ca-certificates
+  script:
+    - curl https://internal.example.com/artifact.tar.gz
+    - git clone https://gitlab.example.com/org/repo.git
+```
+
+**Pass the CA bundle directly to curl:**
+```yaml
+build:
+  script:
+    - curl --cacert "$CI_PROJECT_DIR/certs/internal-ca.crt" https://internal.example.com/artifact.tar.gz
+```
+
+**Configure git to use a specific CA:**
+```yaml
+build:
+  script:
+    - git config http.sslCAInfo "$CI_PROJECT_DIR/certs/internal-ca.crt"
+    - git clone https://gitlab.example.com/org/repo.git
+```
+
+## Notes
+
+- The most common reason teams disable TLS verification is self-signed certificates on internal infrastructure. The correct fix is to distribute the CA certificate, not to disable verification globally.
+- Suppress intentional uses with: `# glsec:ignore GL042 -- internal CA not yet provisioned, tracked in INFRA-123`.
+- Related: GL030 (`ssh-keyscan` blindly trusts SSH host keys), GL016 (HTTP instead of HTTPS).

--- a/rules/all.go
+++ b/rules/all.go
@@ -45,5 +45,6 @@ func All() []rule.Rule {
 		GL039,
 		GL040,
 		GL041,
+		GL042,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -43,6 +43,7 @@ var cweIDs = map[string]string{
 	"GL039": "CWE-390",
 	"GL040": "CWE-319",
 	"GL041": "CWE-1104",
+	"GL042": "CWE-295",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl042.go
+++ b/rules/gl042.go
@@ -1,0 +1,158 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl042 struct{}
+
+var GL042 = &gl042{}
+
+func (r *gl042) ID() string { return "GL042" }
+
+type tlsCheck struct {
+	tool string
+	re   *regexp.Regexp
+	msg  string
+}
+
+var tlsChecks = []tlsCheck{
+	{
+		tool: "curl",
+		re:   regexp.MustCompile(`\bcurl\b.*\s(?:-k|--insecure)\b`),
+		msg:  `curl invoked with "%s" — TLS certificate verification disabled; use --cacert to trust a specific CA instead`,
+	},
+	{
+		tool: "wget",
+		re:   regexp.MustCompile(`\bwget\b.*--no-check-certificate\b`),
+		msg:  `wget invoked with "--no-check-certificate" — TLS certificate verification disabled; add the CA certificate to the system trust store instead`,
+	},
+	{
+		tool: "git",
+		re:   regexp.MustCompile(`\bgit\b.*-c\s+http\.sslVerify\s*=\s*false\b`),
+		msg:  `git invoked with "http.sslVerify=false" — TLS certificate verification disabled; configure the CA with http.sslCAInfo instead`,
+	},
+	{
+		tool: "npm",
+		re:   regexp.MustCompile(`\bnpm\b.*--strict-ssl\s*=?\s*false\b`),
+		msg:  `npm invoked with "--strict-ssl=false" — TLS certificate verification disabled; use cafile in .npmrc to trust a specific CA instead`,
+	},
+	{
+		tool: "npm config",
+		re:   regexp.MustCompile(`\bnpm\s+(?:config\s+set|set)\s+strict-ssl\s+false\b`),
+		msg:  `npm strict-ssl disabled via "npm config set" — TLS certificate verification disabled for all subsequent npm commands`,
+	},
+}
+
+// gitSSLNoVerifyRe matches GIT_SSL_NO_VERIFY=true/1 as a variable export or inline env.
+var gitSSLNoVerifyRe = regexp.MustCompile(`\bGIT_SSL_NO_VERIFY\s*=\s*(?:true|1)\b`)
+
+func (r *gl042) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	// Check GIT_SSL_NO_VERIFY in top-level variables block
+	if vars := parser.FindKey(mapping, "variables"); vars != nil {
+		findings = append(findings, checkGitSSLNoVerifyVars(vars, file, "")...)
+	}
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, checkTLSLines(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkTLSLines(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if vars := parser.FindKey(job, "variables"); vars != nil {
+			findings = append(findings, checkGitSSLNoVerifyVars(vars, file, name.Value)...)
+		}
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				findings = append(findings, checkTLSLines(node, file, name.Value)...)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkTLSLines(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		for _, check := range tlsChecks {
+			m := check.re.FindString(item.Value)
+			if m == "" {
+				continue
+			}
+			msg := check.msg
+			if check.tool == "curl" {
+				flag := regexp.MustCompile(`-k|--insecure`).FindString(m)
+				msg = fmt.Sprintf(msg, flag)
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL042",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  msg,
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+			break
+		}
+
+		if gitSSLNoVerifyRe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL042",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  `GIT_SSL_NO_VERIFY=true in script — TLS certificate verification disabled for all git operations in this step`,
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}
+
+func checkGitSSLNoVerifyVars(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		val := node.Content[i+1]
+		if key.Value == "GIT_SSL_NO_VERIFY" && (val.Value == "true" || val.Value == "1") {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL042",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  `GIT_SSL_NO_VERIFY set to "true" in variables — TLS certificate verification disabled for all git operations in affected jobs`,
+				File:     file,
+				Line:     key.Line,
+				Col:      key.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl042_test.go
+++ b/rules/gl042_test.go
@@ -1,0 +1,136 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func TestGL042(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantHits int
+	}{
+		{
+			name: "curl -k",
+			yaml: `build:
+  script:
+    - curl -k https://internal.example.com/artifact.tar.gz`,
+			wantHits: 1,
+		},
+		{
+			name: "curl --insecure",
+			yaml: `build:
+  script:
+    - curl --insecure https://internal.example.com/artifact.tar.gz`,
+			wantHits: 1,
+		},
+		{
+			name: "wget --no-check-certificate",
+			yaml: `build:
+  script:
+    - wget --no-check-certificate https://internal.example.com/file.zip`,
+			wantHits: 1,
+		},
+		{
+			name: "git with http.sslVerify=false",
+			yaml: `build:
+  script:
+    - git -c http.sslVerify=false clone https://gitlab.example.com/org/repo.git`,
+			wantHits: 1,
+		},
+		{
+			name: "npm --strict-ssl=false",
+			yaml: `build:
+  script:
+    - npm install --strict-ssl=false`,
+			wantHits: 1,
+		},
+		{
+			name: "npm config set strict-ssl false",
+			yaml: `build:
+  script:
+    - npm config set strict-ssl false
+    - npm install`,
+			wantHits: 1,
+		},
+		{
+			name: "GIT_SSL_NO_VERIFY inline in script",
+			yaml: `build:
+  script:
+    - GIT_SSL_NO_VERIFY=true git clone https://gitlab.example.com/org/repo.git`,
+			wantHits: 1,
+		},
+		{
+			name: "GIT_SSL_NO_VERIFY in variables block",
+			yaml: `variables:
+  GIT_SSL_NO_VERIFY: "true"
+
+build:
+  script:
+    - git clone https://gitlab.example.com/org/repo.git`,
+			wantHits: 1,
+		},
+		{
+			name: "GIT_SSL_NO_VERIFY in job variables",
+			yaml: `build:
+  variables:
+    GIT_SSL_NO_VERIFY: "1"
+  script:
+    - git clone https://gitlab.example.com/org/repo.git`,
+			wantHits: 1,
+		},
+		{
+			name: "curl without -k — safe",
+			yaml: `build:
+  script:
+    - curl https://example.com/file.tar.gz`,
+			wantHits: 0,
+		},
+		{
+			name: "curl with --cacert — safe",
+			yaml: `build:
+  script:
+    - curl --cacert /etc/ssl/certs/internal-ca.crt https://internal.example.com/file`,
+			wantHits: 0,
+		},
+		{
+			name: "wget without --no-check-certificate — safe",
+			yaml: `build:
+  script:
+    - wget https://example.com/file.zip`,
+			wantHits: 0,
+		},
+		{
+			name: "multiple violations",
+			yaml: `build:
+  script:
+    - curl -k https://internal.example.com/a.tar.gz
+    - wget --no-check-certificate https://internal.example.com/b.zip`,
+			wantHits: 2,
+		},
+		{
+			name: "before_script at top level",
+			yaml: `before_script:
+  - curl -k https://internal.example.com/setup.sh | bash`,
+			wantHits: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := parser.Parse([]byte(tt.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			findings := GL042.Check(doc.Root, "test.yml")
+			if len(findings) != tt.wantHits {
+				t.Errorf("got %d findings, want %d", len(findings), tt.wantHits)
+				for _, f := range findings {
+					t.Logf("  finding: %s", f.Message)
+				}
+			}
+		})
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -44,6 +44,7 @@ var owaspCategories = map[string][]string{
 	"GL039": {"CICD-SEC-1"},
 	"GL040": {"CICD-SEC-6"},
 	"GL041": {"CICD-SEC-4", "CICD-SEC-8"},
+	"GL042": {"CICD-SEC-7"},
 }
 
 // OWASPCategories returns the OWASP CI/CD security categories for a rule ID.

--- a/testdata/fixtures/gl042-tls-verification-disabled.yml
+++ b/testdata/fixtures/gl042-tls-verification-disabled.yml
@@ -1,0 +1,3 @@
+build:
+  script:
+    - curl -k https://internal.example.com/artifact.tar.gz


### PR DESCRIPTION
Closes #141

## What changed

Adds **GL042** — a `warn`-severity rule that flags commands and variable assignments that explicitly disable TLS certificate verification in CI scripts.

### Detected patterns

| Tool | Pattern |
|------|---------|
| `curl` | `-k`, `--insecure` |
| `wget` | `--no-check-certificate` |
| `git` | `-c http.sslVerify=false` |
| `npm` | `--strict-ssl=false`, `npm config set strict-ssl false` |
| env var | `GIT_SSL_NO_VERIFY=true/1` in `variables:` or inline in script |

`GIT_SSL_NO_VERIFY` is checked both in `variables:` blocks (top-level and job-level) and as inline env assignments in script lines.

### Why

On shared or self-hosted runners, disabling TLS verification enables MITM attacks — an attacker on the runner network can silently replace downloaded artifacts or git repository content. The root cause is almost always an internal self-signed CA; the fix is to distribute the CA certificate rather than disabling verification globally.

## Files

| File | Purpose |
|------|---------|
| `rules/gl042.go` | Rule implementation |
| `rules/gl042_test.go` | 14 unit test cases |
| `testdata/fixtures/gl042-tls-verification-disabled.yml` | Consistency-test fixture |
| `docs/rules/GL042.md` | Rule documentation with safe alternatives |
| `docs/rules.md` | Entry in Insecure Configuration section |
| `README.md` | Updated count (41→42) and category table |
| `rules/all.go`, `owasp.go`, `cwe.go` | Registrations |

## How to test

```sh
go test ./rules/ -run TestGL042 -v
go test ./rules/ -run TestRuleConsistency
go test ./...
```