### PR TITLE
GL003: add stable/trunk to mutableRefs, flag ~latest component ref (#177)

### DIFF
--- a/docs/rules/GL003.md
+++ b/docs/rules/GL003.md
@@ -19,7 +19,9 @@ Including a remote template without pinning `ref` to a specific commit SHA means
 
 ## Mutable refs (flagged)
 
-`main`, `master`, `develop`, `dev`, `HEAD`, `latest`, `stable`, `trunk`
+`main`, `master`, `develop`, `dev`, `HEAD`, `latest`, `stable`, `trunk`, `staging`, `production`, `nightly`, `canary`, `edge`
+
+For component includes, `~latest` (GitLab's floating SemVer constraint) is also flagged.
 
 Everything else (version tags, SHAs) is trusted.
 

--- a/rules/gl003.go
+++ b/rules/gl003.go
@@ -24,6 +24,7 @@ var mutableRefs = map[string]bool{
 	"main": true, "master": true, "dev": true, "develop": true,
 	"staging": true, "production": true, "latest": true, "HEAD": true,
 	"nightly": true, "canary": true, "edge": true,
+	"stable": true, "trunk": true,
 }
 
 func (r *gl003) Check(doc *yaml.Node, file string) []finding.Finding {
@@ -118,7 +119,7 @@ func checkComponentRef(node *yaml.Node, file string) []finding.Finding {
 		}}
 	}
 	ref := node.Value[at+1:]
-	if isMutableRef(ref) {
+	if ref == "~latest" || isMutableRef(ref) {
 		return []finding.Finding{{
 			RuleID:   "GL003",
 			Severity: finding.Error,

--- a/rules/gl003_test.go
+++ b/rules/gl003_test.go
@@ -150,6 +150,40 @@ include:
 	}
 }
 
+func TestGL003_ProjectStableRef(t *testing.T) {
+	f := findings003(t, `
+include:
+  - project: 'company/ci-templates'
+    file: '/jobs/deploy.yml'
+    ref: stable
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for stable ref, got %d", len(f))
+	}
+}
+
+func TestGL003_ProjectTrunkRef(t *testing.T) {
+	f := findings003(t, `
+include:
+  - project: 'company/ci-templates'
+    file: '/jobs/deploy.yml'
+    ref: trunk
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for trunk ref, got %d", len(f))
+	}
+}
+
+func TestGL003_ComponentTildeLatest(t *testing.T) {
+	f := findings003(t, `
+include:
+  - component: 'gitlab.com/my-org/my-component/build@~latest'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for ~latest component ref, got %d", len(f))
+	}
+}
+
 func TestGL003_LineNumbers(t *testing.T) {
 	f := findings003(t, `
 include:


### PR DESCRIPTION
## What

Fixes #177.

Three gaps in GL003 coverage:

**1. `stable` and `trunk` missing from `mutableRefs`**

Both are common mutable branch names in CI template repos and were already listed in the rule doc but absent from the code. Added to the `mutableRefs` map.

**2. `@~latest` component ref not flagged**

GitLab CI supports `~latest` as a floating SemVer constraint that resolves to the highest compatible release at pipeline execution time. It is explicitly mutable — a new tag push in the component registry changes what gets included without any change to the pipeline file. `isMutableRef` only checks a fixed word list, so `~latest` slipped through. Added an explicit `ref == "~latest"` check in `checkComponentRef`.

**3. Doc/code inconsistency**

`GL003.md` listed `stable`/`trunk` (not in code) and omitted `staging`, `production`, `nightly`, `canary`, `edge` (all in code). Updated the doc to reflect the actual set, and added a note about `~latest` for component includes.

## Tests added

- `TestGL003_ProjectStableRef` — `ref: stable` → 1 finding
- `TestGL003_ProjectTrunkRef` — `ref: trunk` → 1 finding
- `TestGL003_ComponentTildeLatest` — `@~latest` → 1 finding

## How to test

```sh
go test ./rules/ -run TestGL003 -v
```