### PR TITLE
GL018: remove redundant _API_KEY suffix, scan default: variables:

### DIFF
--- a/rules/gl018.go
+++ b/rules/gl018.go
@@ -19,7 +19,7 @@ func (r *gl018) ID() string { return "GL018" }
 // secretNameSuffixes identifies variable names that suggest secret content.
 var secretNameSuffixes = []string{
 	"_TOKEN", "_SECRET", "_PASSWORD", "_PASSWD", "_PASS", "_PWD",
-	"_KEY", "_CREDENTIAL", "_CERT", "_API_KEY",
+	"_KEY", "_CREDENTIAL", "_CERT",
 }
 
 // varRefRe matches a value that is (or starts with) a CI variable reference.
@@ -27,11 +27,23 @@ var varRefRe = regexp.MustCompile(`^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?`)
 
 func (r *gl018) Check(doc *yaml.Node, file string) []finding.Finding {
 	mapping := parser.Unwrap(doc)
-	varsNode := parser.FindKey(mapping, "variables")
-	if varsNode == nil || varsNode.Kind != yaml.MappingNode {
-		return nil
+
+	var findings []finding.Finding
+
+	if varsNode := parser.FindKey(mapping, "variables"); varsNode != nil && varsNode.Kind == yaml.MappingNode {
+		findings = append(findings, checkSecretReexport(varsNode, file)...)
 	}
 
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		if varsNode := parser.FindKey(def, "variables"); varsNode != nil && varsNode.Kind == yaml.MappingNode {
+			findings = append(findings, checkSecretReexport(varsNode, file)...)
+		}
+	}
+
+	return findings
+}
+
+func checkSecretReexport(varsNode *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 	for i := 0; i+1 < len(varsNode.Content); i += 2 {
 		nameNode := varsNode.Content[i]

--- a/rules/gl018_test.go
+++ b/rules/gl018_test.go
@@ -121,6 +121,37 @@ variables:
 	}
 }
 
+func TestGL018_DefaultVariablesToken(t *testing.T) {
+	f := findings018(t, `
+default:
+  variables:
+    PROD_API_TOKEN: $PROD_API_TOKEN
+
+build:
+  script: go build
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for default: variables: secret, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL018_DefaultVariablesNonSecret_NoFinding(t *testing.T) {
+	f := findings018(t, `
+default:
+  variables:
+    REGISTRY_URL: $CI_REGISTRY
+
+build:
+  script: go build
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-secret default variable, got %d", len(f))
+	}
+}
+
 func TestGL018_LineNumber(t *testing.T) {
 	f := findings018(t, `
 variables:


### PR DESCRIPTION
## Summary

- Removes `"_API_KEY"` from `secretNameSuffixes` — it was dead code, already covered by `"_KEY"` via `strings.HasSuffix`
- Adds scanning of `default: variables:` for secret re-export patterns, consistent with GL016 and GL005

Closes #192

## What changed

`rules/gl018.go` — extracted inner loop into `checkSecretReexport()` helper; `Check()` now calls it for both top-level `variables:` and `default: variables:`; removed `"_API_KEY"` from the suffix list.

`rules/gl018_test.go` — two new tests: `default: variables:` with a secret variable (should warn) and with a non-secret variable (should not warn).

## Test plan

- [ ] `go test ./rules/ -run TestGL018` — all 11 tests pass
- [ ] `default: variables: PROD_TOKEN: $PROD_TOKEN` → 1 Warn finding
- [ ] `default: variables: REGISTRY_URL: $CI_REGISTRY` → no finding
- [ ] Existing top-level variable tests still pass