### PR TITLE
feat: show job count summary on clean run

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -126,8 +126,11 @@ func main() {
 		seen[abs] = true
 	}
 
+	jobCount := parser.CountJobs(doc.Root)
 	findings := collectFindings(doc, file, cfg, gitlabVersion, *generateIgnoreFlag)
-	findings = append(findings, scanChildPipelines(doc, file, cfg, gitlabVersion, *generateIgnoreFlag, cfg.ExcludePaths, seen, 0)...)
+	childFindings, childJobs := scanChildPipelines(doc, file, cfg, gitlabVersion, *generateIgnoreFlag, cfg.ExcludePaths, seen, 0)
+	findings = append(findings, childFindings...)
+	jobCount += childJobs
 
 	if *generateIgnoreFlag {
 		if err := writeIgnoreFile(suppress.IgnoreFile, findings); err != nil {
@@ -145,7 +148,7 @@ func main() {
 	case output.FormatJSON:
 		writeErr = output.WriteJSON(os.Stdout, findings, rules.OWASPCategories)
 	default:
-		writeErr = output.Write(os.Stdout, format, findings)
+		writeErr = output.Write(os.Stdout, format, findings, jobCount)
 	}
 	if err := writeErr; err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -233,12 +236,14 @@ const maxChildDepth = 5
 
 // scanChildPipelines recursively scans local child pipeline files referenced
 // by trigger: include: in doc. seen prevents re-scanning the same file twice.
-func scanChildPipelines(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, generateIgnore bool, excludePaths []string, seen map[string]bool, depth int) []finding.Finding {
+// Returns findings and the total number of jobs across all child pipelines.
+func scanChildPipelines(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, generateIgnore bool, excludePaths []string, seen map[string]bool, depth int) ([]finding.Finding, int) {
 	if depth >= maxChildDepth {
-		return nil
+		return nil, 0
 	}
 	baseDir := filepath.Dir(path)
 	var all []finding.Finding
+	jobCount := 0
 	for _, child := range parser.ChildPipelinePaths(doc.Root) {
 		childPath := filepath.Join(baseDir, child)
 		if matchesExclude(childPath, excludePaths) {
@@ -255,10 +260,13 @@ func scanChildPipelines(doc *parser.Document, path string, cfg *config.Config, g
 			fmt.Fprintf(os.Stderr, "warning: child pipeline %s: %v\n", childPath, err)
 			continue
 		}
+		jobCount += parser.CountJobs(childDoc.Root)
 		all = append(all, collectFindings(childDoc, childPath, cfg, gitlabVersion, generateIgnore)...)
-		all = append(all, scanChildPipelines(childDoc, childPath, cfg, gitlabVersion, generateIgnore, excludePaths, seen, depth+1)...)
+		childFindings, childJobs := scanChildPipelines(childDoc, childPath, cfg, gitlabVersion, generateIgnore, excludePaths, seen, depth+1)
+		all = append(all, childFindings...)
+		jobCount += childJobs
 	}
-	return all
+	return all, jobCount
 }
 
 // writeIgnoreFile creates or overwrites .glsec-ignore with one entry per finding.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -26,18 +26,18 @@ func ParseFormat(s string) (Format, bool) {
 	}
 }
 
-func Write(w io.Writer, format Format, findings []finding.Finding) error {
+func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int) error {
 	switch format {
 	case FormatJSON:
 		return writeJSON(w, findings, nil)
 	case FormatSARIF:
 		return writeSARIF(w, findings, nil, nil, nil, nil)
 	default:
-		return writeText(w, findings)
+		return writeText(w, findings, jobCount)
 	}
 }
 
-func writeText(w io.Writer, findings []finding.Finding) error {
+func writeText(w io.Writer, findings []finding.Finding, jobCount int) error {
 	for _, f := range findings {
 		var err error
 		if f.Job != "" {
@@ -59,6 +59,10 @@ func writeText(w io.Writer, findings []finding.Finding) error {
 		if err != nil {
 			return err
 		}
+	}
+	if len(findings) == 0 {
+		_, err := fmt.Fprintf(w, "Scanned %d jobs, 0 issues found.\n", jobCount)
+		return err
 	}
 	return nil
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -22,7 +22,7 @@ var testFindingsWithJob = []finding.Finding{
 
 func TestWriteText(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, testFindings); err != nil {
+	if err := Write(&buf, FormatText, testFindings, 5); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -39,17 +39,18 @@ func TestWriteText(t *testing.T) {
 
 func TestWriteText_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, nil); err != nil {
+	if err := Write(&buf, FormatText, nil, 7); err != nil {
 		t.Fatal(err)
 	}
-	if buf.Len() != 0 {
-		t.Errorf("expected empty output for no findings, got %q", buf.String())
+	got := buf.String()
+	if !strings.Contains(got, "7") || !strings.Contains(got, "0 issues found") {
+		t.Errorf("expected summary line with job count, got %q", got)
 	}
 }
 
 func TestWriteJSON(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, testFindings); err != nil {
+	if err := Write(&buf, FormatJSON, testFindings, 0); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -67,7 +68,7 @@ func TestWriteJSON(t *testing.T) {
 
 func TestWriteJSON_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, nil); err != nil {
+	if err := Write(&buf, FormatJSON, nil, 0); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -81,7 +82,7 @@ func TestWriteJSON_Empty(t *testing.T) {
 
 func TestWriteSARIF(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatSARIF, testFindings); err != nil {
+	if err := Write(&buf, FormatSARIF, testFindings, 0); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -112,7 +113,7 @@ func TestWriteSARIF(t *testing.T) {
 
 func TestWriteText_WithJob(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, testFindingsWithJob); err != nil {
+	if err := Write(&buf, FormatText, testFindingsWithJob, 3); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -132,7 +133,7 @@ func TestWriteText_WithJob(t *testing.T) {
 
 func TestWriteJSON_WithJob(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, testFindingsWithJob); err != nil {
+	if err := Write(&buf, FormatJSON, testFindingsWithJob, 0); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -87,6 +87,13 @@ var reservedKeys = map[string]bool{
 	"after_script":  true,
 }
 
+// CountJobs returns the number of job definitions in the document.
+func CountJobs(doc *yaml.Node) int {
+	n := 0
+	EachJob(doc, func(*yaml.Node, *yaml.Node) { n++ })
+	return n
+}
+
 // EachJob calls fn for each job definition in the document.
 func EachJob(doc *yaml.Node, fn func(name *yaml.Node, job *yaml.Node)) {
 	mapping := doc


### PR DESCRIPTION
Closes #143

## What changed

When glsec finds no issues, it now prints a summary line instead of being silent:

```
Scanned 12 jobs, 0 issues found.
```

The count includes jobs from the main pipeline file and all child pipelines (recursively). Hidden jobs (`.template-name`) are included since glsec scans them too. JSON and SARIF output are unchanged.

## Implementation

- `parser.CountJobs(node)` added — thin wrapper around `EachJob`
- `output.Write` / `writeText` accept a `jobCount int` parameter; summary is printed only when `len(findings) == 0`
- `scanChildPipelines` now returns `([]finding.Finding, int)` to accumulate child job counts

## How to test

```bash
# clean pipeline
glsec testdata/clean.yml
# expected: "Scanned N jobs, 0 issues found."

# pipeline with findings — no summary line
glsec testdata/dirty.yml
```