### PR TITLE
GL005: check default: artifacts:, fix doc severity and pattern table (#181)

### DIFF
--- a/docs/rules/GL005.md
+++ b/docs/rules/GL005.md
@@ -1,6 +1,6 @@
 # GL005 — Sensitive artifacts
 
-**Severity:** `warn`  
+**Severity:** `error` (sensitive paths) / `warn` (missing `expire_in`)  
 **OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
 
 ## Risk
@@ -9,17 +9,23 @@ Storing secrets in job artifacts exposes them to anyone with read access to the 
 
 ## What is flagged
 
+Applies to `artifacts:` at `default:` and job level.
+
 **Sensitive file patterns in `artifacts: paths:`:**
 
 | Pattern | Examples |
 |---------|---------|
-| `.env*` | `.env`, `.env.production` |
-| `*.pem` | `cert.pem`, `ca.pem` |
+| `.env`, `.env.*` | `.env`, `.env.production` |
+| `*.pem`, `*.der` | `cert.pem`, `ca.der` |
 | `*.key` | `server.key`, `private.key` |
-| `*.p12`, `*.pfx`, `*.jks` | Certificate keystores |
-| `id_rsa`, `id_ed25519` | SSH private keys |
-| `*.kube*`, `kubeconfig` | Kubernetes config files |
-| `*secret*`, `*credential*`, `*password*` | Generic secret file names |
+| `*.p12`, `*.pfx`, `*.jks`, `*.keystore` | Certificate keystores |
+| `id_rsa`, `id_ecdsa`, `id_ed25519`, `id_dsa` | SSH private keys |
+| `kubeconfig`, `*.kubeconfig` | Kubernetes config files |
+| `*secret*`, `*.secret` | Secret file names |
+| `*credential*`, `*credentials*` | Credential file names |
+| `*password*`, `*passwd*` | Password file names |
+| `*.token` | Token files |
+| `*.tfstate`, `*.tfvars` | Terraform state and variable files |
 
 **Missing `expire_in`:**
 

--- a/rules/gl005.go
+++ b/rules/gl005.go
@@ -32,6 +32,13 @@ var sensitivePatterns = []string{
 
 func (r *gl005) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		if artifactsNode := parser.FindKey(def, "artifacts"); artifactsNode != nil {
+			findings = append(findings, checkArtifacts(artifactsNode, file)...)
+		}
+	}
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		artifactsNode := parser.FindKey(job, "artifacts")

--- a/rules/gl005_test.go
+++ b/rules/gl005_test.go
@@ -135,6 +135,43 @@ build:
 	}
 }
 
+func TestGL005_DefaultBlockSensitivePath(t *testing.T) {
+	f := findings005(t, `
+default:
+  artifacts:
+    paths:
+      - .env.production
+    expire_in: 1 week
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for sensitive path in default: artifacts:, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL005_DefaultBlockNoExpiry(t *testing.T) {
+	f := findings005(t, `
+default:
+  artifacts:
+    paths:
+      - dist/
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for missing expire_in in default: artifacts:, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
 func TestGL005_NoArtifacts(t *testing.T) {
 	f := findings005(t, `
 build:


### PR DESCRIPTION
## What

Fixes #181. Three issues in one:

### 1. `default: artifacts:` now checked

`artifacts:` is valid inside `default:` since GitLab 12.4 and applies to every job in the pipeline — a broader exposure than a single job. The rule was only scanning jobs via `EachJob`; the `default:` block was silently skipped.

Added a pre-pass that checks `default: artifacts:` before iterating jobs. Findings from `default:` have no `Job` field set (consistent with how GL001/GL002 handle `default:`).

New tests:
- `TestGL005_DefaultBlockSensitivePath` — `.env.production` in `default: artifacts:` → 1 Error
- `TestGL005_DefaultBlockNoExpiry` — missing `expire_in` in `default: artifacts:` → 1 Warn

### 2. Doc severity header corrected

Header said `warn`; the code produces `Error` for sensitive file patterns and `Warn` for missing `expire_in`. Updated to `error (sensitive paths) / warn (missing expire_in)`.

### 3. Pattern table aligned with code

Table now lists all patterns actually in `sensitivePatterns`:
- Added `*.der`, `*.keystore`, `id_ecdsa`, `id_dsa`
- Corrected `*.kube*` → `kubeconfig`, `*.kubeconfig`
- Corrected `.env*` → `.env`, `.env.*`
- Split the generic-name patterns into separate rows for clarity

## How to test

```sh
go test ./rules/ -run TestGL005 -v
```