### PR TITLE
GL026: support --branch=value syntax in branchFlagRe

### DIFF
--- a/rules/gl026.go
+++ b/rules/gl026.go
@@ -25,7 +25,8 @@ var (
 	gitCheckoutRe = regexp.MustCompile(`\bgit\b[^|;&]*\bcheckout\b`)
 
 	// branchFlagRe captures the value of --branch or -b.
-	branchFlagRe = regexp.MustCompile(`(?:--branch|-b)\s+(\S+)`)
+	// Handles both space-separated (--branch main) and equals-sign (--branch=main) forms.
+	branchFlagRe = regexp.MustCompile(`(?:--branch|-b)(?:\s+|=)(\S+)`)
 
 	// newBranchFlagRe detects -b or --orphan (creates a local branch, not a dep checkout).
 	newBranchFlagRe = regexp.MustCompile(`\s(?:-b|--orphan)(?:\s|$)`)

--- a/rules/gl026_test.go
+++ b/rules/gl026_test.go
@@ -43,6 +43,31 @@ build:
 	}
 }
 
+func TestGL026_CloneBranchEqualsForm(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone --branch=main https://github.com/org/tools.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --branch=main, got %d", len(f))
+	}
+	if f[0].Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+func TestGL026_CloneBranchEqualsWithSHA_NoFinding(t *testing.T) {
+	f := findings026(t, `
+build:
+  script:
+    - git clone --branch=`+sha40+` https://github.com/org/lib.git
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for --branch=<sha>, got %d", len(f))
+	}
+}
+
 func TestGL026_CloneWithBranchFlagShortForm(t *testing.T) {
 	f := findings026(t, `
 build:


### PR DESCRIPTION
## Summary

Fixes `branchFlagRe` to accept `--branch=value` (equals sign, no space) in addition to the existing `--branch value` form. Both are valid git syntax.

Closes #195

## What changed

`rules/gl026.go` — regex updated from `(?:--branch|-b)\s+(\S+)` to `(?:--branch|-b)(?:\s+|=)(\S+)`.

`rules/gl026_test.go` — two new tests: `--branch=main` (finding expected) and `--branch=<sha40>` (no finding expected).

## Test plan

- [ ] `go test ./rules/ -run TestGL026` — all 16 tests pass
- [ ] `git clone --branch=main https://...` → 1 Warn finding with message containing "main"
- [ ] `git clone --branch=<sha40> https://...` → no finding