### PR TITLE
GL008: remove deprecated license_management job name

### DIFF
--- a/rules/gl008.go
+++ b/rules/gl008.go
@@ -28,7 +28,6 @@ var securityScanJobs = map[string]bool{
 	"coverage_fuzzing":      true,
 	"api_fuzzing":           true,
 	"license_scanning":      true,
-	"license_management":    true,
 }
 
 func (r *gl008) Check(doc *yaml.Node, file string) []finding.Finding {


### PR DESCRIPTION
`license_management` was the predecessor to `license_scanning`, deprecated in GitLab 13.9 and removed in GitLab 14.0 (June 2021). Keeping it in `securityScanJobs` was harmless but misleading — the doc table already omitted it.

Removed the entry. All existing tests pass unchanged.