### PR TITLE
feat: add GL044 rule for untrusted MR source checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ exclude_paths:
 
 ## Rules
 
-43 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+44 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
 | Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -56,6 +56,7 @@ User-controlled inputs and unversioned component references that allow malicious
 | [GL015](rules/GL015.md) | `warn`  | Docker image tag built from user-controlled variable (`$CI_COMMIT_REF_SLUG` etc.) |
 | [GL025](rules/GL025.md) | `warn`  | `curl`/`wget` uses a user-controlled CI variable — attacker can redirect the request to an arbitrary host |
 | [GL041](rules/GL041.md) | `warn`  | `include: component:` without a pinned semver tag or commit SHA |
+| [GL044](rules/GL044.md) | `warn`  | MR-triggered job checks out `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` — executes attacker-controlled code with `$CI_JOB_TOKEN` access |
 
 ---
 

--- a/docs/rules/GL044.md
+++ b/docs/rules/GL044.md
@@ -1,0 +1,58 @@
+# GL044 — Untrusted MR source checkout in pipeline context
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)  
+**CWE:** [CWE-829 – Inclusion of Functionality from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html)
+
+## Risk
+
+GitLab CI pipelines triggered by merge requests run on the source branch — code controlled by the MR author. If a job in such a pipeline checks out `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` and then executes code from that checkout, it runs **attacker-controlled code** with access to `$CI_JOB_TOKEN` and any protected variables available to the job.
+
+This is a Poisoned Pipeline Execution (PPE) attack: the attacker opens an MR with malicious script content, which the pipeline then executes in a trusted context.
+
+## What is flagged
+
+Jobs that combine:
+
+1. A trigger on merge request events (`rules:if` containing `merge_request_event` or `merge_requests`, or the legacy `only: [merge_requests]`)
+2. Any of:
+   - `script:` or `before_script:` referencing `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA`
+   - `image:` referencing `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` (attacker-controlled container image)
+
+## Trigger example
+
+```yaml
+security-scan:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - git checkout $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+    - ./scan.sh   # executes attacker-controlled code with $CI_JOB_TOKEN access
+```
+
+## Safe alternatives
+
+**Run MR pipelines without access to protected variables:**
+
+Use `inherit: variables: false` combined with an explicit allowlist of non-sensitive variables, or run the job in a dedicated MR-only project with no protected variables.
+
+**Use GitLab's built-in MR diff analysis instead of checkout:**
+
+For code analysis, use GitLab's native SAST/code quality runners or CI components that analyse the MR diff without executing code from the source branch.
+
+**Only run trusted code in protected contexts:**
+
+Structure your pipeline so that jobs with access to `$CI_JOB_TOKEN` or protected variables only run on protected branches, never on MR source branches:
+
+```yaml
+deploy:
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH   # protected branch only
+  script:
+    - ./deploy.sh
+```
+
+## Notes
+
+- This rule only flags `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` — the specific commit SHA of the MR source. The branch name variable (`CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`) is not flagged as it is also commonly used for logging and artifact naming
+- The risk exists regardless of whether explicit secrets are referenced; `$CI_JOB_TOKEN` is always available and grants read access to the GitLab API on behalf of the pipeline

