### PR TITLE
feat: result cache keyed on version and input file hashes

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/glsec/glsec/internal/cache"
 	"github.com/glsec/glsec/internal/config"
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/output"
@@ -33,6 +34,8 @@ func main() {
 	strictFlag := flag.Bool("strict", false, "treat warn findings as errors for the exit code (output severity is unchanged)")
 	noExitCodesFlag := flag.Bool("no-exit-codes", false, "always exit 0 on successful execution, regardless of findings")
 	generateIgnoreFlag := flag.Bool("generate-ignore", false, "write all current findings to .glsec-ignore as a baseline and exit 0")
+	noCacheFlag := flag.Bool("no-cache", false, "disable result cache for this run")
+	clearCacheFlag := flag.Bool("clear-cache", false, "remove all cached results and exit")
 	var excludeArgs []string
 	flag.Func("exclude", "exclude a file or glob pattern from scanning (may be repeated)", func(s string) error {
 		excludeArgs = append(excludeArgs, s)
@@ -47,6 +50,15 @@ func main() {
 
 	if *versionFlag {
 		fmt.Printf("glsec %s (commit %s, built %s)\n", resolvedVersion(), commit, date)
+		return
+	}
+
+	if *clearCacheFlag {
+		if err := cache.Clear(); err != nil {
+			fmt.Fprintf(os.Stderr, "error: --clear-cache: %v\n", err)
+			os.Exit(2)
+		}
+		fmt.Fprintln(os.Stderr, "cache cleared")
 		return
 	}
 
@@ -121,16 +133,40 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Collect all pipeline documents first so we can build a complete cache key.
 	seen := map[string]bool{}
 	if abs, absErr := filepath.Abs(file); absErr == nil {
 		seen[abs] = true
 	}
+	allDocs := collectDocuments(doc, file, cfg.ExcludePaths, seen)
 
+	// Compute job count across all documents.
 	jobCount := parser.CountJobs(doc.Root)
-	findings := collectFindings(doc, file, cfg, gitlabVersion, *generateIgnoreFlag)
-	childFindings, childJobs := scanChildPipelines(doc, file, cfg, gitlabVersion, *generateIgnoreFlag, cfg.ExcludePaths, seen, 0)
-	findings = append(findings, childFindings...)
-	jobCount += childJobs
+	for _, d := range allDocs[1:] {
+		jobCount += parser.CountJobs(d.Root)
+	}
+
+	// Cache lookup (skipped for --generate-ignore since it writes new state).
+	useCache := !*noCacheFlag && !*generateIgnoreFlag
+	var cacheKey string
+	if useCache {
+		filePaths := make([]string, len(allDocs))
+		for i, d := range allDocs {
+			filePaths[i] = d.File
+		}
+		cacheKey, err = cache.Key(resolvedVersion(), gitlabVersionStr, filePaths, *configFlag, suppress.IgnoreFile, cfg.ExcludePaths)
+		if err == nil {
+			if entry, ok := cache.Load(cacheKey); ok {
+				writeAndExit(os.Stdout, format, entry.Findings, entry.JobCount, cfg)
+			}
+		}
+	}
+
+	// Cache miss — run rules across all collected documents.
+	var findings []finding.Finding
+	for _, d := range allDocs {
+		findings = append(findings, collectFindings(d, d.File, cfg, gitlabVersion, *generateIgnoreFlag)...)
+	}
 
 	if *generateIgnoreFlag {
 		if err := writeIgnoreFile(suppress.IgnoreFile, findings); err != nil {
@@ -141,17 +177,25 @@ func main() {
 		return // exit 0
 	}
 
+	if useCache && cacheKey != "" {
+		cache.Store(cacheKey, &cache.Entry{Findings: findings, JobCount: jobCount})
+	}
+
+	writeAndExit(os.Stdout, format, findings, jobCount, cfg)
+}
+
+func writeAndExit(w *os.File, format output.Format, findings []finding.Finding, jobCount int, cfg *config.Config) {
 	var writeErr error
 	switch format {
 	case output.FormatSARIF:
-		writeErr = output.WriteSARIF(os.Stdout, findings, rules.CWEID, rules.CWEName, rules.OWASPCategories, rules.OWASPCategoryName)
+		writeErr = output.WriteSARIF(w, findings, rules.CWEID, rules.CWEName, rules.OWASPCategories, rules.OWASPCategoryName)
 	case output.FormatJSON:
-		writeErr = output.WriteJSON(os.Stdout, findings, rules.OWASPCategories)
+		writeErr = output.WriteJSON(w, findings, rules.OWASPCategories)
 	default:
-		writeErr = output.Write(os.Stdout, format, findings, jobCount)
+		writeErr = output.Write(w, format, findings, jobCount)
 	}
-	if err := writeErr; err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	if writeErr != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", writeErr)
 		os.Exit(2)
 	}
 
@@ -202,6 +246,31 @@ func matchesExclude(file string, patterns []string) bool {
 	return false
 }
 
+// collectDocuments recursively collects all pipeline documents (main + children)
+// without running any rules. The first element is always the root document.
+func collectDocuments(doc *parser.Document, path string, excludePaths []string, seen map[string]bool) []*parser.Document {
+	all := []*parser.Document{doc}
+	baseDir := filepath.Dir(path)
+	for _, child := range parser.ChildPipelinePaths(doc.Root) {
+		childPath := filepath.Join(baseDir, child)
+		if matchesExclude(childPath, excludePaths) {
+			continue
+		}
+		abs, err := filepath.Abs(childPath)
+		if err != nil || seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		childDoc, err := parser.ParseFile(childPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: child pipeline %s: %v\n", childPath, err)
+			continue
+		}
+		all = append(all, collectDocuments(childDoc, childPath, excludePaths, seen)...)
+	}
+	return all
+}
+
 // collectFindings runs all applicable rules against doc and returns the findings.
 func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, generateIgnore bool) []finding.Finding {
 	sm := suppress.Build(doc.Root)
@@ -230,43 +299,6 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 		}
 	}
 	return findings
-}
-
-const maxChildDepth = 5
-
-// scanChildPipelines recursively scans local child pipeline files referenced
-// by trigger: include: in doc. seen prevents re-scanning the same file twice.
-// Returns findings and the total number of jobs across all child pipelines.
-func scanChildPipelines(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, generateIgnore bool, excludePaths []string, seen map[string]bool, depth int) ([]finding.Finding, int) {
-	if depth >= maxChildDepth {
-		return nil, 0
-	}
-	baseDir := filepath.Dir(path)
-	var all []finding.Finding
-	jobCount := 0
-	for _, child := range parser.ChildPipelinePaths(doc.Root) {
-		childPath := filepath.Join(baseDir, child)
-		if matchesExclude(childPath, excludePaths) {
-			continue
-		}
-		abs, err := filepath.Abs(childPath)
-		if err != nil || seen[abs] {
-			continue
-		}
-		seen[abs] = true
-
-		childDoc, err := parser.ParseFile(childPath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: child pipeline %s: %v\n", childPath, err)
-			continue
-		}
-		jobCount += parser.CountJobs(childDoc.Root)
-		all = append(all, collectFindings(childDoc, childPath, cfg, gitlabVersion, generateIgnore)...)
-		childFindings, childJobs := scanChildPipelines(childDoc, childPath, cfg, gitlabVersion, generateIgnore, excludePaths, seen, depth+1)
-		all = append(all, childFindings...)
-		jobCount += childJobs
-	}
-	return all, jobCount
 }
 
 // writeIgnoreFile creates or overwrites .glsec-ignore with one entry per finding.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -40,14 +40,14 @@ func Dir() string {
 func Key(version, gitlabVersion string, filePaths []string, configPath, ignorePath string, excludePatterns []string) (string, error) {
 	h := sha256.New()
 
-	fmt.Fprintf(h, "version:%s\n", version)
-	fmt.Fprintf(h, "gitlab-version:%s\n", gitlabVersion)
+	_, _ = fmt.Fprintf(h, "version:%s\n", version)
+	_, _ = fmt.Fprintf(h, "gitlab-version:%s\n", gitlabVersion)
 
 	sorted := make([]string, len(excludePatterns))
 	copy(sorted, excludePatterns)
 	sort.Strings(sorted)
 	for _, p := range sorted {
-		fmt.Fprintf(h, "exclude:%s\n", p)
+		_, _ = fmt.Fprintf(h, "exclude:%s\n", p)
 	}
 
 	sortedFiles := make([]string, len(filePaths))
@@ -75,7 +75,7 @@ func hashFile(h io.Writer, path string) error {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Fprintf(h, "file:%s:missing\n", path)
+			_, _ = fmt.Fprintf(h, "file:%s:missing\n", path)
 			return nil
 		}
 		return err
@@ -83,13 +83,13 @@ func hashFile(h io.Writer, path string) error {
 	data, err := os.ReadFile(resolved) //nolint:gosec
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Fprintf(h, "file:%s:missing\n", path)
+			_, _ = fmt.Fprintf(h, "file:%s:missing\n", path)
 			return nil
 		}
 		return err
 	}
 	fh := sha256.Sum256(data)
-	fmt.Fprintf(h, "file:%s:%s\n", path, hex.EncodeToString(fh[:]))
+	_, _ = fmt.Fprintf(h, "file:%s:%s\n", path, hex.EncodeToString(fh[:]))
 	return nil
 }
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,146 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/glsec/glsec/internal/finding"
+)
+
+// Entry is a cached scan result.
+type Entry struct {
+	Findings []finding.Finding `json:"findings"`
+	JobCount int               `json:"job_count"`
+	CachedAt time.Time         `json:"cached_at"`
+}
+
+// Dir returns the glsec cache directory, respecting XDG_CACHE_HOME.
+func Dir() string {
+	base := os.Getenv("XDG_CACHE_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		base = filepath.Join(home, ".cache")
+	}
+	return filepath.Join(base, "glsec")
+}
+
+// Key computes a deterministic hex key from all inputs that affect scan results.
+// filePaths must include the main pipeline file and all discovered child pipeline files.
+// configPath and ignorePath are read from disk if they exist.
+func Key(version, gitlabVersion string, filePaths []string, configPath, ignorePath string, excludePatterns []string) (string, error) {
+	h := sha256.New()
+
+	fmt.Fprintf(h, "version:%s\n", version)
+	fmt.Fprintf(h, "gitlab-version:%s\n", gitlabVersion)
+
+	sorted := make([]string, len(excludePatterns))
+	copy(sorted, excludePatterns)
+	sort.Strings(sorted)
+	for _, p := range sorted {
+		fmt.Fprintf(h, "exclude:%s\n", p)
+	}
+
+	sortedFiles := make([]string, len(filePaths))
+	copy(sortedFiles, filePaths)
+	sort.Strings(sortedFiles)
+	for _, path := range sortedFiles {
+		if err := hashFile(h, path); err != nil {
+			return "", err
+		}
+	}
+
+	for _, path := range []string{configPath, ignorePath} {
+		if path == "" {
+			continue
+		}
+		if err := hashFile(h, path); err != nil && !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func hashFile(h io.Writer, path string) error {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(h, "file:%s:missing\n", path)
+			return nil
+		}
+		return err
+	}
+	data, err := os.ReadFile(resolved) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(h, "file:%s:missing\n", path)
+			return nil
+		}
+		return err
+	}
+	fh := sha256.Sum256(data)
+	fmt.Fprintf(h, "file:%s:%s\n", path, hex.EncodeToString(fh[:]))
+	return nil
+}
+
+// Load reads a cached entry by key. Returns nil, false on miss or error.
+func Load(key string) (*Entry, bool) {
+	dir := Dir()
+	if dir == "" {
+		return nil, false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, key+".json")) //nolint:gosec
+	if err != nil {
+		return nil, false
+	}
+	var entry Entry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, false
+	}
+	return &entry, true
+}
+
+// Store writes an entry to the cache. Silently ignores write errors.
+func Store(key string, entry *Entry) {
+	dir := Dir()
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return
+	}
+	entry.CachedAt = time.Now()
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(dir, key+".json"), data, 0600) //nolint:gosec
+}
+
+// Clear removes all cached entries.
+func Clear() error {
+	dir := Dir()
+	if dir == "" {
+		return nil
+	}
+	entries, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if err := os.Remove(e); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,112 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+)
+
+func TestStoreAndLoad(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	entry := &Entry{
+		Findings: []finding.Finding{
+			{RuleID: "GL001", Severity: finding.Error, File: "ci.yml", Line: 4, Message: "mutable tag"},
+		},
+		JobCount: 5,
+	}
+
+	Store("testkey", entry)
+
+	got, ok := Load("testkey")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if len(got.Findings) != 1 || got.Findings[0].RuleID != "GL001" {
+		t.Errorf("unexpected findings: %+v", got.Findings)
+	}
+	if got.JobCount != 5 {
+		t.Errorf("expected JobCount=5, got %d", got.JobCount)
+	}
+}
+
+func TestLoad_Miss(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	_, ok := Load("doesnotexist")
+	if ok {
+		t.Error("expected cache miss")
+	}
+}
+
+func TestClear(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	Store("key1", &Entry{JobCount: 1})
+	Store("key2", &Entry{JobCount: 2})
+
+	if err := Clear(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := Load("key1"); ok {
+		t.Error("expected key1 to be cleared")
+	}
+	if _, ok := Load("key2"); ok {
+		t.Error("expected key2 to be cleared")
+	}
+}
+
+func TestKey_Deterministic(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "ci.yml")
+	if err := os.WriteFile(f, []byte("stages: [build]"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	k1, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	k2, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k1 != k2 {
+		t.Errorf("key not deterministic: %q vs %q", k1, k2)
+	}
+}
+
+func TestKey_DiffersOnContentChange(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "ci.yml")
+
+	if err := os.WriteFile(f, []byte("stages: [build]"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	k1, err := Key("v1.0.0", "", []string{f}, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(f, []byte("stages: [deploy]"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	k2, err := Key("v1.0.0", "", []string{f}, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if k1 == k2 {
+		t.Error("key should differ when file content changes")
+	}
+}
+
+func TestKey_DiffersOnVersion(t *testing.T) {
+	k1, _ := Key("v1.0.0", "", nil, "", "", nil)
+	k2, _ := Key("v1.0.1", "", nil, "", "", nil)
+	if k1 == k2 {
+		t.Error("key should differ on version change")
+	}
+}


### PR DESCRIPTION
Closes #157

## What changed

Adds a disk-based result cache so repeated runs with unchanged inputs return instantly. Particularly useful in pre-commit hooks and CI jobs where `.gitlab-ci.yml` rarely changes between runs.

## Cache key

A run is fully deterministic given glsec version, `--gitlab-version`, all scanned file contents (main + child pipelines), `.glsec.yml`, `.glsec-ignore`, and `--exclude` patterns. All of these are SHA-256 hashed into a single hex key.

## Cache location

`$XDG_CACHE_HOME/glsec/` (falls back to `~/.cache/glsec/`). Each entry is a `<hex-key>.json` file containing serialised findings, job count, and timestamp.

## New flags

- `--no-cache` — skip cache for this run (reads and writes nothing)
- `--clear-cache` — wipe all cached entries and exit

## Implementation notes

- File collection (`collectDocuments`) is now separated from rule execution (`collectFindings`), so all child pipeline paths are known before computing the cache key
- `--generate-ignore` bypasses the cache entirely since it writes new state
- Write errors are silently ignored (read-only filesystem, missing home dir)
- Symlinks are resolved before hashing so the content hash is stable

## How to test

```bash
# first run — cache miss, runs rules
glsec .gitlab-ci.yml

# second run — cache hit, instant
glsec .gitlab-ci.yml

# bypass cache
glsec --no-cache .gitlab-ci.yml

# clear cache
glsec --clear-cache
```