### PR TITLE
GL002: skip bare assignment RHS (#175)

### DIFF
--- a/docs/rules/GL001.md
+++ b/docs/rules/GL001.md
@@ -2,7 +2,6 @@
 
 **Severity:** `error`  
 **OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)  
-**zizmor analogue:** `unpinned-images`
 
 ## Risk
 

--- a/docs/rules/GL002.md
+++ b/docs/rules/GL002.md
@@ -2,7 +2,6 @@
 
 **Severity:** `warn`  
 **OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)  
-**zizmor analogue:** `template-injection`
 
 ## Risk
 

--- a/docs/rules/GL003.md
+++ b/docs/rules/GL003.md
@@ -2,7 +2,6 @@
 
 **Severity:** `error`  
 **OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)  
-**zizmor analogue:** `unpinned-uses`
 
 ## Risk
 

--- a/docs/rules/GL005.md
+++ b/docs/rules/GL005.md
@@ -2,7 +2,6 @@
 
 **Severity:** `warn`  
 **OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
-**zizmor analogue:** `artipacked`
 
 ## Risk
 

--- a/docs/rules/GL010.md
+++ b/docs/rules/GL010.md
@@ -44,7 +44,3 @@ When `pipeline_variables: true` is set:
 - Masking is not applied in the downstream pipeline — secrets can appear in plain text in job logs
 - The downstream project may have a broader set of maintainers and less strict access controls
 - A malicious job in the downstream project can trivially exfiltrate all forwarded secrets
-
-## zizmor analogue
-
-`secrets-inherit` (GitHub Actions) — same class of vulnerability, different mechanism.

--- a/docs/rules/GL011.md
+++ b/docs/rules/GL011.md
@@ -43,7 +43,3 @@ Or better: commit the script to the repository and reference it locally, removin
 ## Why this matters
 
 HTTPS provides transport-level security but no content integrity guarantee. If the script host is compromised, the pipeline will silently execute malicious code in the CI environment with access to all secrets, tokens, and build artifacts. Unlike a committed dependency, the executed code is unversioned and cannot be audited in pull request reviews or git history.
-
-## zizmor analogue
-
-`unpinned-tools` — same supply chain risk on GitHub Actions.

--- a/docs/rules/GL012.md
+++ b/docs/rules/GL012.md
@@ -51,7 +51,3 @@ If you need to deploy after a partial failure (e.g. only one test suite failed),
 - A failed `secret_detection` job does not prevent deployment
 
 The security and quality gates in earlier stages are effectively disabled for the downstream deployment.
-
-## zizmor analogue
-
-`unsound-condition` — same class of flow control bypass on GitHub Actions.

--- a/docs/rules/GL013.md
+++ b/docs/rules/GL013.md
@@ -50,7 +50,3 @@ Without a branch restriction:
 - Hotfix or feature branches can accidentally deploy untested code
 - Manual pipeline runs from the GitLab UI can bypass normal review workflows
 - GitLab's environment protection rules (defined in Settings → CI/CD → Environments) are a second line of defence, not a substitute for restricting which pipelines can target the environment
-
-## zizmor analogue
-
-`secrets-outside-env` — same class of missing access control on GitHub Actions.

--- a/docs/rules/GL014.md
+++ b/docs/rules/GL014.md
@@ -49,7 +49,3 @@ GitLab's `dotenv` report artifact is designed to pass a small set of computed va
 - Cloud provider credentials, deploy keys, and any other secret injected into the job
 
 Any project member with the Reporter role or above can download pipeline artifacts through the GitLab UI or API.
-
-## zizmor analogue
-
-`artipacked` — same credential-in-artifact risk on GitHub Actions.

