### PR TITLE
feat(GL005): flag absolute paths and path traversal in artifact paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,50 @@ func TestGL006_Clean(t *testing.T) {
 
 Cover the happy path (flagged), the clean path, and any edge cases (empty values, missing keys, nested structures).
 
+### Avoiding false positives
+
+Before finishing a rule, work through this checklist:
+
+**1. Verify the YAML key exists and does what you think**
+
+Check the [GitLab CI/CD YAML syntax reference](https://docs.gitlab.com/ci/yaml/) to confirm the key you are inspecting is actually used by GitLab Runner, not just valid YAML syntax. A key that GitLab silently ignores cannot be a real vulnerability.
+
+Common areas to check:
+- [`artifacts:`](https://docs.gitlab.com/ci/yaml/#artifacts) — paths, exclude, reports, expire_in
+- [`variables:`](https://docs.gitlab.com/ci/yaml/#variables) — job-level vs. global, `expand`/`value`/`description` sub-keys
+- [`rules:`](https://docs.gitlab.com/ci/yaml/#rules) — if, changes, exists, when, variables
+- [`trigger:`](https://docs.gitlab.com/ci/yaml/#trigger) — forward, strategy, branch
+
+**2. Consider common legitimate patterns**
+
+Before flagging a pattern, search for how it is used in real-world GitLab CI configs. If a pattern appears constantly in legitimate pipelines (e.g. `dist/$CI_COMMIT_REF_NAME` as an artifact path), the rule will create noise and get ignored or suppressed.
+
+Ask: _is there a realistic, benign configuration that would trigger this finding?_ If yes, refine the detection or raise the threshold.
+
+**3. Understand variable constraints**
+
+[Predefined CI/CD variables](https://docs.gitlab.com/ci/variables/predefined_variables/) are not all equal. Variables derived from Git ref names (`CI_COMMIT_REF_NAME`, `CI_COMMIT_BRANCH`, `CI_COMMIT_TAG`, `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`) are constrained by [`git check-ref-format`](https://git-scm.com/docs/git-check-ref-format) and cannot contain sequences like `..`. Free-form text variables (`CI_COMMIT_MESSAGE`, `CI_MERGE_REQUEST_TITLE`, `CI_PIPELINE_NAME`, etc.) can contain arbitrary content. Treat them differently when assessing injection risk.
+
+**4. Write an explicit no-finding test**
+
+Every rule must have at least one test that asserts _zero_ findings for a realistic, valid config. Name it `TestGLNNN_<CommonPattern>NoFinding` or `TestGLNNN_Clean` so its intent is clear:
+
+```go
+func TestGL006_CommonPatternNoFinding(t *testing.T) {
+    f := findings006(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - dist/$CI_COMMIT_REF_NAME   # common pattern — must not be flagged
+    expire_in: 1 week
+`)
+    if len(f) != 0 {
+        t.Fatalf("expected no findings for common artifact path, got %d", len(f))
+    }
+}
+```
+
 ### Step 6 — add a fixture
 
 Create `testdata/fixtures/glNNN-short-name.yml` with a realistic example that exercises the rule. The fixture must be valid GitLab CI YAML — CI validates all fixtures against the GitLab CI JSON schema via `check-jsonschema`.

--- a/docs/rules/GL005.md
+++ b/docs/rules/GL005.md
@@ -1,17 +1,26 @@
 # GL005 — Sensitive artifacts
 
-**Severity:** `error` (sensitive paths) / `warn` (missing `expire_in`)  
+**Severity:** `error` (sensitive paths, absolute paths, path traversal) / `warn` (missing `expire_in`)  
 **OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
+**CWE:** [CWE-23 – Relative Path Traversal](https://cwe.mitre.org/data/definitions/23.html)
 
 ## Risk
 
-Storing secrets in job artifacts exposes them to anyone with read access to the project and its pipelines. Missing `expire_in` keeps artifacts (and any secrets they contain) indefinitely, compounding the exposure window.
+Storing secrets in job artifacts exposes them to anyone with read access to the project and its pipelines. Absolute paths and path traversal sequences can exfiltrate arbitrary host files on shell-executor runners. Missing `expire_in` keeps artifacts indefinitely, compounding the exposure window.
 
 ## What is flagged
 
-Applies to `artifacts:` at `default:` and job level.
+Applies to `artifacts:paths:` and `artifacts:exclude:` at `default:` and job level.
 
-**Sensitive file patterns in `artifacts: paths:`:**
+**Absolute paths (`error`):**
+
+A path starting with `/` references the host filesystem directly. On a shell executor this can exfiltrate any file the runner user can read.
+
+**Path traversal (`error`):**
+
+A path containing `../` attempts to escape the project directory.
+
+**Sensitive file patterns (`error`):**
 
 | Pattern | Examples |
 |---------|---------|
@@ -27,18 +36,20 @@ Applies to `artifacts:` at `default:` and job level.
 | `*.token` | Token files |
 | `*.tfstate`, `*.tfvars` | Terraform state and variable files |
 
-**Missing `expire_in`:**
+**Missing `expire_in` (`warn`):**
 
 Any `artifacts:` block without an `expire_in` key. Artifacts kept forever increase the blast radius of any sensitive content they contain.
 
-## Trigger example
+## Trigger examples
 
 ```yaml
 build:
   artifacts:
     paths:
-      - .env              # sensitive file pattern
-      - deploy.pem        # private key
+      - /etc/passwd                   # absolute path — host filesystem
+      - ../../etc/shadow              # path traversal — escapes project dir
+      - .env                          # sensitive file pattern
+      - deploy.pem                    # private key
     # no expire_in — artifacts kept forever
 ```
 
@@ -57,5 +68,6 @@ Never include secret files in artifact paths. Use [GitLab CI/CD variables](https
 
 ## Notes
 
-- Pattern matching is case-insensitive and uses glob-style prefix/suffix matching
-- `expire_in` is flagged as a separate finding regardless of whether sensitive paths are present
+- Absolute path and path traversal checks are active vulnerability indicators on shell-executor runners; on Docker executors the Runner enforces project-directory boundaries at upload time, making these defence-in-depth catches
+- Pattern matching for sensitive filenames is case-insensitive and uses glob-style prefix/suffix matching
+- `expire_in` is flagged as a separate finding regardless of whether other issues are present

--- a/rules/gl005.go
+++ b/rules/gl005.go
@@ -57,22 +57,16 @@ func (r *gl005) Check(doc *yaml.Node, file string) []finding.Finding {
 func checkArtifacts(node *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
-	pathsNode := parser.FindKey(node, "paths")
-	if pathsNode != nil && pathsNode.Kind == yaml.SequenceNode {
-		for _, item := range pathsNode.Content {
+	for _, section := range []string{"paths", "exclude"} {
+		seqNode := parser.FindKey(node, section)
+		if seqNode == nil || seqNode.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range seqNode.Content {
 			if item.Kind != yaml.ScalarNode {
 				continue
 			}
-			if pat := matchesSensitivePattern(item.Value); pat != "" {
-				findings = append(findings, finding.Finding{
-					RuleID:   "GL005",
-					Severity: finding.Error,
-					Message:  fmt.Sprintf("artifact path %q matches sensitive file pattern %q — exclude secrets from artifacts", item.Value, pat),
-					File:     file,
-					Line:     item.Line,
-					Col:      item.Column,
-				})
-			}
+			findings = append(findings, checkArtifactPath(item, file)...)
 		}
 	}
 
@@ -86,6 +80,45 @@ func checkArtifacts(node *yaml.Node, file string) []finding.Finding {
 			Line:     node.Line,
 			Col:      node.Column,
 		})
+	}
+
+	return findings
+}
+
+func checkArtifactPath(item *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	path := item.Value
+
+	switch {
+	case strings.HasPrefix(path, "/"):
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL005",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("artifact path %q is an absolute path — references the host filesystem directly and can exfiltrate arbitrary files on shell executors", path),
+			File:     file,
+			Line:     item.Line,
+			Col:      item.Column,
+		})
+	case strings.Contains(path, "../"):
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL005",
+			Severity: finding.Error,
+			Message:  fmt.Sprintf("artifact path %q contains path traversal — can escape the project directory on shell executors", path),
+			File:     file,
+			Line:     item.Line,
+			Col:      item.Column,
+		})
+	default:
+		if pat := matchesSensitivePattern(path); pat != "" {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL005",
+				Severity: finding.Error,
+				Message:  fmt.Sprintf("artifact path %q matches sensitive file pattern %q — exclude secrets from artifacts", path, pat),
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
 	}
 
 	return findings

--- a/rules/gl005_test.go
+++ b/rules/gl005_test.go
@@ -172,6 +172,90 @@ build:
 	}
 }
 
+func TestGL005_AbsolutePath(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - /etc/passwd
+    expire_in: 1 day
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for absolute path, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL005_PathTraversal(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - ../../etc/shadow
+    expire_in: 1 day
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for path traversal, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL005_UserControlledVarNoFinding(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - dist/$CI_COMMIT_REF_NAME
+    expire_in: 1 day
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for common branch-based artifact path, got %d", len(f))
+	}
+}
+
+func TestGL005_ExcludePath(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - dist/
+    exclude:
+      - ../secrets.env
+    expire_in: 1 day
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for traversal in exclude, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL005_AbsolutePathWithVar(t *testing.T) {
+	f := findings005(t, `
+build:
+  script: [make]
+  artifacts:
+    paths:
+      - /tmp/$CI_COMMIT_REF_NAME
+    expire_in: 1 day
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (absolute path only), got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
 func TestGL005_NoArtifacts(t *testing.T) {
 	f := findings005(t, `
 build:

--- a/testdata/fixtures/gl005-sensitive-artifacts.yml
+++ b/testdata/fixtures/gl005-sensitive-artifacts.yml
@@ -12,3 +12,7 @@ build-job:
       - dist/
       - .env.production
       - deploy-key.pem
+      - /etc/passwd
+      - ../../etc/shadow
+    exclude:
+      - ../other-project/secrets.env


### PR DESCRIPTION
## What changed

Extends GL005 with two new checks on `artifacts:paths:` and `artifacts:exclude:` (both at job level and under `default:`):

- **Absolute paths** (`/etc/passwd`, `/root/.ssh/id_rsa`) — severity `error`. On shell-executor runners the job runs directly on the host filesystem, so an absolute path in `artifacts:paths:` can exfiltrate any file readable by the `gitlab-runner` user. On Docker executors the Runner refuses to upload files outside the project directory, so this is still a configuration error worth catching.
- **Path traversal** (`../../etc/shadow`, `../other-project/secrets.env`) — severity `error`. A `../` sequence attempts to escape the project checkout directory. Same executor-level distinction applies.

The user-controlled-variable check described in the issue was evaluated but excluded: `CI_COMMIT_REF_NAME` and other ref-name variables are constrained by `git check-ref-format` (two consecutive dots are forbidden), making the traversal scenario impossible for the most common case. Flagging `dist/$CI_COMMIT_REF_NAME` — an extremely common legitimate pattern — would create noise. This can be revisited in a more targeted follow-up if needed.

A new **"Avoiding false positives"** section was added to `CONTRIBUTING.md` covering:
- Verifying YAML keys against the GitLab CI syntax reference
- Checking for common legitimate patterns before flagging
- Distinguishing ref-name variables (Git-constrained) from free-form variables
- Requiring an explicit no-finding test for every rule

## Tests

17 GL005 tests pass, including:
- `TestGL005_AbsolutePath` — `/etc/passwd` → 1 error
- `TestGL005_PathTraversal` — `../../etc/shadow` → 1 error
- `TestGL005_ExcludePath` — traversal in `exclude:` → 1 error
- `TestGL005_AbsolutePathWithVar` — `/tmp/$CI_COMMIT_REF_NAME` → 1 error (absolute only, no extra finding for the variable)
- `TestGL005_UserControlledVarNoFinding` — `dist/$CI_COMMIT_REF_NAME` → 0 findings (common pattern must not be flagged)

```
go test ./rules/ -run TestGL005 -v   # all pass
go test -race ./...                  # all pass
```

## Closes

Closes #171