### PR TITLE
GL011: detect bash -c "$(curl ...)" command substitution (#188)

### DIFF
--- a/docs/rules/GL011.md
+++ b/docs/rules/GL011.md
@@ -15,6 +15,7 @@ glsec flags script lines that download content with `curl` or `wget` and pipe it
 | Pipe to Ruby/Perl/Node | `curl URL \| ruby` |
 | Process substitution | `python3 <(curl URL)` |
 | Multi-stage pipe | `curl URL \| base64 -d \| bash` |
+| Command substitution | `bash -c "$(curl URL)"` |
 
 ## Trigger example
 

--- a/rules/gl011.go
+++ b/rules/gl011.go
@@ -22,6 +22,8 @@ var (
 	pipeToShellRe = regexp.MustCompile(`\|\s*(?:bash|sh|python[23]?|ruby|perl|node)\b`)
 	// processSubstRe matches bash process substitution: <(curl ...) or <(wget ...).
 	processSubstRe = regexp.MustCompile(`<\s*\(\s*(?:curl|wget)\b`)
+	// cmdSubstRe matches command substitution passed to a shell: bash -c "$(curl ...)".
+	cmdSubstRe = regexp.MustCompile(`\b(?:bash|sh)\b.*\$\(\s*(?:curl|wget)\b`)
 )
 
 func (r *gl011) Check(doc *yaml.Node, file string) []finding.Finding {
@@ -80,6 +82,9 @@ func checkScriptDownloadExecute(node *yaml.Node, file string) []finding.Finding 
 
 func isDownloadExecute(line string) bool {
 	if processSubstRe.MatchString(line) {
+		return true
+	}
+	if cmdSubstRe.MatchString(line) {
 		return true
 	}
 	return downloadToolRe.MatchString(line) && pipeToShellRe.MatchString(line)

--- a/rules/gl011_test.go
+++ b/rules/gl011_test.go
@@ -74,6 +74,28 @@ setup:
 	}
 }
 
+func TestGL011_CommandSubstitutionBash(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - bash -c "$(curl -sSL https://example.com/install.sh)"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for bash -c $(curl ...), got %d", len(f))
+	}
+}
+
+func TestGL011_CommandSubstitutionSh(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - sh -c "$(wget -qO- https://example.com/install.sh)"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for sh -c $(wget ...), got %d", len(f))
+	}
+}
+
 func TestGL011_CurlDownloadOnly_NoFinding(t *testing.T) {
 	f := findings011(t, `
 setup:


### PR DESCRIPTION
## What

Fixes #188.

`sh -c "$(curl -sSL https://example.com/install.sh)"` was not flagged. The rule checked for pipe (`|`) and process substitution (`<(`), but not command substitution (`$(...)`). This pattern is used by Homebrew, nvm, rustup, and other common installers — it appears frequently in CI setup scripts.

## Fix

Added `cmdSubstRe` matching `\b(?:bash|sh)\b.*\$\(\s*(?:curl|wget)\b` and a third branch in `isDownloadExecute`.

New tests:
- `TestGL011_CommandSubstitutionBash` — `bash -c "$(curl ...)"` → 1 finding
- `TestGL011_CommandSubstitutionSh` — `sh -c "$(wget ...)"` → 1 finding

Doc table updated with the new pattern.

## How to test

```sh
go test ./rules/ -run TestGL011 -v
```