### PR TITLE
feat: surface OWASP categories in JSON/SARIF output and fix mapping consistency

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -157,9 +157,12 @@ func main() {
 	}
 
 	var writeErr error
-	if format == output.FormatSARIF {
-		writeErr = output.WriteSARIF(os.Stdout, findings, rules.CWEID, rules.CWEName)
-	} else {
+	switch format {
+	case output.FormatSARIF:
+		writeErr = output.WriteSARIF(os.Stdout, findings, rules.CWEID, rules.CWEName, rules.OWASPCategories, rules.OWASPCategoryName)
+	case output.FormatJSON:
+		writeErr = output.WriteJSON(os.Stdout, findings, rules.OWASPCategories)
+	default:
 		writeErr = output.Write(os.Stdout, format, findings)
 	}
 	if err := writeErr; err != nil {

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -10,7 +10,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 
 | ID | Severity | Description |
 |----|----------|-------------|
-| [GL002](rules/GL002.md) | `warn`  | User-controlled CI variable used unquoted in script |
+| [GL005](rules/GL005.md) | `warn`  | Sensitive file patterns in `artifacts:` paths |
 | [GL027](rules/GL027.md) | `warn`  | Secret-like variable defined without `masked: true` |
 | [GL004](rules/GL004.md) | `warn`  | `CI_JOB_TOKEN` forwarded to a non-GitLab host |
 | [GL006](rules/GL006.md) | `error` | Hardcoded secret in `variables:` block |
@@ -25,6 +25,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL029](rules/GL029.md) | `warn`  | `docker login -p` exposes password in process table — use `--password-stdin` instead |
 | [GL035](rules/GL035.md) | `warn`  | `git` command uses URL with embedded credentials (`user:token@host`) — token appears in job logs |
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |
+| [GL040](rules/GL040.md) | `warn`  | Script uses plain `ftp://` — credentials and content transmitted unencrypted |
 
 ---
 
@@ -36,19 +37,24 @@ Mutable references that allow silent substitution of images, templates, or packa
 |----|----------|-------------|
 | [GL001](rules/GL001.md) | `error` | Mutable image tag (`latest`, no tag, non-digest pin) |
 | [GL003](rules/GL003.md) | `error` | Remote `include:` with mutable or missing `ref` |
-| [GL015](rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
+| [GL011](rules/GL011.md) | `error` | Download-and-execute pattern in script (`curl \| bash`, `wget \| sh`) |
+| [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL022](rules/GL022.md) | `warn`  | Package manager install without version pin or explicit update-to-latest in CI |
 | [GL023](rules/GL023.md) | `warn`  | Lockfile not enforced (`npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, etc.) |
 | [GL026](rules/GL026.md) | `warn`  | `git clone`/`checkout` uses a mutable ref (branch or tag) instead of a pinned commit SHA |
 
 ---
 
-## Component & Third-Party Integrity — [CICD-SEC-4](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) / [CICD-SEC-8](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-08-Ungoverned-Usage-of-3rd-Party-Services)
+## Poisoned Pipeline Execution — [CICD-SEC-4](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) / [CICD-SEC-8](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-08-Ungoverned-Usage-of-3rd-Party-Services)
 
-Mutable or unversioned component includes that allow silent substitution of pipeline templates.
+User-controlled inputs and unversioned component references that allow malicious code to run inside the pipeline.
 
 | ID | Severity | Description |
 |----|----------|-------------|
+| [GL002](rules/GL002.md) | `warn`  | User-controlled CI variable used unquoted in script |
+| [GL007](rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
+| [GL015](rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
+| [GL025](rules/GL025.md) | `warn`  | `curl`/`wget` uses a user-controlled CI variable — attacker can redirect the request to an arbitrary host |
 | [GL041](rules/GL041.md) | `warn`  | `include: component:` without a pinned semver tag or commit SHA |
 
 ---
@@ -59,9 +65,7 @@ Downloads and executions that bypass integrity checks, enabling tampering mid-pi
 
 | ID | Severity | Description |
 |----|----------|-------------|
-| [GL011](rules/GL011.md) | `error` | Download-and-execute pattern in script (`curl \| bash`, `wget \| sh`) |
 | [GL020](rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
-| [GL025](rules/GL025.md) | `warn`  | `curl`/`wget` uses a user-controlled CI variable — attacker can redirect the request to an arbitrary host |
 
 ---
 
@@ -72,13 +76,13 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | ID | Severity | Description |
 |----|----------|-------------|
 | [GL008](rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
+| [GL012](rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
+| [GL013](rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |
+| [GL019](rules/GL019.md) | `warn`  | Deploy/publish job has no `resource_group:` — concurrent runs risk race conditions or partial deploys |
 | [GL034](rules/GL034.md) | `warn`  | `trigger:` job without `strategy: depend` — child pipeline failures are silently ignored |
 | [GL039](rules/GL039.md) | `warn`  | Security audit tool silenced with `\|\| true` — failures discarded, pipeline always green |
 | [GL009](rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
-| [GL012](rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
-| [GL013](rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |
 | [GL017](rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
-| [GL019](rules/GL019.md) | `warn`  | Deploy/publish job has no `resource_group:` — concurrent runs risk race conditions or partial deploys |
 
 ---
 
@@ -88,10 +92,6 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 
 | ID | Severity | Description |
 |----|----------|-------------|
-| [GL005](rules/GL005.md) | `warn`  | Sensitive file patterns in `artifacts:` or missing `expire_in` |
-| [GL007](rules/GL007.md) | `error` | CI variable interpolation in `image:` reference |
-| [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
-| [GL040](rules/GL040.md) | `warn`  | Script uses plain `ftp://` — credentials and content transmitted unencrypted |
 | [GL024](rules/GL024.md) | `warn`  | Shell pipe without `set -o pipefail` — failures in all but the last command are silently ignored |
 | [GL028](rules/GL028.md) | `warn`  | `artifacts: untracked: true` without `paths:` or `exclude:` may archive `.env`, keys, and other sensitive files |
 | [GL030](rules/GL030.md) | `warn`  | `ssh-keyscan` at runtime blindly trusts the remote host key — MITM risk on shared runner networks |

--- a/docs/rules/GL001.md
+++ b/docs/rules/GL001.md
@@ -1,7 +1,7 @@
 # GL001 — Mutable image tag
 
 **Severity:** `error`  
-**OWASP:** CICD-SEC-3 (Dependency Chain Abuse)  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)  
 **zizmor analogue:** `unpinned-images`
 
 ## Risk

--- a/docs/rules/GL002.md
+++ b/docs/rules/GL002.md
@@ -1,7 +1,7 @@
 # GL002 — Variable injection
 
 **Severity:** `warn`  
-**OWASP:** CICD-SEC-4 (Poisoned Pipeline Execution)  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)  
 **zizmor analogue:** `template-injection`
 
 ## Risk

--- a/docs/rules/GL003.md
+++ b/docs/rules/GL003.md
@@ -1,7 +1,7 @@
 # GL003 — Unpinned include ref
 
 **Severity:** `error`  
-**OWASP:** CICD-SEC-3 (Dependency Chain Abuse), CICD-SEC-8 (Ungoverned Usage of 3rd Party Services)  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)  
 **zizmor analogue:** `unpinned-uses`
 
 ## Risk

