### PR TITLE
feat: colored text output with TTY detection and NO_COLOR support

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/glsec/glsec/internal/cache"
+	"github.com/glsec/glsec/internal/color"
 	"github.com/glsec/glsec/internal/config"
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/output"
@@ -36,6 +37,7 @@ func main() {
 	generateIgnoreFlag := flag.Bool("generate-ignore", false, "write all current findings to .glsec-ignore as a baseline and exit 0")
 	noCacheFlag := flag.Bool("no-cache", false, "disable result cache for this run")
 	clearCacheFlag := flag.Bool("clear-cache", false, "remove all cached results and exit")
+	noColorFlag := flag.Bool("no-color", false, "disable colored output")
 	var excludeArgs []string
 	flag.Func("exclude", "exclude a file or glob pattern from scanning (may be repeated)", func(s string) error {
 		excludeArgs = append(excludeArgs, s)
@@ -146,6 +148,8 @@ func main() {
 		jobCount += parser.CountJobs(d.Root)
 	}
 
+	colorEnabled := color.IsEnabled(*noColorFlag, os.Stdout)
+
 	// Cache lookup (skipped for --generate-ignore since it writes new state).
 	useCache := !*noCacheFlag && !*generateIgnoreFlag
 	var cacheKey string
@@ -157,7 +161,7 @@ func main() {
 		cacheKey, err = cache.Key(resolvedVersion(), gitlabVersionStr, filePaths, *configFlag, suppress.IgnoreFile, cfg.ExcludePaths)
 		if err == nil {
 			if entry, ok := cache.Load(cacheKey); ok {
-				writeAndExit(os.Stdout, format, entry.Findings, entry.JobCount, cfg)
+				writeAndExit(os.Stdout, format, entry.Findings, entry.JobCount, cfg, colorEnabled)
 			}
 		}
 	}
@@ -181,10 +185,10 @@ func main() {
 		cache.Store(cacheKey, &cache.Entry{Findings: findings, JobCount: jobCount})
 	}
 
-	writeAndExit(os.Stdout, format, findings, jobCount, cfg)
+	writeAndExit(os.Stdout, format, findings, jobCount, cfg, colorEnabled)
 }
 
-func writeAndExit(w *os.File, format output.Format, findings []finding.Finding, jobCount int, cfg *config.Config) {
+func writeAndExit(w *os.File, format output.Format, findings []finding.Finding, jobCount int, cfg *config.Config, colorEnabled bool) {
 	var writeErr error
 	switch format {
 	case output.FormatSARIF:
@@ -192,7 +196,7 @@ func writeAndExit(w *os.File, format output.Format, findings []finding.Finding, 
 	case output.FormatJSON:
 		writeErr = output.WriteJSON(w, findings, rules.OWASPCategories)
 	default:
-		writeErr = output.Write(w, format, findings, jobCount)
+		writeErr = output.Write(w, format, findings, jobCount, colorEnabled)
 	}
 	if writeErr != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", writeErr)

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,0 +1,57 @@
+package color
+
+import (
+	"io"
+	"os"
+)
+
+const (
+	reset  = "\033[0m"
+	bold   = "\033[1m"
+	red    = "\033[31m"
+	yellow = "\033[33m"
+)
+
+// IsEnabled returns true if color output should be used.
+// Color is disabled when:
+//   - noColor is true (--no-color flag)
+//   - NO_COLOR env var is set (https://no-color.org)
+//   - w is not a terminal
+func IsEnabled(noColor bool, w io.Writer) bool {
+	if noColor || os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// Red wraps s in red ANSI codes if enabled.
+func Red(s string, enabled bool) string {
+	if !enabled {
+		return s
+	}
+	return red + s + reset
+}
+
+// Yellow wraps s in yellow ANSI codes if enabled.
+func Yellow(s string, enabled bool) string {
+	if !enabled {
+		return s
+	}
+	return yellow + s + reset
+}
+
+// Bold wraps s in bold ANSI codes if enabled.
+func Bold(s string, enabled bool) string {
+	if !enabled {
+		return s
+	}
+	return bold + s + reset
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/glsec/glsec/internal/color"
 	"github.com/glsec/glsec/internal/finding"
 )
 
@@ -26,34 +27,37 @@ func ParseFormat(s string) (Format, bool) {
 	}
 }
 
-func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int) error {
+func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int, colorEnabled bool) error {
 	switch format {
 	case FormatJSON:
 		return writeJSON(w, findings, nil)
 	case FormatSARIF:
 		return writeSARIF(w, findings, nil, nil, nil, nil)
 	default:
-		return writeText(w, findings, jobCount)
+		return writeText(w, findings, jobCount, colorEnabled)
 	}
 }
 
-func writeText(w io.Writer, findings []finding.Finding, jobCount int) error {
+func writeText(w io.Writer, findings []finding.Finding, jobCount int, col bool) error {
 	for _, f := range findings {
+		sev := strings.ToUpper(string(f.Severity))
+		switch f.Severity {
+		case finding.Error:
+			sev = color.Red(sev, col)
+		case finding.Warn:
+			sev = color.Yellow(sev, col)
+		}
+		ruleID := color.Bold(f.RuleID, col)
+		location := color.Bold(fmt.Sprintf("%s:%d", f.File, f.Line), col)
+
 		var err error
 		if f.Job != "" {
-			_, err = fmt.Fprintf(w, "%-6s %s:%d  %s  [%s]  %s\n",
-				strings.ToUpper(string(f.Severity)),
-				f.File, f.Line,
-				f.RuleID,
-				f.Job,
-				f.Message,
+			_, err = fmt.Fprintf(w, "%-6s %s  %s  [%s]  %s\n",
+				sev, location, ruleID, f.Job, f.Message,
 			)
 		} else {
-			_, err = fmt.Fprintf(w, "%-6s %s:%d  %s  %s\n",
-				strings.ToUpper(string(f.Severity)),
-				f.File, f.Line,
-				f.RuleID,
-				f.Message,
+			_, err = fmt.Fprintf(w, "%-6s %s  %s  %s\n",
+				sev, location, ruleID, f.Message,
 			)
 		}
 		if err != nil {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -22,7 +22,7 @@ var testFindingsWithJob = []finding.Finding{
 
 func TestWriteText(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, testFindings, 5); err != nil {
+	if err := Write(&buf, FormatText, testFindings, 5, false); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -39,7 +39,7 @@ func TestWriteText(t *testing.T) {
 
 func TestWriteText_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, nil, 7); err != nil {
+	if err := Write(&buf, FormatText, nil, 7, false); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -50,7 +50,7 @@ func TestWriteText_Empty(t *testing.T) {
 
 func TestWriteJSON(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, testFindings, 0); err != nil {
+	if err := Write(&buf, FormatJSON, testFindings, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -68,7 +68,7 @@ func TestWriteJSON(t *testing.T) {
 
 func TestWriteJSON_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, nil, 0); err != nil {
+	if err := Write(&buf, FormatJSON, nil, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -82,7 +82,7 @@ func TestWriteJSON_Empty(t *testing.T) {
 
 func TestWriteSARIF(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatSARIF, testFindings, 0); err != nil {
+	if err := Write(&buf, FormatSARIF, testFindings, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -113,7 +113,7 @@ func TestWriteSARIF(t *testing.T) {
 
 func TestWriteText_WithJob(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, testFindingsWithJob, 3); err != nil {
+	if err := Write(&buf, FormatText, testFindingsWithJob, 3, false); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -133,7 +133,7 @@ func TestWriteText_WithJob(t *testing.T) {
 
 func TestWriteJSON_WithJob(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, testFindingsWithJob, 0); err != nil {
+	if err := Write(&buf, FormatJSON, testFindingsWithJob, 0, false); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput


### PR DESCRIPTION
Closes #200

## What changed

Text output now uses ANSI colors when writing to a terminal:

- `ERROR` → red
- `WARN` → yellow
- Rule ID and file:line → bold

Color is automatically disabled when stdout is not a TTY (piped output, CI log redirection), when `NO_COLOR` is set in the environment ([no-color.org](https://no-color.org)), or when `--no-color` is passed.

JSON and SARIF output are unchanged.

## Implementation

- New `internal/color` package — no external dependencies, raw ANSI escape codes
- TTY detection via `os.File.Stat()` + `ModeCharDevice`
- `color.IsEnabled(noColor bool, w io.Writer) bool` centralises the decision
- `output.Write` / `writeText` accept a `colorEnabled bool` parameter

## How to test

```bash
# colored output in terminal
glsec .gitlab-ci.yml

# no color when piped
glsec .gitlab-ci.yml | cat

# force disable
glsec --no-color .gitlab-ci.yml
NO_COLOR=1 glsec .gitlab-ci.yml
```