### PR TITLE
GL016: scan default: block and top-level scripts for HTTP URLs

### DIFF
--- a/rules/gl016.go
+++ b/rules/gl016.go
@@ -48,6 +48,23 @@ func (r *gl016) Check(doc *yaml.Node, file string) []finding.Finding {
 	// variables: values
 	findings = append(findings, r.checkVariablesHTTP(parser.FindKey(mapping, "variables"), file)...)
 
+	// top-level before_script / after_script
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			findings = append(findings, r.checkScriptHTTP(node, file)...)
+		}
+	}
+
+	// default: variables / before_script / after_script
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, r.checkVariablesHTTP(parser.FindKey(def, "variables"), file)...)
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, r.checkScriptHTTP(node, file)...)
+			}
+		}
+	}
+
 	// per-job
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, f := range r.checkVariablesHTTP(parser.FindKey(job, "variables"), file) {

--- a/rules/gl016_test.go
+++ b/rules/gl016_test.go
@@ -201,6 +201,83 @@ build:
 	}
 }
 
+func TestGL016_TopLevelBeforeScript_Warn(t *testing.T) {
+	f := findings016(t, `
+before_script:
+  - curl http://install.example.com/setup.sh -o setup.sh
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for top-level before_script curl http://, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_TopLevelAfterScript_Warn(t *testing.T) {
+	f := findings016(t, `
+after_script:
+  - wget http://metrics.example.com/report
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for top-level after_script wget http://, got %d", len(f))
+	}
+}
+
+func TestGL016_DefaultVariables_Warn(t *testing.T) {
+	f := findings016(t, `
+default:
+  variables:
+    REGISTRY: "http://registry.example.com"
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for default: variables: http://, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity for public host in default variable, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_DefaultBeforeScript_Warn(t *testing.T) {
+	f := findings016(t, `
+default:
+  before_script:
+    - curl http://nexus.example.com/tool.sh -o tool.sh
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for default: before_script curl http://, got %d", len(f))
+	}
+}
+
+func TestGL016_DefaultVariablesInternal_Info(t *testing.T) {
+	f := findings016(t, `
+default:
+  variables:
+    NEXUS: "http://nexus.internal/repo"
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for default: variables: internal http://, got %d", len(f))
+	}
+	if f[0].Severity != finding.Info {
+		t.Errorf("expected Info severity for internal host, got %s", f[0].Severity)
+	}
+}
+
 func TestGL016_LineNumber(t *testing.T) {
 	f := findings016(t, `
 include:


### PR DESCRIPTION
## Summary

- Adds scanning of top-level `before_script:` / `after_script:` for `curl http://` / `wget http://` downloads
- Adds scanning of `default: variables:` for HTTP URLs
- Adds scanning of `default: before_script:` / `default: after_script:` for HTTP downloads

Closes #190

## What changed

`rules/gl016.go` — three new context checks added to `Check()` before the per-job loop, matching the pattern already used by GL005 and GL011 for the `default:` block.

`rules/gl016_test.go` — five new tests covering each added context (top-level before/after, default variables public + internal, default before_script).

## Test plan

- [ ] `go test ./rules/ -run TestGL016` — all 19 tests pass
- [ ] Top-level `before_script: - curl http://...` → 1 Warn finding
- [ ] Top-level `after_script: - wget http://...` → 1 Warn finding
- [ ] `default: variables: URL: "http://public.example.com"` → 1 Warn finding
- [ ] `default: variables: URL: "http://nexus.internal/..."` → 1 Info finding
- [ ] `default: before_script: - curl http://...` → 1 Warn finding