### PR TITLE
GL001: fix false positive for $VAR image refs, add missing mutable tags

### DIFF
--- a/docs/rules/GL001.md
+++ b/docs/rules/GL001.md
@@ -11,7 +11,7 @@ Using `latest`, a branch name, or no tag at all means the image pulled by the ru
 ## What is flagged
 
 - No tag: `image: alpine` (implicitly pulls `latest`)
-- Mutable tags: `latest`, `stable`, `edge`, `dev`, `main`, `master`, `nightly`, `rolling`, `canary`, `beta`, `alpha`
+- Mutable tags: `latest`, `stable`, `edge`, `dev`, `main`, `master`, `nightly`, `rolling`, `canary`, `beta`, `alpha`, `lts`, `current`, `testing`, `oldstable`
 - Applies to `image:` and `services:` at global, `default:`, and job level
 
 SHA256 digest pins (`@sha256:...`) are always safe and never flagged.
@@ -40,4 +40,6 @@ test:
 
 ## Notes
 
-Named variant tags such as `docker:dind`, `docker:alpine`, `python:3.11-slim` are **not** flagged — the part after the last `-` or before `:` is checked, not the full tag string.
+Named variant tags such as `docker:dind`, `docker:alpine`, `python:3.11-slim` are **not** flagged — the full tag string is checked against a fixed list of known mutable tags, so version-qualified variants pass through.
+
+Image references that consist entirely of a variable expression (e.g. `image: $MY_IMAGE`) are not flagged — the tag cannot be determined statically.

--- a/rules/gl001.go
+++ b/rules/gl001.go
@@ -114,7 +114,7 @@ func isVarRef(ref string) bool {
 		rest = rest[1:]
 	}
 	for _, ch := range rest {
-		if !((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_') {
+		if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '_' {
 			return false
 		}
 	}

--- a/rules/gl001.go
+++ b/rules/gl001.go
@@ -43,17 +43,21 @@ func (r *gl001) Check(doc *yaml.Node, file string) []finding.Finding {
 
 // mutableTags is the set of well-known mutable image tags.
 var mutableTags = map[string]bool{
-	"latest":  true,
-	"stable":  true,
-	"edge":    true,
-	"dev":     true,
-	"main":    true,
-	"master":  true,
-	"nightly": true,
-	"rolling": true,
-	"canary":  true,
-	"beta":    true,
-	"alpha":   true,
+	"latest":    true,
+	"stable":    true,
+	"edge":      true,
+	"dev":       true,
+	"main":      true,
+	"master":    true,
+	"nightly":   true,
+	"rolling":   true,
+	"canary":    true,
+	"beta":      true,
+	"alpha":     true,
+	"lts":       true,
+	"current":   true,
+	"testing":   true,
+	"oldstable": true,
 }
 
 func checkImageNode(node *yaml.Node, file string) []finding.Finding {
@@ -97,8 +101,31 @@ func imageRef(node *yaml.Node) (ref string, line, col int) {
 	return "", 0, 0
 }
 
+// isVarRef reports whether ref is entirely a shell variable expression
+// ($MY_IMAGE or ${MY_IMAGE}). Such refs cannot be statically analysed
+// for tag presence and must not be flagged as "no tag".
+func isVarRef(ref string) bool {
+	if len(ref) == 0 || ref[0] != '$' {
+		return false
+	}
+	rest := ref[1:]
+	if len(rest) > 0 && rest[0] == '{' {
+		rest = strings.TrimSuffix(rest, "}")
+		rest = rest[1:]
+	}
+	for _, ch := range rest {
+		if !((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_') {
+			return false
+		}
+	}
+	return len(rest) > 0
+}
+
 func checkRef(ref string, line, col int, file string) []finding.Finding {
 	if strings.Contains(ref, "@sha256:") {
+		return nil
+	}
+	if isVarRef(ref) {
 		return nil
 	}
 	tag := imageTag(ref)

--- a/rules/gl001_test.go
+++ b/rules/gl001_test.go
@@ -155,3 +155,71 @@ build:
 		t.Fatalf("expected 1 finding for registry image with latest tag, got %d", len(f))
 	}
 }
+
+func TestGL001_VariableRef(t *testing.T) {
+	f := findings(t, `
+variables:
+  MY_IMAGE: alpine:3.19
+build:
+  image: $MY_IMAGE
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for image: $VARIABLE (tag cannot be determined statically), got %d", len(f))
+	}
+}
+
+func TestGL001_VariableRefBrace(t *testing.T) {
+	f := findings(t, `
+build:
+  image: ${MY_IMAGE}
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for image: ${VARIABLE}, got %d", len(f))
+	}
+}
+
+func TestGL001_LtsTag(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node:lts
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for node:lts, got %d", len(f))
+	}
+}
+
+func TestGL001_CurrentTag(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node:current
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for node:current, got %d", len(f))
+	}
+}
+
+func TestGL001_TestingTag(t *testing.T) {
+	f := findings(t, `
+build:
+  image: debian:testing
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for debian:testing, got %d", len(f))
+	}
+}
+
+func TestGL001_LtsVariantNotFlagged(t *testing.T) {
+	f := findings(t, `
+build:
+  image: node:20-alpine
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for node:20-alpine (pinned version), got %d", len(f))
+	}
+}


### PR DESCRIPTION
Closes #173

## Changes

### False positive fix: `image: $VARIABLE`
`imageTag("$MY_IMAGE")` returned `""` (no `:` found) → incorrectly flagged as "no tag". Added `isVarRef()` which detects refs that are entirely a shell variable expression (`$VAR` or `${VAR}`) and skips them — the tag cannot be determined statically.

### Missing mutable tags
Added `lts`, `current` (Node.js), `testing`, `oldstable` (Debian) to `mutableTags`.

### Doc note corrected
The Notes section incorrectly described the tag check as operating on "the part after the last `-` or before `:`". Corrected to accurately describe what the code does (full tag string checked against a fixed list).

## Test plan

- [x] `image: $MY_IMAGE` → no finding
- [x] `image: ${MY_IMAGE}` → no finding
- [x] `image: node:lts` → finding
- [x] `image: node:current` → finding
- [x] `image: debian:testing` → finding
- [x] `image: node:20-alpine` → no finding (version-qualified variant)
- [x] All 17 GL001 tests pass
- [x] Full test suite passes