--- a/docs/rules/GL004.md
+++ b/docs/rules/GL004.md
@@ -1,7 +1,7 @@
 # GL004 — CI_JOB_TOKEN exfiltration
 
 **Severity:** `warn`  
-**OWASP:** CICD-SEC-6 (Insufficient Credential Hygiene)
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
 
 ## Risk
 

--- a/docs/rules/GL005.md
+++ b/docs/rules/GL005.md
@@ -1,7 +1,7 @@
 # GL005 — Sensitive artifacts
 
 **Severity:** `warn`  
-**OWASP:** CICD-SEC-6 (Insufficient Credential Hygiene)  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
 **zizmor analogue:** `artipacked`
 
 ## Risk

--- a/docs/rules/GL009.md
+++ b/docs/rules/GL009.md
@@ -2,7 +2,7 @@
 
 **Severity:** warn  
 **Minimum GitLab version:** 15.7 (`id_tokens:` was introduced in 15.7)  
-**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+**OWASP:** [CICD-SEC-5 – Insufficient PBAC](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)
 
 ## What glsec checks
 

--- a/docs/rules/GL010.md
+++ b/docs/rules/GL010.md
@@ -2,7 +2,7 @@
 
 **Severity:** warn  
 **Minimum GitLab version:** 14.9 (`trigger: forward:` was introduced in 14.9)  