--- a/rules/all.go
+++ b/rules/all.go
@@ -47,5 +47,6 @@ func All() []rule.Rule {
 		GL041,
 		GL042,
 		GL043,
+		GL044,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -45,6 +45,7 @@ var cweIDs = map[string]string{
 	"GL041": "CWE-1104",
 	"GL042": "CWE-295",
 	"GL043": "CWE-625",
+	"GL044": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl044.go
+++ b/rules/gl044.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -91,9 +90,7 @@ func checkScriptForMRSourceSHA(node *yaml.Node, file string) []finding.Finding {
 			findings = append(findings, finding.Finding{
 				RuleID:   "GL044",
 				Severity: finding.Warn,
-				Message: fmt.Sprintf(
-					"MR-triggered job checks out $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA — executes attacker-controlled code with access to $CI_JOB_TOKEN and protected variables",
-				),
+				Message: "MR-triggered job checks out $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA — executes attacker-controlled code with access to $CI_JOB_TOKEN and protected variables",
 				File: file,
 				Line: item.Line,
 				Col:  item.Column,

--- a/rules/gl044.go
+++ b/rules/gl044.go
@@ -1,0 +1,130 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl044 struct{}
+
+var GL044 = &gl044{}
+
+func (r *gl044) ID() string { return "GL044" }
+
+// mrSourceSHARe matches any reference to CI_MERGE_REQUEST_SOURCE_BRANCH_SHA.
+var mrSourceSHARe = regexp.MustCompile(`\$\{?CI_MERGE_REQUEST_SOURCE_BRANCH_SHA\}?`)
+
+func (r *gl044) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if !jobHasMRTrigger(job) {
+			return
+		}
+
+		for _, key := range []string{"script", "before_script"} {
+			node := parser.FindKey(job, key)
+			if node == nil {
+				continue
+			}
+			for _, f := range checkScriptForMRSourceSHA(node, file) {
+				f.Job = name.Value
+				findings = append(findings, f)
+			}
+		}
+
+		if imageNode := parser.FindKey(job, "image"); imageNode != nil {
+			if f := checkImageForMRSourceSHA(imageNode, file, name.Value); f != nil {
+				findings = append(findings, *f)
+			}
+		}
+	})
+
+	return findings
+}
+
+// jobHasMRTrigger returns true if the job is triggered on merge request events,
+// either via the legacy only: syntax or via rules:if conditions.
+func jobHasMRTrigger(job *yaml.Node) bool {
+	if onlyNode := parser.FindKey(job, "only"); onlyNode != nil && onlyNode.Kind == yaml.SequenceNode {
+		for _, item := range onlyNode.Content {
+			if item.Kind == yaml.ScalarNode && item.Value == "merge_requests" {
+				return true
+			}
+		}
+	}
+
+	rulesNode := parser.FindKey(job, "rules")
+	if rulesNode == nil || rulesNode.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, item := range rulesNode.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		ifNode := parser.FindKey(item, "if")
+		if ifNode == nil || ifNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		if strings.Contains(ifNode.Value, "merge_request") {
+			return true
+		}
+	}
+	return false
+}
+
+func checkScriptForMRSourceSHA(node *yaml.Node, file string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if mrSourceSHARe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL044",
+				Severity: finding.Warn,
+				Message: fmt.Sprintf(
+					"MR-triggered job checks out $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA — executes attacker-controlled code with access to $CI_JOB_TOKEN and protected variables",
+				),
+				File: file,
+				Line: item.Line,
+				Col:  item.Column,
+			})
+		}
+	}
+	return findings
+}
+
+func checkImageForMRSourceSHA(node *yaml.Node, file, job string) *finding.Finding {
+	var imageValue string
+	switch node.Kind {
+	case yaml.ScalarNode:
+		imageValue = node.Value
+	case yaml.MappingNode:
+		if nameNode := parser.FindKey(node, "name"); nameNode != nil && nameNode.Kind == yaml.ScalarNode {
+			imageValue = nameNode.Value
+			node = nameNode
+		}
+	}
+	if !mrSourceSHARe.MatchString(imageValue) {
+		return nil
+	}
+	f := finding.Finding{
+		RuleID:   "GL044",
+		Severity: finding.Warn,
+		Job:      job,
+		Message:  "MR-triggered job uses $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA in image: — pulls an attacker-controlled container image",
+		File:     file,
+		Line:     node.Line,
+		Col:      node.Column,
+	}
+	return &f
+}

