### PR TITLE
feat: scan child pipeline files referenced by trigger: include:

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -121,31 +121,13 @@ func main() {
 		os.Exit(2)
 	}
 
-	suppressMap := suppress.Build(doc.Root)
-	suppressMap.Merge(suppress.LoadIgnoreFile(suppress.IgnoreFile, file))
-
-	var findings []finding.Finding
-	for _, rule := range rules.All() {
-		if !cfg.RuleEnabled(rule.ID()) {
-			continue
-		}
-		if !cfg.OWASPEnabled(rules.OWASPCategories(rule.ID())) {
-			continue
-		}
-		if !rules.EnabledFor(rule.ID(), gitlabVersion) {
-			continue
-		}
-		for _, f := range rule.Check(doc.Root, file) {
-			f = cfg.ApplySeverity(f)
-			if !cfg.AboveMinSeverity(f) {
-				continue
-			}
-			if !*generateIgnoreFlag && suppressMap.IsSuppressed(f.Line, f.RuleID) {
-				continue
-			}
-			findings = append(findings, f)
-		}
+	seen := map[string]bool{}
+	if abs, absErr := filepath.Abs(file); absErr == nil {
+		seen[abs] = true
 	}
+
+	findings := collectFindings(doc, file, cfg, gitlabVersion, *generateIgnoreFlag)
+	findings = append(findings, scanChildPipelines(doc, file, cfg, gitlabVersion, *generateIgnoreFlag, cfg.ExcludePaths, seen, 0)...)
 
 	if *generateIgnoreFlag {
 		if err := writeIgnoreFile(suppress.IgnoreFile, findings); err != nil {
@@ -215,6 +197,68 @@ func matchesExclude(file string, patterns []string) bool {
 		}
 	}
 	return false
+}
+
+// collectFindings runs all applicable rules against doc and returns the findings.
+func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, generateIgnore bool) []finding.Finding {
+	sm := suppress.Build(doc.Root)
+	sm.Merge(suppress.LoadIgnoreFile(suppress.IgnoreFile, path))
+
+	var findings []finding.Finding
+	for _, rule := range rules.All() {
+		if !cfg.RuleEnabled(rule.ID()) {
+			continue
+		}
+		if !cfg.OWASPEnabled(rules.OWASPCategories(rule.ID())) {
+			continue
+		}
+		if !rules.EnabledFor(rule.ID(), gitlabVersion) {
+			continue
+		}
+		for _, f := range rule.Check(doc.Root, path) {
+			f = cfg.ApplySeverity(f)
+			if !cfg.AboveMinSeverity(f) {
+				continue
+			}
+			if !generateIgnore && sm.IsSuppressed(f.Line, f.RuleID) {
+				continue
+			}
+			findings = append(findings, f)
+		}
+	}
+	return findings
+}
+
+const maxChildDepth = 5
+
+// scanChildPipelines recursively scans local child pipeline files referenced
+// by trigger: include: in doc. seen prevents re-scanning the same file twice.
+func scanChildPipelines(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, generateIgnore bool, excludePaths []string, seen map[string]bool, depth int) []finding.Finding {
+	if depth >= maxChildDepth {
+		return nil
+	}
+	baseDir := filepath.Dir(path)
+	var all []finding.Finding
+	for _, child := range parser.ChildPipelinePaths(doc.Root) {
+		childPath := filepath.Join(baseDir, child)
+		if matchesExclude(childPath, excludePaths) {
+			continue
+		}
+		abs, err := filepath.Abs(childPath)
+		if err != nil || seen[abs] {
+			continue
+		}
+		seen[abs] = true
+
+		childDoc, err := parser.ParseFile(childPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: child pipeline %s: %v\n", childPath, err)
+			continue
+		}
+		all = append(all, collectFindings(childDoc, childPath, cfg, gitlabVersion, generateIgnore)...)
+		all = append(all, scanChildPipelines(childDoc, childPath, cfg, gitlabVersion, generateIgnore, excludePaths, seen, depth+1)...)
+	}
+	return all
 }
 
 // writeIgnoreFile creates or overwrites .glsec-ignore with one entry per finding.