-**OWASP:** [CICD-SEC-5 – Insufficient PBAC (Pipeline-Based Access Controls)](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
 
 ## What glsec checks
 

--- a/docs/rules/GL013.md
+++ b/docs/rules/GL013.md
@@ -1,7 +1,7 @@
 # GL013 — Production deploy job without branch restriction
 
 **Severity:** warn  
-**OWASP:** [CICD-SEC-5 – Insufficient PBAC (Pipeline-Based Access Controls)](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
 
 ## What glsec checks
 

--- a/docs/rules/GL017.md
+++ b/docs/rules/GL017.md
@@ -1,7 +1,7 @@
 # GL017 — Deploy/publish job has no `tags:` restriction
 
 **Severity:** `warn`  
-**OWASP:** [CICD-SEC-9 – Improper Artifact Integrity Validation](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation)
+**OWASP:** [CICD-SEC-5 – Insufficient PBAC](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)
 
 ## What glsec checks
 

--- a/docs/rules/GL019.md
+++ b/docs/rules/GL019.md
@@ -1,7 +1,7 @@
 # GL019 — Deploy job missing `resource_group:`
 
 **Severity:** `warn`  
-**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
 
 ## What glsec checks
 

--- a/docs/rules/GL020.md
+++ b/docs/rules/GL020.md
@@ -1,7 +1,7 @@
 # GL020 — Downloaded file without checksum verification
 
 **Severity:** `warn`  
-**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+**OWASP:** [CICD-SEC-9 – Improper Artifact Integrity Validation](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation)
 
 ## What glsec checks
 

--- a/docs/rules/GL024.md
+++ b/docs/rules/GL024.md
@@ -1,7 +1,7 @@
 # GL024 — Shell pipe without `set -o pipefail`
 
 **Severity:** `warn`  
-**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)
 
 ## What glsec checks
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -29,9 +29,9 @@ func ParseFormat(s string) (Format, bool) {
 func Write(w io.Writer, format Format, findings []finding.Finding) error {
 	switch format {
 	case FormatJSON:
-		return writeJSON(w, findings)
+		return writeJSON(w, findings, nil)
 	case FormatSARIF:
-		return writeSARIF(w, findings, nil, nil)
+		return writeSARIF(w, findings, nil, nil, nil, nil)
 	default:
 		return writeText(w, findings)
 	}
@@ -64,29 +64,40 @@ func writeText(w io.Writer, findings []finding.Finding) error {
 }
 
 type jsonFinding struct {
-	Rule     string `json:"rule"`
-	Severity string `json:"severity"`
-	Job      string `json:"job,omitempty"`
-	File     string `json:"file"`
-	Line     int    `json:"line"`
-	Message  string `json:"message"`
+	Rule     string   `json:"rule"`
+	Severity string   `json:"severity"`
+	Job      string   `json:"job,omitempty"`
+	File     string   `json:"file"`
+	Line     int      `json:"line"`
+	Message  string   `json:"message"`
+	OWASP    []string `json:"owasp,omitempty"`
 }
 
 type jsonOutput struct {
 	Findings []jsonFinding `json:"findings"`
 }
 
-func writeJSON(w io.Writer, findings []finding.Finding) error {
+// WriteJSON writes findings as JSON. owasp, if non-nil, is called per finding
+// to populate the "owasp" field with category IDs.
+func WriteJSON(w io.Writer, findings []finding.Finding, owasp func(string) []string) error {
+	return writeJSON(w, findings, owasp)
+}
+
+func writeJSON(w io.Writer, findings []finding.Finding, owasp func(string) []string) error {
 	out := jsonOutput{Findings: make([]jsonFinding, 0, len(findings))}
 	for _, f := range findings {
-		out.Findings = append(out.Findings, jsonFinding{
+		jf := jsonFinding{
 			Rule:     f.RuleID,
 			Severity: string(f.Severity),
 			Job:      f.Job,
 			File:     f.File,
 			Line:     f.Line,
 			Message:  f.Message,
-		})
+		}
+		if owasp != nil {
+			jf.OWASP = owasp(f.RuleID)
+		}
+		out.Findings = append(out.Findings, jf)
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -186,15 +197,23 @@ func severityToSARIFLevel(s finding.Severity) string {
 	}
 }
 
-// WriteSARIF writes SARIF output enriched with CWE metadata.
+// WriteSARIF writes SARIF output enriched with CWE and OWASP metadata.
 // cweID maps a rule ID to its CWE identifier (e.g. "CWE-798").
 // cweName maps a CWE identifier to its human-readable name.
-// Pass nil for either to omit CWE data.
-func WriteSARIF(w io.Writer, findings []finding.Finding, cweID func(string) string, cweName func(string) string) error {
-	return writeSARIF(w, findings, cweID, cweName)
+// owasp maps a rule ID to its OWASP CI/CD Security Risks categories.
+// owaspName maps an OWASP category ID to its human-readable name.
+// Pass nil for any parameter to omit that taxonomy.
+func WriteSARIF(w io.Writer, findings []finding.Finding,
+	cweID func(string) string, cweName func(string) string,
+	owasp func(string) []string, owaspName func(string) string,
+) error {
+	return writeSARIF(w, findings, cweID, cweName, owasp, owaspName)
 }
 
-func writeSARIF(w io.Writer, findings []finding.Finding, cweID func(string) string, cweName func(string) string) error {
+func writeSARIF(w io.Writer, findings []finding.Finding,
+	cweID func(string) string, cweName func(string) string,
+	owasp func(string) []string, owaspName func(string) string,
+) error {
 	results := make([]sarifResult, 0, len(findings))
 	for _, f := range findings {
 		results = append(results, sarifResult{
@@ -218,42 +237,63 @@ func writeSARIF(w io.Writer, findings []finding.Finding, cweID func(string) stri
 		Results: results,
 	}
 
-	if cweID != nil && cweName != nil {
-		seenRules := map[string]bool{}
-		seenCWEs := map[string]bool{}
-		for _, f := range findings {
-			if seenRules[f.RuleID] {
-				continue
+	seenRules := map[string]bool{}
+	seenCWEs := map[string]bool{}
+	seenOWASP := map[string]bool{}
+
+	for _, f := range findings {
+		if seenRules[f.RuleID] {
+			continue
+		}
+		seenRules[f.RuleID] = true
+
+		var rels []sarifRelationship
+
+		if cweID != nil {
+			if cwe := cweID(f.RuleID); cwe != "" {
+				rels = append(rels, sarifRelationship{
+					Target: sarifRelationshipTarget{ID: cwe, ToolComponent: sarifToolComponentRef{Name: "CWE"}},
+					Kinds:  []string{"superset"},
+				})
+				seenCWEs[cwe] = true
 			}
-			seenRules[f.RuleID] = true
-			cwe := cweID(f.RuleID)
-			if cwe == "" {
-				continue
+		}
+
+		if owasp != nil {
+			for _, cat := range owasp(f.RuleID) {
+				rels = append(rels, sarifRelationship{
+					Target: sarifRelationshipTarget{ID: cat, ToolComponent: sarifToolComponentRef{Name: "OWASP Top 10 CI/CD Security Risks"}},
+					Kinds:  []string{"superset"},
+				})
+				seenOWASP[cat] = true
 			}
+		}
+
+		if len(rels) > 0 {
 			run.Tool.Driver.Rules = append(run.Tool.Driver.Rules, sarifRule{
-				ID: f.RuleID,
-				Relationships: []sarifRelationship{{
-					Target: sarifRelationshipTarget{
-						ID:            cwe,
-						ToolComponent: sarifToolComponentRef{Name: "CWE"},
-					},
-					Kinds: []string{"superset"},
-				}},
+				ID: f.RuleID, Relationships: rels,
 			})
-			seenCWEs[cwe] = true
 		}
-		if len(seenCWEs) > 0 {
-			taxa := make([]sarifTaxon, 0, len(seenCWEs))
-			for cwe := range seenCWEs {
-				taxa = append(taxa, sarifTaxon{ID: cwe, Name: cweName(cwe)})
-			}
-			run.Taxonomies = []sarifTaxonomy{{
-				Name:         "CWE",
-				Version:      "4.14",
-				Organization: "MITRE",
-				Taxa:         taxa,
-			}}
+	}
+
+	if len(seenCWEs) > 0 && cweName != nil {
+		taxa := make([]sarifTaxon, 0, len(seenCWEs))
+		for cwe := range seenCWEs {
+			taxa = append(taxa, sarifTaxon{ID: cwe, Name: cweName(cwe)})
 		}
+		run.Taxonomies = append(run.Taxonomies, sarifTaxonomy{
+			Name: "CWE", Version: "4.14", Organization: "MITRE", Taxa: taxa,
+		})
+	}
+
+	if len(seenOWASP) > 0 && owaspName != nil {
+		taxa := make([]sarifTaxon, 0, len(seenOWASP))
+		for cat := range seenOWASP {
+			taxa = append(taxa, sarifTaxon{ID: cat, Name: owaspName(cat)})
+		}
+		run.Taxonomies = append(run.Taxonomies, sarifTaxonomy{
+			Name: "OWASP Top 10 CI/CD Security Risks", Version: "2022", Organization: "OWASP", Taxa: taxa,
+		})
 	}
 
 	log := sarifLog{

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -184,7 +184,7 @@ func TestWriteSARIF_WithCWE(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteSARIF(&buf, testFindings, cweID, cweName); err != nil {
+	if err := WriteSARIF(&buf, testFindings, cweID, cweName, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -215,7 +215,7 @@ func TestWriteSARIF_WithCWE(t *testing.T) {
 
 func TestWriteSARIF_NoCWE(t *testing.T) {
 	var buf bytes.Buffer
-	if err := WriteSARIF(&buf, testFindings, nil, nil); err != nil {
+	if err := WriteSARIF(&buf, testFindings, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -227,5 +227,71 @@ func TestWriteSARIF_NoCWE(t *testing.T) {
 	}
 	if len(log.Runs[0].Taxonomies) != 0 {
 		t.Error("expected no taxonomies when CWE lookup is nil")
+	}
+}
+
+func TestWriteJSON_WithOWASP(t *testing.T) {
+	owasp := func(id string) []string {
+		if id == "GL001" {
+			return []string{"CICD-SEC-3"}
+		}
+		return []string{"CICD-SEC-6"}
+	}
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, testFindings, owasp); err != nil {
+		t.Fatal(err)
+	}
+	var out jsonOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(out.Findings[0].OWASP) != 1 || out.Findings[0].OWASP[0] != "CICD-SEC-3" {
+		t.Errorf("unexpected OWASP for GL001: %v", out.Findings[0].OWASP)
+	}
+	if len(out.Findings[1].OWASP) != 1 || out.Findings[1].OWASP[0] != "CICD-SEC-6" {
+		t.Errorf("unexpected OWASP for GL002: %v", out.Findings[1].OWASP)
+	}
+}
+
+func TestWriteSARIF_WithOWASP(t *testing.T) {
+	owasp := func(id string) []string {
+		if id == "GL001" {
+			return []string{"CICD-SEC-3"}
+		}
+		return nil
+	}
+	owaspName := func(id string) string {
+		if id == "CICD-SEC-3" {
+			return "Dependency Chain Abuse"
+		}
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, testFindings, nil, nil, owasp, owaspName); err != nil {
+		t.Fatal(err)
+	}
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid SARIF JSON: %v", err)
+	}
+	run := log.Runs[0]
+	if len(run.Tool.Driver.Rules) != 1 {
+		t.Fatalf("expected 1 rule descriptor (GL001 has OWASP, GL002 does not), got %d", len(run.Tool.Driver.Rules))
+	}
+	rule := run.Tool.Driver.Rules[0]
+	if rule.ID != "GL001" {
+		t.Errorf("expected rule GL001, got %q", rule.ID)
+	}
+	if len(rule.Relationships) != 1 || rule.Relationships[0].Target.ID != "CICD-SEC-3" {
+		t.Errorf("unexpected OWASP relationship: %+v", rule.Relationships)
+	}
+	if rule.Relationships[0].Target.ToolComponent.Name != "OWASP Top 10 CI/CD Security Risks" {
+		t.Errorf("unexpected tool component name: %q", rule.Relationships[0].Target.ToolComponent.Name)
+	}
+	if len(run.Taxonomies) != 1 || run.Taxonomies[0].Name != "OWASP Top 10 CI/CD Security Risks" {
+		t.Fatalf("expected OWASP taxonomy, got %+v", run.Taxonomies)
+	}
+	if len(run.Taxonomies[0].Taxa) != 1 || run.Taxonomies[0].Taxa[0].ID != "CICD-SEC-3" {
+		t.Errorf("unexpected taxa: %+v", run.Taxonomies[0].Taxa)
 	}
 }

--- a/rules/consistency_test.go
+++ b/rules/consistency_test.go
@@ -33,6 +33,7 @@ func TestRuleConsistency(t *testing.T) {
 			checkOWASPMapping(t, id)
 			checkCWEMapping(t, id)
 			checkRulesOverviewLink(t, id, rulesOverview)
+			checkRulesOverviewSection(t, id, rulesOverview, OWASPCategories(id))
 		})
 	}
 }
@@ -104,8 +105,76 @@ func checkFixtureFires(t *testing.T, id string) {
 
 func checkOWASPMapping(t *testing.T, id string) {
 	t.Helper()
-	if len(OWASPCategories(id)) == 0 {
+	cats := OWASPCategories(id)
+	if len(cats) == 0 {
 		t.Errorf("no OWASP category mapping for %s (add to rules/owasp.go)", id)
+		return
+	}
+	checkDocOWASPMatchesMap(t, id, cats)
+}
+
+var owaspLineURLPat = regexp.MustCompile(`\]\([^)]*\)`)
+var owaspCatPat = regexp.MustCompile(`CICD-SEC-([1-9][0-9]?)\b`)
+
+func checkDocOWASPMatchesMap(t *testing.T, id string, expected []string) {
+	t.Helper()
+	path := filepath.Join("..", "docs", "rules", id+".md")
+	content, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return // missing doc is already caught by checkDocFile
+	}
+	owaspLine := ""
+	for _, l := range strings.Split(string(content), "\n") {
+		if strings.Contains(l, "**OWASP:**") {
+			owaspLine = l
+			break
+		}
+	}
+	if owaspLine == "" {
+		t.Errorf("%s: no **OWASP:** line in doc", id)
+		return
+	}
+	// Strip URL portions so CICD-SEC-06 in a URL doesn't count as a category.
+	stripped := owaspLineURLPat.ReplaceAllString(owaspLine, "")
+	var got []string
+	for _, m := range owaspCatPat.FindAllStringSubmatch(stripped, -1) {
+		got = append(got, fmt.Sprintf("CICD-SEC-%s", m[1]))
+	}
+	if fmt.Sprint(got) != fmt.Sprint(expected) {
+		t.Errorf("%s: doc OWASP %v does not match owasp.go map %v", id, got, expected)
+	}
+}
+
+func checkRulesOverviewSection(t *testing.T, id string, overview string, expected []string) {
+	t.Helper()
+	// Find the section header line(s) that this rule's link falls under.
+	// A section starts with "## " and contains a CICD-SEC-N link.
+	sectionCatPat := regexp.MustCompile(`\[CICD-SEC-([1-9][0-9]?)\]`)
+	ruleLink := fmt.Sprintf("[%s](rules/%s.md)", id, id)
+	lines := strings.Split(overview, "\n")
+	var currentCats []string
+	for _, l := range lines {
+		if strings.HasPrefix(l, "## ") {
+			currentCats = nil
+			for _, m := range sectionCatPat.FindAllStringSubmatch(l, -1) {
+				currentCats = append(currentCats, fmt.Sprintf("CICD-SEC-%s", m[1]))
+			}
+		}
+		if strings.Contains(l, ruleLink) {
+			for _, cat := range expected {
+				found := false
+				for _, sc := range currentCats {
+					if sc == cat {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("%s: in rules.md section %v but owasp.go map says %v", id, currentCats, expected)
+				}
+			}
+			return
+		}
 	}
 }
 

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -4,21 +4,21 @@ package rules
 // addresses. A rule may belong to more than one category.
 var owaspCategories = map[string][]string{
 	"GL001": {"CICD-SEC-3"},
-	"GL002": {"CICD-SEC-6"},
+	"GL002": {"CICD-SEC-4"},
 	"GL003": {"CICD-SEC-3"},
 	"GL004": {"CICD-SEC-6"},
-	"GL005": {"CICD-SEC-7"},
+	"GL005": {"CICD-SEC-6"},
 	"GL006": {"CICD-SEC-6"},
-	"GL007": {"CICD-SEC-7"},
+	"GL007": {"CICD-SEC-4"},
 	"GL008": {"CICD-SEC-1"},
 	"GL009": {"CICD-SEC-5"},
 	"GL010": {"CICD-SEC-6"},
-	"GL011": {"CICD-SEC-9"},
+	"GL011": {"CICD-SEC-3"},
 	"GL012": {"CICD-SEC-1"},
 	"GL013": {"CICD-SEC-1"},
 	"GL014": {"CICD-SEC-6"},
-	"GL015": {"CICD-SEC-3"},
-	"GL016": {"CICD-SEC-7"},
+	"GL015": {"CICD-SEC-4"},
+	"GL016": {"CICD-SEC-3"},
 	"GL017": {"CICD-SEC-5"},
 	"GL018": {"CICD-SEC-6"},
 	"GL019": {"CICD-SEC-1"},
@@ -27,7 +27,7 @@ var owaspCategories = map[string][]string{
 	"GL022": {"CICD-SEC-3"},
 	"GL023": {"CICD-SEC-3"},
 	"GL024": {"CICD-SEC-7"},
-	"GL025": {"CICD-SEC-9"},
+	"GL025": {"CICD-SEC-4"},
 	"GL026": {"CICD-SEC-3"},
 	"GL027": {"CICD-SEC-6"},
 	"GL028": {"CICD-SEC-7"},
@@ -47,7 +47,26 @@ var owaspCategories = map[string][]string{
 	"GL042": {"CICD-SEC-7"},
 }
 
+// owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.
+var owaspCategoryNames = map[string]string{
+	"CICD-SEC-1":  "Insufficient Flow Control Mechanisms",
+	"CICD-SEC-2":  "Inadequate Identity and Access Management",
+	"CICD-SEC-3":  "Dependency Chain Abuse",
+	"CICD-SEC-4":  "Poisoned Pipeline Execution",
+	"CICD-SEC-5":  "Insufficient PBAC",
+	"CICD-SEC-6":  "Insufficient Credential Hygiene",
+	"CICD-SEC-7":  "Insecure System Configuration",
+	"CICD-SEC-8":  "Ungoverned Usage of 3rd-Party Services",
+	"CICD-SEC-9":  "Improper Artifact Integrity Validation",
+	"CICD-SEC-10": "Insufficient Logging and Visibility",
+}
+
 // OWASPCategories returns the OWASP CI/CD security categories for a rule ID.
 func OWASPCategories(id string) []string {
 	return owaspCategories[id]
+}
+
+// OWASPCategoryName returns the human-readable name for an OWASP category ID.
+func OWASPCategoryName(id string) string {
+	return owaspCategoryNames[id]
 }


### PR DESCRIPTION
Closes #144

## What changed

### OWASP in output formats
- JSON output now includes an `owasp` array per finding (e.g. `["CICD-SEC-4"]`) when glsec is invoked with `-format json`
- SARIF output now emits an `OWASP Top 10 CI/CD Security Risks` taxonomy alongside the existing CWE taxonomy, with per-rule relationships
- New exported `output.WriteJSON(w, findings, owaspFn)` function — mirrors the existing `WriteSARIF` pattern
- `output.WriteSARIF` gains two additional parameters: `owasp func(string) []string` and `owaspName func(string) string`
- `rules.OWASPCategoryName(id)` added, parallel to `rules.CWEName`

### OWASP mapping corrections
Audited all 42 rules across three sources — `owasp.go`, individual `docs/rules/GL***.md`, and `docs/rules.md` — and resolved every inconsistency:

| Rule | Was | Now | Rationale |
|------|-----|-----|-----------|
| GL002 | CICD-SEC-6 | CICD-SEC-4 | Variable injection into script is PPE, not credential hygiene |
| GL005 | CICD-SEC-7 | CICD-SEC-6 | Sensitive artifact paths leak credentials |
| GL007 | CICD-SEC-7 | CICD-SEC-4 | User-controlled image reference = PPE |
| GL009 | CICD-SEC-6 (doc) | CICD-SEC-5 | Overly broad OIDC audience is an access-control issue |
| GL010 | CICD-SEC-5 (doc) | CICD-SEC-6 | Forwarding secrets downstream is credential hygiene |
| GL011 | CICD-SEC-9 | CICD-SEC-3 | `curl \| bash` is the canonical dependency chain abuse pattern |
| GL013 | CICD-SEC-5 (doc) | CICD-SEC-1 | No branch restriction = insufficient flow control |
| GL015 | CICD-SEC-3 | CICD-SEC-4 | User-controlled image tag = PPE |
| GL016 | CICD-SEC-7 | CICD-SEC-3 | HTTP downloads are MITM-able → dependency chain abuse |
| GL017 | CICD-SEC-9 (doc) | CICD-SEC-5 | Any runner can execute the deploy job = insufficient PBAC |
| GL019 | CICD-SEC-4 (doc) | CICD-SEC-1 | Missing `resource_group` → concurrent deploys = flow control |
| GL020 | CICD-SEC-3 (doc) | CICD-SEC-9 | No checksum verification = artifact integrity |
| GL024 | CICD-SEC-4 (doc) | CICD-SEC-7 | Missing `pipefail` is a shell configuration issue |
| GL025 | CICD-SEC-9 | CICD-SEC-4 | Attacker-controlled URL in curl/wget = PPE |

`docs/rules.md` reorganised to match: GL002/GL007/GL015/GL025 moved to the PPE section, GL005/GL010/GL040 to Credential Hygiene, GL011/GL016 to Dependency Pinning; the old "Component & Third-Party Integrity" section renamed to "Poisoned Pipeline Execution".

GL001–GL005 doc headers updated from plain-text OWASP format to link format. GL003 reduced from two categories to one (CICD-SEC-3 only).

### Consistency test strengthened
`checkOWASPMapping` now also runs `checkDocOWASPMatchesMap`, which parses the `**OWASP:**` line from each rule's doc (stripping URL fragments to avoid false positives) and asserts it matches `owasp.go`. A new `checkRulesOverviewSection` check verifies each rule appears under the correct CICD-SEC section in `docs/rules.md`. These two checks would have caught all 18 inconsistencies fixed here automatically.

## Testing
- `go test ./...` passes
- `glsec -format json` output verified to include `owasp` field
- `glsec -format sarif` output verified to include `OWASP Top 10 CI/CD Security Risks` taxonomy alongside CWE