### PR TITLE
feat: add GL043 rule for unanchored regex in rules:if conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ exclude_paths:
 
 ## Rules
 
-42 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+43 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -99,7 +99,7 @@ exclude_paths:
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025 |
-| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039 |
+| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
 | Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -83,6 +83,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL039](rules/GL039.md) | `warn`  | Security audit tool silenced with `\|\| true` — failures discarded, pipeline always green |
 | [GL009](rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL017](rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
+| [GL043](rules/GL043.md) | `warn`  | Unanchored regex on user-controlled variable in `rules:if` — prefix match can be bypassed by crafting a matching value |
 
 ---
 

--- a/docs/rules/GL043.md
+++ b/docs/rules/GL043.md
@@ -1,0 +1,73 @@
+# GL043 — Unanchored regex on user-controlled variable in rules condition
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-5 – Insufficient PBAC](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)
+
+## Risk
+
+GitLab CI `rules:if` uses `=~` for regex matching. A regex without a trailing `$` anchor is a prefix (or substring) match — an attacker who controls the matched variable can bypass the condition by crafting a value that satisfies the unanchored pattern.
+
+For example, `/^admin/` matches both `admin` and `adminevil`. If a job is gated on `$GITLAB_USER_LOGIN =~ /^admin/`, any user with a login starting with `admin` can trigger it.
+
+## What is flagged
+
+`rules:if` conditions at job level and under `workflow:` that use `=~` against one of the following user-controlled variables with an unanchored regex:
+
+| Variable | Controlled by |
+|----------|--------------|
+| `$GITLAB_USER_LOGIN` | The user triggering the pipeline |
+| `$CI_COMMIT_BRANCH` | The pusher (branch name) |
+| `$CI_COMMIT_REF_NAME` | The pusher (branch or tag name) |
+| `$CI_PROJECT_NAMESPACE` | The project namespace |
+
+Two cases are flagged:
+
+- **Prefix match** — has `^` but no trailing `$`: `/^release/` matches `release-evil`
+- **Unanchored** — neither `^` nor `$`: `/admin/` matches any value containing `admin`
+
+## Trigger examples
+
+```yaml
+deploy-prod:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^release/     # prefix match — "release-evil" also matches
+
+privileged-job:
+  rules:
+    - if: $GITLAB_USER_LOGIN =~ /^admin/      # prefix match — "adminevil" also matches
+
+restricted:
+  rules:
+    - if: $CI_PROJECT_NAMESPACE =~ /myteam/   # no anchors — any namespace containing "myteam" matches
+```
+
+## Safe alternative
+
+Use both `^` and `$` anchors to require an exact match:
+
+```yaml
+deploy-prod:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^release$/
+
+privileged-job:
+  rules:
+    - if: $GITLAB_USER_LOGIN =~ /^deploy-bot$/
+
+restricted:
+  rules:
+    - if: $CI_PROJECT_NAMESPACE =~ /^myteam$/
+```
+
+For patterns that intentionally match a family of values (e.g. all `release/x.y` branches), make the suffix explicit:
+
+```yaml
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^release\/\d+\.\d+$/
+```
+
+## Notes
+
+- Only `=~` is checked; `==` and `!=` comparisons are exact by definition and are not flagged
+- The check applies to both `workflow: rules:` and per-job `rules:`
+- Variables not in the list above (e.g. `$CI_PIPELINE_SOURCE`) are not flagged — they are set by GitLab internally and are not attacker-controlled in the same way

