### PR TITLE
GL006: add sk-proj- OpenAI key pattern, fix doc table (#183)

### DIFF
--- a/docs/rules/GL006.md
+++ b/docs/rules/GL006.md
@@ -15,9 +15,11 @@ glsec scans all `variables:` blocks (global, `default:`, and per-job) for scalar
 | GitLab CI job token | `glcbt-…` |
 | AWS access key | `AKIA…` (16 uppercase chars) |
 | PEM private key header | `-----BEGIN … PRIVATE KEY` |
-| GitHub PAT | `ghp_…` |
-| Slack bot token | `xoxb-…` / `xoxp-…` |
-| OpenAI API key | `sk-…` (32+ chars) |
+| GitHub PAT | `ghp_…` (36+ chars) |
+| GitHub fine-grained PAT | `github_pat_…` (82+ chars) |
+| Slack token | `xoxb-…` / `xoxp-…` / `xoxa-…` / `xoxs-…` / `xoxr-…` |
+| OpenAI API key | `sk-…` (32+ alphanum chars) |
+| OpenAI project API key | `sk-proj-…` (80+ chars) |
 
 Values that are variable references (starting with `$`) are ignored.
 

--- a/rules/gl006.go
+++ b/rules/gl006.go
@@ -32,6 +32,7 @@ var secretPatterns = []secretPattern{
 	{"GitHub fine-grained PAT", regexp.MustCompile(`^github_pat_[A-Za-z0-9_]{82,}$`)},
 	{"Slack token", regexp.MustCompile(`^xox[baprs]-[A-Za-z0-9-]{10,}$`)},
 	{"OpenAI API key", regexp.MustCompile(`^sk-[A-Za-z0-9]{32,}$`)},
+	{"OpenAI project API key", regexp.MustCompile(`^sk-proj-[A-Za-z0-9_-]{80,}$`)},
 }
 
 func (r *gl006) Check(doc *yaml.Node, file string) []finding.Finding {

--- a/rules/gl006_test.go
+++ b/rules/gl006_test.go
@@ -79,6 +79,18 @@ build:
 	}
 }
 
+func TestGL006_OpenAIProjectKey(t *testing.T) {
+	f := findings006(t, `
+variables:
+  OPENAI_KEY: "sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for OpenAI project API key, got %d", len(f))
+	}
+}
+
 func TestGL006_VariableReference_NoFinding(t *testing.T) {
 	f := findings006(t, `
 variables:


### PR DESCRIPTION
## What

Fixes #183.

### 1. OpenAI project API key pattern added

OpenAI project API keys (introduced late 2023) use `sk-proj-[A-Za-z0-9_-]{...}`. The existing `^sk-[A-Za-z0-9]{32,}$` pattern excluded them because the body contains hyphens. Added:

```go
{"OpenAI project API key", regexp.MustCompile(`^sk-proj-[A-Za-z0-9_-]{80,}$`)},
```

The two patterns are intentionally separate: the old one catches classic API keys, the new one catches project keys.

New test: `TestGL006_OpenAIProjectKey`

### 2. Doc pattern table corrected

- Added GitHub fine-grained PAT (`github_pat_…`) — was in the code but missing from the table
- Corrected Slack entry: code covers `xox[baprs]-` (bot, user, app, socket, refresh), not just `xoxb-` / `xoxp-`
- Added OpenAI project API key row
- Minor: added length hints to GitHub PAT and OpenAI classic key entries for clarity

## How to test

```sh
go test ./rules/ -run TestGL006 -v
```