--- a/internal/parser/childpipelines.go
+++ b/internal/parser/childpipelines.go
@@ -1,0 +1,46 @@
+package parser
+
+import "gopkg.in/yaml.v3"
+
+// ChildPipelinePaths returns the local file paths referenced by
+// trigger: include: in any job in doc. Both forms are handled:
+//
+//	trigger:
+//	  include: child.yml           # scalar shorthand
+//
+//	trigger:
+//	  include:
+//	    - local: child.yml         # sequence with local key
+//
+// Multi-project triggers (trigger: project: ...) are ignored since
+// there is no local file to scan.
+func ChildPipelinePaths(doc *yaml.Node) []string {
+	var paths []string
+	EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		trigger := FindKey(job, "trigger")
+		if trigger == nil || trigger.Kind != yaml.MappingNode {
+			return
+		}
+		include := FindKey(trigger, "include")
+		if include == nil {
+			return
+		}
+		switch include.Kind {
+		case yaml.ScalarNode:
+			if include.Value != "" {
+				paths = append(paths, include.Value)
+			}
+		case yaml.SequenceNode:
+			for _, item := range include.Content {
+				if item.Kind != yaml.MappingNode {
+					continue
+				}
+				local := FindKey(item, "local")
+				if local != nil && local.Value != "" {
+					paths = append(paths, local.Value)
+				}
+			}
+		}
+	})
+	return paths
+}

--- a/internal/parser/childpipelines_test.go
+++ b/internal/parser/childpipelines_test.go
@@ -1,0 +1,67 @@
+package parser
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestChildPipelinePaths(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{
+			name: "no trigger",
+			yaml: "build:\n  script:\n    - make\n",
+			want: nil,
+		},
+		{
+			name: "multi-project trigger (no include)",
+			yaml: "deploy:\n  trigger:\n    project: my-group/my-project\n    branch: main\n",
+			want: nil,
+		},
+		{
+			name: "scalar include shorthand",
+			yaml: "child:\n  trigger:\n    include: .gitlab/child.yml\n",
+			want: []string{".gitlab/child.yml"},
+		},
+		{
+			name: "sequence with local key",
+			yaml: "child:\n  trigger:\n    include:\n      - local: .gitlab/a.yml\n      - local: .gitlab/b.yml\n",
+			want: []string{".gitlab/a.yml", ".gitlab/b.yml"},
+		},
+		{
+			name: "sequence with mixed types (ignores non-local)",
+			yaml: "child:\n  trigger:\n    include:\n      - local: ci/child.yml\n      - remote: https://example.com/ci.yml\n",
+			want: []string{"ci/child.yml"},
+		},
+		{
+			name: "multiple jobs each with a child",
+			yaml: "job-a:\n  trigger:\n    include: a.yml\njob-b:\n  trigger:\n    include: b.yml\n",
+			want: []string{"a.yml", "b.yml"},
+		},
+		{
+			name: "trigger with string value (not mapping)",
+			yaml: "job:\n  trigger: my-group/my-project\n",
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := Parse([]byte(tc.yaml), "test.yml")
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			got := ChildPipelinePaths(doc.Root)
+			sort.Strings(got)
+			want := tc.want
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #147

## What changed

When glsec encounters `trigger: include:` in any job, it now automatically scans the referenced local file and reports findings with the correct filename. Recursive child pipelines are followed up to 5 levels deep; cycles are detected via an absolute-path seen-set.

### YAML patterns handled

```yaml
# scalar shorthand
child-job:
  trigger:
    include: .gitlab/ci/child.yml

# sequence with local key
child-job:
  trigger:
    include:
      - local: .gitlab/ci/child.yml
      - local: .gitlab/ci/other.yml
```

Multi-project triggers (`trigger: project: my-group/my-project`) and plain-string `trigger:` values are intentionally ignored — no local file is available to scan.

### Implementation

- `internal/parser/childpipelines.go` — `ChildPipelinePaths(doc *yaml.Node) []string` extracts local paths from trigger jobs; unit-tested with 7 cases covering both YAML forms, mixed sequences, multi-job pipelines, and non-local trigger variants
- `cmd/glsec/main.go` — scan loop extracted into `collectFindings()`; new `scanChildPipelines()` walks the child tree recursively up to `maxChildDepth = 5`; child files that fail to parse emit a `warning:` to stderr and are skipped; `--exclude` patterns apply to child files

## Testing

```
# parent.yml -> child.yml -> grandchild.yml
$ glsec parent.yml
WARN   parent.yml:4      GL017  [trigger-child]      no tags: restriction
ERROR  child.yml:2       GL001  [unit-tests]         image "node:latest" uses mutable tag
ERROR  grandchild.yml:3  GL011  [deploy]             curl | bash pattern
WARN   grandchild.yml:3  GL016  [deploy]             HTTP download
```