--- a/rules/all.go
+++ b/rules/all.go
@@ -46,5 +46,6 @@ func All() []rule.Rule {
 		GL040,
 		GL041,
 		GL042,
+		GL043,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -44,6 +44,7 @@ var cweIDs = map[string]string{
 	"GL040": "CWE-319",
 	"GL041": "CWE-1104",
 	"GL042": "CWE-295",
+	"GL043": "CWE-625",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -62,6 +63,7 @@ var cweNames = map[string]string{
 	"CWE-538":  "Insertion of Sensitive Information into Externally-Accessible File or Directory",
 	"CWE-691":  "Insufficient Control Flow Management",
 	"CWE-798":  "Use of Hard-coded Credentials",
+	"CWE-625":  "Permissive Regular Expression",
 	"CWE-829":  "Inclusion of Functionality from Untrusted Control Sphere",
 	"CWE-1104": "Use of Unmaintained Third-Party Components",
 }

--- a/rules/gl043.go
+++ b/rules/gl043.go
@@ -1,0 +1,113 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl043 struct{}
+
+var GL043 = &gl043{}
+
+func (r *gl043) ID() string { return "GL043" }
+
+// gl043Vars are predefined variables commonly used in access-control conditions
+// whose values are set by external actors (pusher, MR creator, API caller).
+var gl043Vars = []string{
+	"GITLAB_USER_LOGIN",
+	"CI_COMMIT_BRANCH",
+	"CI_COMMIT_REF_NAME",
+	"CI_PROJECT_NAMESPACE",
+}
+
+// gl043Re matches "$VAR =~ /pattern/" in a rules:if condition string.
+// Group 1: variable name, Group 2: regex pattern content (between slashes).
+var gl043Re = regexp.MustCompile(
+	`\$\{?(` + strings.Join(gl043Vars, "|") + `)\}?\s*=~\s*/([^/]*)/`,
+)
+
+func (r *gl043) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	if wf := parser.FindKey(mapping, "workflow"); wf != nil {
+		if rulesNode := parser.FindKey(wf, "rules"); rulesNode != nil {
+			findings = append(findings, checkRulesIfNodes(rulesNode, file, "")...)
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		rulesNode := parser.FindKey(job, "rules")
+		if rulesNode == nil {
+			return
+		}
+		for _, f := range checkRulesIfNodes(rulesNode, file, "") {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func checkRulesIfNodes(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		ifNode := parser.FindKey(item, "if")
+		if ifNode == nil || ifNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		findings = append(findings, checkIfCondition(ifNode, file)...)
+	}
+	return findings
+}
+
+func checkIfCondition(node *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	matches := gl043Re.FindAllStringSubmatch(node.Value, -1)
+	for _, m := range matches {
+		varName := m[1]
+		pattern := m[2]
+
+		hasStart := strings.HasPrefix(pattern, "^")
+		hasEnd := strings.HasSuffix(pattern, "$")
+
+		if hasEnd {
+			continue
+		}
+
+		var msg string
+		if hasStart {
+			msg = fmt.Sprintf(
+				"rules:if uses $%s =~ /%s/ — no trailing $ anchor; a value prefixed with %q also matches",
+				varName, pattern, strings.TrimPrefix(pattern, "^"),
+			)
+		} else {
+			msg = fmt.Sprintf(
+				"rules:if uses $%s =~ /%s/ — no ^ or $ anchors; any value containing %q matches",
+				varName, pattern, pattern,
+			)
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL043",
+			Severity: finding.Warn,
+			Message:  msg,
+			File:     file,
+			Line:     node.Line,
+			Col:      node.Column,
+		})
+	}
+	return findings
+}

--- a/rules/gl043_test.go
+++ b/rules/gl043_test.go
@@ -1,0 +1,164 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings043(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL043.Check(doc.Root, "test.yml")
+}
+
+func TestGL043_PrefixMatchBranch(t *testing.T) {
+	f := findings043(t, `
+deploy-prod:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^release/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for prefix match, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL043_NoAnchorsBranch(t *testing.T) {
+	f := findings043(t, `
+deploy-prod:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /release/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unanchored match, got %d", len(f))
+	}
+}
+
+func TestGL043_FullyAnchoredNoFinding(t *testing.T) {
+	f := findings043(t, `
+deploy-prod:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^release$/
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for fully anchored pattern, got %d", len(f))
+	}
+}
+
+func TestGL043_UserLoginPrefixMatch(t *testing.T) {
+	f := findings043(t, `
+privileged-job:
+  script: [./admin.sh]
+  rules:
+    - if: $GITLAB_USER_LOGIN =~ /^admin/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for user login prefix match, got %d", len(f))
+	}
+}
+
+func TestGL043_UserLoginFullyAnchoredNoFinding(t *testing.T) {
+	f := findings043(t, `
+privileged-job:
+  script: [./admin.sh]
+  rules:
+    - if: $GITLAB_USER_LOGIN =~ /^admin$/
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for fully anchored user login, got %d", len(f))
+	}
+}
+
+func TestGL043_NamespacePrefixMatch(t *testing.T) {
+	f := findings043(t, `
+deploy:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_PROJECT_NAMESPACE =~ /^myteam/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for namespace prefix match, got %d", len(f))
+	}
+}
+
+func TestGL043_RefNamePrefixMatch(t *testing.T) {
+	f := findings043(t, `
+deploy:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^v/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for ref name prefix match, got %d", len(f))
+	}
+}
+
+func TestGL043_WorkflowRules(t *testing.T) {
+	f := findings043(t, `
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^release/
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in workflow rules, got %d", len(f))
+	}
+}
+
+func TestGL043_EqualityNoFinding(t *testing.T) {
+	f := findings043(t, `
+deploy:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for == operator, got %d", len(f))
+	}
+}
+
+func TestGL043_UnrelatedVariableNoFinding(t *testing.T) {
+	f := findings043(t, `
+deploy:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_PIPELINE_SOURCE =~ /^push/
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for non-target variable, got %d", len(f))
+	}
+}
+
+func TestGL043_MultipleConditionsOneUnanchored(t *testing.T) {
+	f := findings043(t, `
+deploy:
+  script: [./deploy.sh]
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^main$/ && $GITLAB_USER_LOGIN =~ /^admin/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (only the unanchored pattern), got %d", len(f))
+	}
+}
+
+func TestGL043_NoRulesNoFinding(t *testing.T) {
+	f := findings043(t, `
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when no rules block, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -45,6 +45,7 @@ var owaspCategories = map[string][]string{
 	"GL040": {"CICD-SEC-6"},
 	"GL041": {"CICD-SEC-4", "CICD-SEC-8"},
 	"GL042": {"CICD-SEC-7"},
+	"GL043": {"CICD-SEC-5"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl043-unanchored-regex.yml
+++ b/testdata/fixtures/gl043-unanchored-regex.yml
@@ -1,0 +1,26 @@
+stages:
+  - build
+  - deploy
+
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^release/
+
+build:
+  stage: build
+  script:
+    - make build
+
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: $GITLAB_USER_LOGIN =~ /^admin/
+
+restricted:
+  stage: deploy
+  script:
+    - ./restricted.sh
+  rules:
+    - if: $CI_PROJECT_NAMESPACE =~ /^myteam/


### PR DESCRIPTION
## What changed

New rule **GL043** detects unanchored regular expressions in `rules:if` conditions that match against user-controlled predefined variables.

GitLab CI `rules:if` uses `=~` for regex matching. A regex without a trailing `$` anchor is a prefix (or substring) match — an attacker who controls the matched variable can bypass the condition by crafting a value that satisfies the unanchored pattern. For example, `$GITLAB_USER_LOGIN =~ /^admin/` also matches `adminevil`.

### Variables checked

| Variable | Controlled by |
|----------|--------------|
| `$GITLAB_USER_LOGIN` | User triggering the pipeline |
| `$CI_COMMIT_BRANCH` | Pusher (branch name) |
| `$CI_COMMIT_REF_NAME` | Pusher (branch or tag name) |
| `$CI_PROJECT_NAMESPACE` | Project namespace |

### Cases flagged (severity `warn`)

- **Prefix match** — has `^` but no trailing `$`: `/^release/` matches `release-evil`
- **Unanchored** — neither `^` nor `$`: `/admin/` matches any value containing `admin`

### Scope

Checks `rules:if` at job level and under `workflow:rules:`. Only the `=~` operator is checked; `==`/`!=` comparisons are exact by definition.

### False positive analysis

- `==` operator → not flagged (exact match)
- Unrelated variables like `$CI_PIPELINE_SOURCE` → not flagged
- Fully anchored patterns `/^main$/` → not flagged
- Only `=~` with the four listed access-control variables is in scope

## Test plan

12 unit tests covering:
- Prefix match on branch, user login, namespace, ref name → 1 finding each
- Fully anchored patterns → 0 findings
- `==` operator → 0 findings
- Unrelated variable → 0 findings
- Mixed condition (one anchored, one not) → 1 finding
- Workflow-level rules → finding
- No rules block → 0 findings

```
go test ./rules/ -run TestGL043 -v   # all pass
go test -race ./...                  # all pass
```

## Closes

Closes #146