### PR TITLE
docs: add note on CVE scanning for pinned images in GL001

### DIFF
--- a/docs/rules/GL001.md
+++ b/docs/rules/GL001.md
@@ -42,3 +42,5 @@ test:
 Named variant tags such as `docker:dind`, `docker:alpine`, `python:3.11-slim` are **not** flagged — the full tag string is checked against a fixed list of known mutable tags, so version-qualified variants pass through.
 
 Image references that consist entirely of a variable expression (e.g. `image: $MY_IMAGE`) are not flagged — the tag cannot be determined statically.
+
+Pinning an image prevents tag mutation but does not verify whether the pinned version contains known vulnerabilities. Use a dedicated container scanner such as [trivy](https://github.com/aquasecurity/trivy) as a separate CI job to check for CVEs in pinned images.


### PR DESCRIPTION
Pinning an image tag is only half the story — a pinned version can still contain known CVEs. Added a note to the GL001 docs pointing users to trivy for container scanning as a complementary CI job.