### PR TITLE
GL004: fix false positive for CI_JOB_TOKEN in URL userinfo (#179)

### DIFF
--- a/rules/gl004.go
+++ b/rules/gl004.go
@@ -18,8 +18,8 @@ func (r *gl004) ID() string { return "GL004" }
 
 var (
 	jobTokenPattern = regexp.MustCompile(`\$\{?CI_JOB_TOKEN\}?`)
-	// urlPattern captures the full URL and its domain separately.
-	urlPattern004 = regexp.MustCompile(`https?://([a-zA-Z0-9.\-]+)`)
+	// urlPattern captures the hostname from a URL, skipping optional userinfo (user:pass@).
+	urlPattern004 = regexp.MustCompile(`https?://(?:[^@]*@)?([a-zA-Z0-9.\-]+)`)
 )
 
 func (r *gl004) Check(doc *yaml.Node, file string) []finding.Finding {

--- a/rules/gl004_test.go
+++ b/rules/gl004_test.go
@@ -98,6 +98,31 @@ build:
 	}
 }
 
+func TestGL004_GitCloneWithToken(t *testing.T) {
+	f := findings004(t, `
+build:
+  script:
+    - git clone https://gitlab-ci-token:$CI_JOB_TOKEN@gitlab.com/org/repo.git
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for git clone to gitlab.com with token in userinfo, got %d", len(f))
+	}
+}
+
+func TestGL004_ExternalUserinfoURL(t *testing.T) {
+	f := findings004(t, `
+build:
+  script:
+    - curl https://user:$CI_JOB_TOKEN@external.com/upload
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for token sent to external host via userinfo, got %d", len(f))
+	}
+	if f[0].Message != `CI_JOB_TOKEN sent to non-GitLab host "external.com" — this token is scoped to the GitLab API and should not be forwarded to external services` {
+		t.Errorf("unexpected message: %s", f[0].Message)
+	}
+}
+
 func TestGL004_LineNumbers(t *testing.T) {
 	f := findings004(t, `
 upload:


### PR DESCRIPTION
## What

Fixes #179.

The URL regex `https?://([a-zA-Z0-9.\-]+)` extracted the first segment after `://` as the domain. For `user:pass@host` URLs it captured the username, not the hostname.

The common GitLab CI git-clone pattern:

```yaml
- git clone https://gitlab-ci-token:$CI_JOB_TOKEN@gitlab.com/org/repo.git
```

was falsely flagged as `"CI_JOB_TOKEN sent to non-GitLab host "gitlab-ci-token""` because the regex returned `gitlab-ci-token` as the domain instead of `gitlab.com`.

## Fix

Added an optional non-capturing group `(?:[^@]*@)?` to skip the userinfo segment before capturing the hostname:

```go
// before
`https?://([a-zA-Z0-9.\-]+)`

// after
`https?://(?:[^@]*@)?([a-zA-Z0-9.\-]+)`
```

This correctly handles:
- `https://gitlab-ci-token:$TOKEN@gitlab.com/...` → domain `gitlab.com` (safe, no finding)
- `https://user:pass@external.com/...` → domain `external.com` (flagged, correct message)
- `https://external.com/...` → domain `external.com` (unchanged behaviour)

## Tests added

- `TestGL004_GitCloneWithToken` — standard git clone with token in userinfo to `gitlab.com` → 0 findings
- `TestGL004_ExternalUserinfoURL` — token in userinfo to an external host → 1 finding with correct domain in message

## How to test

```sh
go test ./rules/ -run TestGL004 -v
```