### PR TITLE
GL002: fix false positives via shell quote-masking, add missing variables

### DIFF
--- a/docs/rules/GL002.md
+++ b/docs/rules/GL002.md
@@ -15,11 +15,13 @@ Several GitLab CI predefined variables are populated from user-supplied data: br
 | `CI_COMMIT_REF_NAME` | Branch or tag name |
 | `CI_COMMIT_BRANCH` | Branch name |
 | `CI_COMMIT_TAG` | Tag name |
-| `CI_COMMIT_MESSAGE` | Full commit message |
 | `CI_COMMIT_TITLE` | First line of commit message |
+| `CI_COMMIT_MESSAGE` | Full commit message |
+| `CI_COMMIT_DESCRIPTION` | Commit description (after first paragraph) |
+| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | Source branch of MR |
 | `CI_MERGE_REQUEST_TITLE` | MR title |
 | `CI_MERGE_REQUEST_DESCRIPTION` | MR description |
-| `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | Source branch of MR |
+| `CI_PIPELINE_NAME` | Pipeline name set by the caller when triggering via API |
 
 ## Trigger example
 
@@ -43,4 +45,4 @@ deploy:
 
 ## Notes
 
-The rule flags any occurrence of a user-controlled variable that is **not immediately preceded by a double-quote** (`"`). Single-quoted strings in YAML are flagged unless the variable is also quoted within the shell command.
+The rule uses shell quote-masking to detect unquoted occurrences: the contents of `"..."` and `'...'` strings and `\X` escape sequences are replaced with spaces before checking for variable references. Only variables that remain visible after masking are flagged, so `"Branch: $CI_COMMIT_REF_NAME"` and `'$CI_COMMIT_REF_NAME'` are not flagged.

--- a/rules/gl002.go
+++ b/rules/gl002.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/parser"
@@ -20,6 +21,8 @@ func (r *gl002) ID() string { return "GL002" }
 // shell metacharacters like $(...) or `...`.
 var userControlledVars = []string{
 	"CI_COMMIT_REF_NAME",
+	"CI_COMMIT_BRANCH",
+	"CI_COMMIT_TAG",
 	"CI_COMMIT_TITLE",
 	"CI_COMMIT_MESSAGE",
 	"CI_COMMIT_DESCRIPTION",
@@ -29,17 +32,11 @@ var userControlledVars = []string{
 	"CI_PIPELINE_NAME",
 }
 
-// unquotedVarPatterns matches $VAR or ${VAR} not immediately preceded by '"'.
-// Using '"' as the only safe predecessor keeps the heuristic simple:
-// "$VAR" is the idiomatic safe form; anything else (unquoted args, assignments,
-// subshells) is potentially exploitable.
-var unquotedVarPatterns = func() []*regexp.Regexp {
-	out := make([]*regexp.Regexp, len(userControlledVars))
-	for i, v := range userControlledVars {
-		out[i] = regexp.MustCompile(`(?:^|[^"])\$\{?` + regexp.QuoteMeta(v) + `\}?`)
-	}
-	return out
-}()
+// userVarRe matches any user-controlled variable reference ($VAR or ${VAR})
+// followed by a word boundary so that e.g. $CI_COMMIT_REF_NAME_EXTRA is not matched.
+var userVarRe = regexp.MustCompile(
+	`\$\{?(` + strings.Join(userControlledVars, "|") + `)\b`,
+)
 
 func (r *gl002) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
@@ -80,30 +77,91 @@ func checkScriptNode(node *yaml.Node, file string) []finding.Finding {
 	}
 	var findings []finding.Finding
 	for _, item := range node.Content {
-		if item.Kind != yaml.ScalarNode {
-			continue
+		if item.Kind == yaml.ScalarNode {
+			findings = append(findings, checkScriptLine(item, file)...)
 		}
-		findings = append(findings, checkScriptLine(item, file)...)
 	}
 	return findings
 }
 
 func checkScriptLine(node *yaml.Node, file string) []finding.Finding {
+	masked := maskShellQuotes(node.Value)
+	matches := userVarRe.FindAllStringSubmatch(masked, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
 	var findings []finding.Finding
-	for i, pat := range unquotedVarPatterns {
-		if pat.MatchString(node.Value) {
-			findings = append(findings, finding.Finding{
-				RuleID:   "GL002",
-				Severity: finding.Warn,
-				Message: fmt.Sprintf(
-					"unquoted user-controlled variable $%s in script — value is set by commit authors and may contain shell metacharacters",
-					userControlledVars[i],
-				),
-				File: file,
-				Line: node.Line,
-				Col:  node.Column,
-			})
+	for _, m := range matches {
+		varName := m[1]
+		if seen[varName] {
+			continue
 		}
+		seen[varName] = true
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL002",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"unquoted user-controlled variable $%s in script — value is set by commit authors and may contain shell metacharacters",
+				varName,
+			),
+			File: file,
+			Line: node.Line,
+			Col:  node.Column,
+		})
 	}
 	return findings
+}
+
+// maskShellQuotes replaces the contents of single- and double-quoted shell
+// strings with spaces. Variable references inside either quote type are safe
+// from word splitting and should not be flagged; masking them makes the
+// caller's regex only see genuinely unquoted occurrences.
+//
+// Backslash escapes outside quotes are also masked (two spaces replace the
+// pair) because \$VAR is not a variable reference.
+func maskShellQuotes(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		switch {
+		case s[i] == '\\' && i+1 < len(s):
+			b.WriteByte(' ')
+			b.WriteByte(' ')
+			i += 2
+		case s[i] == '\'':
+			b.WriteByte('\'')
+			i++
+			for i < len(s) && s[i] != '\'' {
+				b.WriteByte(' ')
+				i++
+			}
+			if i < len(s) {
+				b.WriteByte('\'')
+				i++
+			}
+		case s[i] == '"':
+			b.WriteByte('"')
+			i++
+			for i < len(s) && s[i] != '"' {
+				if s[i] == '\\' && i+1 < len(s) {
+					b.WriteByte(' ')
+					b.WriteByte(' ')
+					i += 2
+					continue
+				}
+				b.WriteByte(' ')
+				i++
+			}
+			if i < len(s) {
+				b.WriteByte('"')
+				i++
+			}
+		default:
+			b.WriteByte(s[i])
+			i++
+		}
+	}
+	return b.String()
 }

