### PR TITLE
GL025: add CI_COMMIT_BRANCH and CI_COMMIT_TAG to user-controlled variables

### DIFF
--- a/docs/rules/GL025.md
+++ b/docs/rules/GL025.md
@@ -15,8 +15,10 @@ The following variables are fully or partially controlled by the author of a bra
 
 | Variable | Controlled via |
 |----------|---------------|
-| `$CI_COMMIT_REF_NAME` | Branch name |
-| `$CI_COMMIT_REF_SLUG` | Branch name (slugified) |
+| `$CI_COMMIT_REF_NAME` | Branch or tag name |
+| `$CI_COMMIT_REF_SLUG` | Branch or tag name (slugified) |
+| `$CI_COMMIT_BRANCH` | Branch name |
+| `$CI_COMMIT_TAG` | Tag name |
 | `$CI_COMMIT_MESSAGE` | Commit message |
 | `$CI_COMMIT_TITLE` | First line of commit message |
 | `$CI_COMMIT_DESCRIPTION` | Body of commit message |

--- a/rules/gl025.go
+++ b/rules/gl025.go
@@ -17,7 +17,7 @@ func (r *gl025) ID() string { return "GL025" }
 // userControlledVarRe matches any of the CI variables an attacker can influence
 // via branch name, MR title, commit message, etc.
 var userControlledVarRe = regexp.MustCompile(
-	`\$\{?CI_(?:COMMIT_REF_NAME|COMMIT_REF_SLUG|COMMIT_MESSAGE|COMMIT_TITLE|COMMIT_DESCRIPTION|MERGE_REQUEST_SOURCE_BRANCH_NAME|MERGE_REQUEST_TITLE)\}?`,
+	`\$\{?CI_(?:COMMIT_REF_NAME|COMMIT_REF_SLUG|COMMIT_BRANCH|COMMIT_TAG|COMMIT_MESSAGE|COMMIT_TITLE|COMMIT_DESCRIPTION|MERGE_REQUEST_SOURCE_BRANCH_NAME|MERGE_REQUEST_TITLE)\}?`,
 )
 
 // curlWgetRe matches curl or wget invocations.

--- a/rules/gl025_test.go
+++ b/rules/gl025_test.go
@@ -155,3 +155,25 @@ notify:
 		t.Fatalf("expected 1 finding for braced variable, got %d", len(f))
 	}
 }
+
+func TestGL025_CommitBranch(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://api.example.com/builds/$CI_COMMIT_BRANCH
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_BRANCH, got %d", len(f))
+	}
+}
+
+func TestGL025_CommitTag(t *testing.T) {
+	f := findings025(t, `
+notify:
+  script:
+    - curl https://api.example.com/releases/$CI_COMMIT_TAG
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_TAG, got %d", len(f))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CI_COMMIT_BRANCH` (branch name) and `CI_COMMIT_TAG` (tag name) to `userControlledVarRe`
- Updates `docs/rules/GL025.md` variable table with both new entries; clarifies `CI_COMMIT_REF_NAME` covers "branch or tag name"

Closes #194

## What changed

`rules/gl025.go` — two new alternations in the regex.

`docs/rules/GL025.md` — two new rows in the variable table.

`rules/gl025_test.go` — two new tests: `CI_COMMIT_BRANCH` and `CI_COMMIT_TAG` in curl URLs.

## Test plan

- [ ] `go test ./rules/ -run TestGL025` — all 15 tests pass
- [ ] `curl https://api.example.com/$CI_COMMIT_BRANCH` → 1 Warn finding
- [ ] `curl https://api.example.com/$CI_COMMIT_TAG` → 1 Warn finding