--- a/docs/rules/GL019.md
+++ b/docs/rules/GL019.md
@@ -46,5 +46,4 @@ Without concurrency control, two developers merging to the same branch within se
 ## References
 
 - [GitLab `resource_group` documentation](https://docs.gitlab.com/ee/ci/resource_groups/)
-- zizmor `concurrency-limits`
 - GL017 (deploy job without runner `tags:` — complementary rule)

--- a/rules/gl002.go
+++ b/rules/gl002.go
@@ -86,15 +86,19 @@ func checkScriptNode(node *yaml.Node, file string) []finding.Finding {
 
 func checkScriptLine(node *yaml.Node, file string) []finding.Finding {
 	masked := maskShellQuotes(node.Value)
-	matches := userVarRe.FindAllStringSubmatch(masked, -1)
+	matches := userVarRe.FindAllStringSubmatchIndex(masked, -1)
 	if len(matches) == 0 {
 		return nil
 	}
 	seen := map[string]bool{}
 	var findings []finding.Finding
-	for _, m := range matches {
-		varName := m[1]
+	for _, loc := range matches {
+		dollarPos := loc[0]
+		varName := masked[loc[2]:loc[3]]
 		if seen[varName] {
+			continue
+		}
+		if isBareAssignment(masked, dollarPos) {
 			continue
 		}
 		seen[varName] = true
@@ -111,6 +115,31 @@ func checkScriptLine(node *yaml.Node, file string) []finding.Finding {
 		})
 	}
 	return findings
+}
+
+// isBareAssignment reports whether the $ at dollarPos in s is the RHS of a
+// simple shell assignment (IDENTIFIER=$VAR). The LHS must consist solely of
+// a valid identifier followed by '=', with nothing else on the line before it.
+// The RHS of such an assignment is not word-split by the shell, so it is not
+// subject to injection via metacharacters.
+func isBareAssignment(s string, dollarPos int) bool {
+	if dollarPos == 0 {
+		return false
+	}
+	if s[dollarPos-1] != '=' {
+		return false
+	}
+	lhs := s[:dollarPos-1]
+	if len(lhs) == 0 {
+		return false
+	}
+	for _, ch := range lhs {
+		if (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '_' {
+			return false
+		}
+	}
+	// first char must not be a digit
+	return lhs[0] < '0' || lhs[0] > '9'
 }
 
 // maskShellQuotes replaces the contents of single- and double-quoted shell

--- a/rules/gl002_test.go
+++ b/rules/gl002_test.go
@@ -226,3 +226,27 @@ build:
 		t.Errorf("expected no findings for suffixed variable name, got %d", len(f))
 	}
 }
+
+func TestGL002_BareAssignment(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - BRANCH=$CI_COMMIT_REF_NAME
+    - git checkout "$BRANCH"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for bare assignment RHS, got %d", len(f))
+	}
+}
+
+func TestGL002_BareAssignmentThenUnquotedUse(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - BRANCH=$CI_COMMIT_REF_NAME
+    - git checkout $CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unquoted use, got %d", len(f))
+	}
+}


### PR DESCRIPTION
## What

Fixes #175.

GL002 was flagging `BRANCH=$CI_COMMIT_REF_NAME` even though the RHS of a simple shell assignment is **not subject to word splitting**. Only uses like `git checkout $BRANCH` (or a direct `git checkout $CI_COMMIT_REF_NAME`) carry injection risk.

## How

Added `isBareAssignment(s string, dollarPos int) bool` in `rules/gl002.go`. After `maskShellQuotes` runs, each regex match's `$` offset is checked:

- `s[dollarPos-1]` must be `=`
- Every character in `s[:dollarPos-1]` must be a valid identifier character (letters, digits, `_`)
- First character must not be a digit

If all three hold, the match is a bare assignment RHS and is skipped.

A command-level assignment such as `make test BRANCH=$CI_COMMIT_REF_NAME` has a space in the prefix before `=` and is correctly **not** skipped.

## Tests

- `TestGL002_BareAssignment` — `BRANCH=$CI_COMMIT_REF_NAME` on its own line → 0 findings
- `TestGL002_BareAssignmentThenUnquotedUse` — assignment line + direct unquoted use → exactly 1 finding (for the use, not the assignment)
- Existing `TestGL002_SubshellInjection` (`make test BRANCH=$CI_COMMIT_REF_NAME`) continues to produce 1 finding

## How to test

```sh
go test ./rules/ -run TestGL002 -v
```