--- a/rules/gl044_test.go
+++ b/rules/gl044_test.go
@@ -1,0 +1,155 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings044(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL044.Check(doc.Root, "test.yml")
+}
+
+func TestGL044_MRTriggerWithSHACheckout(t *testing.T) {
+	f := findings044(t, `
+security-scan:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - git checkout $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+    - ./scan.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL044_OnlyMergeRequestsWithSHACheckout(t *testing.T) {
+	f := findings044(t, `
+scan:
+  only:
+    - merge_requests
+  script:
+    - git checkout $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding via only: syntax, got %d", len(f))
+	}
+}
+
+func TestGL044_SHAInBeforeScript(t *testing.T) {
+	f := findings044(t, `
+scan:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  before_script:
+    - git fetch origin $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+  script:
+    - ./analyze.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for SHA in before_script, got %d", len(f))
+	}
+}
+
+func TestGL044_SHAInImage(t *testing.T) {
+	f := findings044(t, `
+scan:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  image: myregistry/myapp:$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+  script:
+    - ./scan.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for SHA in image, got %d", len(f))
+	}
+}
+
+func TestGL044_NoMRTriggerNoFinding(t *testing.T) {
+	f := findings044(t, `
+scan:
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  script:
+    - git checkout $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without MR trigger, got %d", len(f))
+	}
+}
+
+func TestGL044_MRTriggerNoSHANoFinding(t *testing.T) {
+	f := findings044(t, `
+test:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - npm test
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without SHA reference, got %d", len(f))
+	}
+}
+
+func TestGL044_MRTriggerBranchNameNoFinding(t *testing.T) {
+	f := findings044(t, `
+test:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - echo "Branch is $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for branch name only (not SHA), got %d", len(f))
+	}
+}
+
+func TestGL044_NoRulesNoFinding(t *testing.T) {
+	f := findings044(t, `
+build:
+  script:
+    - make build
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for job with no rules, got %d", len(f))
+	}
+}
+
+func TestGL044_JobNameInFinding(t *testing.T) {
+	f := findings044(t, `
+security-scan:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - git checkout $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Job != "security-scan" {
+		t.Errorf("expected job name 'security-scan', got %q", f[0].Job)
+	}
+}
+
+func TestGL044_CurlyBraceSyntax(t *testing.T) {
+	f := findings044(t, `
+scan:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - git checkout ${CI_MERGE_REQUEST_SOURCE_BRANCH_SHA}
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for ${VAR} syntax, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -46,6 +46,7 @@ var owaspCategories = map[string][]string{
 	"GL041": {"CICD-SEC-4", "CICD-SEC-8"},
 	"GL042": {"CICD-SEC-7"},
 	"GL043": {"CICD-SEC-5"},
+	"GL044": {"CICD-SEC-4"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl044-mr-source-checkout.yml
+++ b/testdata/fixtures/gl044-mr-source-checkout.yml
@@ -1,0 +1,10 @@
+stages:
+  - test
+
+security-scan:
+  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - git checkout $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+    - ./scan.sh


### PR DESCRIPTION
## What changed

New rule **GL044** detects jobs that execute attacker-controlled code from an MR source branch in a pipeline context with access to `$CI_JOB_TOKEN`.

### Detection

A job is flagged when it combines:

1. **MR trigger** — `rules:if` containing `merge_request_event` or `merge_requests`, or the legacy `only: [merge_requests]` syntax
2. **Source SHA reference** — `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` in `script:`, `before_script:`, or `image:`

### Why this specific variable

`CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` is the exact commit SHA of the MR author's branch. Using it in a script almost exclusively means checking out and running that commit. The branch name variable (`CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`) is deliberately excluded — it is commonly used for logging, artifact naming, and other non-execution purposes.

### False positive analysis

- Jobs without an MR trigger → not flagged
- MR-triggered jobs that don't reference the source SHA → not flagged  
- `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` usage → not flagged
- `==` / `!=` conditions in rules (no `=~`) → not affected

## Test plan

10 unit tests:
- MR trigger via `rules:if` + SHA in `script:` → 1 finding
- MR trigger via `only: [merge_requests]` → 1 finding
- SHA in `before_script:` → 1 finding
- SHA in `image:` → 1 finding
- No MR trigger + SHA in script → 0 findings (must not flag)
- MR trigger + no SHA reference → 0 findings
- MR trigger + branch name only (not SHA) → 0 findings
- `${VAR}` curly-brace syntax → 1 finding
- Job name propagated correctly

```
go test ./rules/ -run TestGL044 -v   # all pass
go test -race ./...                  # all pass
```

## Closes

Closes #160