--- a/rules/gl002_test.go
+++ b/rules/gl002_test.go
@@ -41,6 +41,50 @@ build:
 	}
 }
 
+func TestGL002_QuotedMidString(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo "Branch: $CI_COMMIT_REF_NAME"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for variable inside double-quoted string, got %d", len(f))
+	}
+}
+
+func TestGL002_MultipleQuotedVars(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo "$CI_COMMIT_REF_NAME and $CI_COMMIT_MESSAGE"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for multiple vars inside double-quoted string, got %d", len(f))
+	}
+}
+
+func TestGL002_SingleQuoted(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo '$CI_COMMIT_REF_NAME'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for single-quoted variable, got %d", len(f))
+	}
+}
+
+func TestGL002_EscapedDollar(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo \$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for escaped dollar, got %d", len(f))
+	}
+}
+
 func TestGL002_BraceForm(t *testing.T) {
 	f := findings002(t, `
 build:
@@ -61,6 +105,39 @@ build:
 `)
 	if len(f) != 2 {
 		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL002_CommitBranch(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - git checkout $CI_COMMIT_BRANCH
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_BRANCH, got %d", len(f))
+	}
+}
+
+func TestGL002_CommitTag(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - git tag -a $CI_COMMIT_TAG -m release
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_TAG, got %d", len(f))
+	}
+}
+
+func TestGL002_PipelineName(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - ./trigger.sh $CI_PIPELINE_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_PIPELINE_NAME, got %d", len(f))
 	}
 }
 
@@ -125,5 +202,27 @@ build:
 `)
 	if len(f) != 1 {
 		t.Fatalf("expected 1 finding for assignment context, got %d", len(f))
+	}
+}
+
+func TestGL002_DeduplicatePerLine(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo $CI_COMMIT_REF_NAME $CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (deduplicated), got %d", len(f))
+	}
+}
+
+func TestGL002_NoSuffixMatch(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo $CI_COMMIT_REF_NAME_CUSTOM
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for suffixed variable name, got %d", len(f))
 	}
 }


### PR DESCRIPTION
Closes #153

## What changed

### False positive fix
The old detection used `(?:^|[^"])\$\{?VAR\}?` — this flagged variables inside double-quoted strings whenever the variable wasn't the first character after `"`:

```yaml
script:
  - echo "Branch: $CI_COMMIT_REF_NAME"         # incorrectly flagged
  - echo "$CI_COMMIT_REF_NAME and $CI_COMMIT_MESSAGE"  # second var incorrectly flagged
```

The new approach uses `maskShellQuotes()`, a character-by-character state machine that replaces the contents of `"..."`, `'...'`, and `\X` escape sequences with spaces before running the pattern. Only variable references that remain visible after masking (i.e. genuinely unquoted) are flagged.

### Missing variables added
`CI_COMMIT_BRANCH` and `CI_COMMIT_TAG` were documented in the rule doc but absent from the code. `CI_PIPELINE_NAME` was in the code but missing from the doc. All three are now consistent.

### Deduplication
If the same variable appears multiple times on the same script line, only one finding is reported.

### Suffix safety
`$CI_COMMIT_REF_NAME_CUSTOM` no longer produces a false match (`\b` word boundary in the combined regex).

## Test plan

- [x] `echo "Branch: $CI_COMMIT_REF_NAME"` → no finding
- [x] `echo "$CI_COMMIT_REF_NAME and $CI_COMMIT_MESSAGE"` → no finding
- [x] `echo '$CI_COMMIT_REF_NAME'` → no finding (single-quoted)
- [x] `echo \$CI_COMMIT_REF_NAME` → no finding (escaped dollar)
- [x] `git checkout $CI_COMMIT_BRANCH` → finding (new variable)
- [x] `git tag -a $CI_COMMIT_TAG` → finding (new variable)
- [x] `./trigger.sh $CI_PIPELINE_NAME` → finding
- [x] `$CI_COMMIT_REF_NAME_CUSTOM` → no finding (suffix guard)
- [x] All 18 GL002 tests pass
- [x] `TestRuleConsistency/GL002` passes