### PR TITLE
feat: add GL045 rule for release jobs without artifact signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ exclude_paths:
 
 ## Rules
 
-44 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+45 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044 |
-| Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025 |
+| Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
 | Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042 |
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -67,6 +67,7 @@ Downloads and executions that bypass integrity checks, enabling tampering mid-pi
 | ID | Severity | Description |
 |----|----------|-------------|
 | [GL020](rules/GL020.md) | `warn`  | File downloaded with `curl`/`wget` without checksum verification before execution |
+| [GL045](rules/GL045.md) | `warn`  | Release job pushes artifacts without a signing step (`cosign sign`, `gpg --detach-sign`, `notation sign`) |
 
 ---
 

--- a/docs/rules/GL045.md
+++ b/docs/rules/GL045.md
@@ -1,0 +1,64 @@
+# GL045 — Release job without artifact signing
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-9 – Improper Artifact Integrity Validation](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-09-Improper-Artifact-Integrity-Validation)  
+**CWE:** [CWE-494 – Download of Code Without Integrity Check](https://cwe.mitre.org/data/definitions/494.html)
+
+## Risk
+
+Release and publish jobs that push artifacts (container images, packages, binaries) without cryptographically signing them leave consumers with no way to verify that what they download matches what was built. An attacker who compromises the registry or distribution channel can substitute tampered artifacts without detection.
+
+## What is flagged
+
+Jobs whose name or `stage:` contains a release/publish keyword (`release`, `publish`, `deploy`, `push`, `upload`, `dist`) and whose script contains a known push command but no signing command.
+
+**Push commands detected:**
+
+| Command | Tool |
+|---------|------|
+| `docker push` | Docker |
+| `crane push` | Google crane |
+| `helm push` | Helm OCI |
+| `twine upload` | Python / PyPI |
+| `cargo publish` | Rust / crates.io |
+| `npm publish` | Node.js / npm |
+| `goreleaser release` | GoReleaser |
+
+**Signing commands that suppress the finding:**
+
+| Command | Tool |
+|---------|------|
+| `cosign sign` | Sigstore cosign |
+| `gpg --detach-sign` / `gpg -b` | GPG |
+| `notation sign` | Notary v2 |
+| `slsa-verifier` | SLSA |
+
+Signing commands in `before_script:` or `after_script:` also count.
+
+## Trigger example
+
+```yaml
+publish:
+  stage: release
+  script:
+    - docker build -t registry.example.com/app:$CI_COMMIT_TAG .
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+    # no signing step
+```
+
+## Safe alternative
+
+```yaml
+publish:
+  stage: release
+  script:
+    - docker build -t registry.example.com/app:$CI_COMMIT_TAG .
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+    - cosign sign --key $COSIGN_KEY registry.example.com/app:$CI_COMMIT_TAG
+```
+
+## Notes
+
+- Detection is heuristic: jobs that push to internal or staging registries may be flagged even if signing is not required there
+- GoReleaser can sign artifacts via its own config (`.goreleaser.yml`) without an explicit script command — such configurations will be flagged since glsec only analyses the CI YAML
+- Jobs that do not match a release keyword in their name or stage are not checked, even if they contain push commands

--- a/rules/all.go
+++ b/rules/all.go
@@ -48,5 +48,6 @@ func All() []rule.Rule {
 		GL042,
 		GL043,
 		GL044,
+		GL045,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -46,6 +46,7 @@ var cweIDs = map[string]string{
 	"GL042": "CWE-295",
 	"GL043": "CWE-625",
 	"GL044": "CWE-829",
+	"GL045": "CWE-494",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl045.go
+++ b/rules/gl045.go
@@ -1,0 +1,115 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl045 struct{}
+
+var GL045 = &gl045{}
+
+func (r *gl045) ID() string { return "GL045" }
+
+// releaseKeywords identifies job and stage names that indicate a release or publish step.
+var releaseKeywords = []string{"release", "publish", "deploy", "push", "upload", "dist"}
+
+// releasePushRe matches script lines that push artifacts to a registry or package index.
+var releasePushRe = regexp.MustCompile(
+	`\bdocker\s+push\b` +
+		`|\bcrane\s+push\b` +
+		`|\bhelm\s+push\b` +
+		`|\btwine\s+upload\b` +
+		`|\bcargo\s+publish\b` +
+		`|\bnpm\s+publish\b` +
+		`|\bgoreleaser\s+release\b`,
+)
+
+// releaseSigningRe matches script lines that cryptographically sign an artifact.
+var releaseSigningRe = regexp.MustCompile(
+	`\bcosign\s+sign\b` +
+		`|\bgpg\b.*--detach-sign\b` +
+		`|\bgpg\b.*\s-b\b` +
+		`|\bnotation\s+sign\b` +
+		`|\bslsa-verifier\b`,
+)
+
+func (r *gl045) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if !isReleaseJob(name.Value, job) {
+			return
+		}
+
+		lines := collectJobScriptLines(job)
+		if len(lines) == 0 {
+			return
+		}
+
+		var pushLine *yaml.Node
+		hasSigning := false
+
+		for _, line := range lines {
+			if line.Kind != yaml.ScalarNode {
+				continue
+			}
+			if pushLine == nil && releasePushRe.MatchString(line.Value) {
+				pushLine = line
+			}
+			if releaseSigningRe.MatchString(line.Value) {
+				hasSigning = true
+			}
+		}
+
+		if pushLine == nil || hasSigning {
+			return
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL045",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message:  "release job pushes artifacts without a signing step — consumers cannot verify artifact integrity; add cosign, gpg --detach-sign, or notation sign",
+			File:     file,
+			Line:     pushLine.Line,
+			Col:      pushLine.Column,
+		})
+	})
+
+	return findings
+}
+
+func isReleaseJob(jobName string, job *yaml.Node) bool {
+	lower := strings.ToLower(jobName)
+	for _, kw := range releaseKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	if stageNode := parser.FindKey(job, "stage"); stageNode != nil && stageNode.Kind == yaml.ScalarNode {
+		lowerStage := strings.ToLower(stageNode.Value)
+		for _, kw := range releaseKeywords {
+			if strings.Contains(lowerStage, kw) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func collectJobScriptLines(job *yaml.Node) []*yaml.Node {
+	var lines []*yaml.Node
+	for _, key := range []string{"before_script", "script", "after_script"} {
+		node := parser.FindKey(job, key)
+		if node == nil || node.Kind != yaml.SequenceNode {
+			continue
+		}
+		lines = append(lines, node.Content...)
+	}
+	return lines
+}

--- a/rules/gl045_test.go
+++ b/rules/gl045_test.go
@@ -1,0 +1,182 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings045(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL045.Check(doc.Root, "test.yml")
+}
+
+func TestGL045_DockerPushWithoutSigning(t *testing.T) {
+	f := findings045(t, `
+publish:
+  stage: release
+  script:
+    - docker build -t registry.example.com/app:$CI_COMMIT_TAG .
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL045_DockerPushWithCosignNoFinding(t *testing.T) {
+	f := findings045(t, `
+publish:
+  stage: release
+  script:
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+    - cosign sign --key $COSIGN_KEY registry.example.com/app:$CI_COMMIT_TAG
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when cosign sign present, got %d", len(f))
+	}
+}
+
+func TestGL045_DockerPushWithGPGNoFinding(t *testing.T) {
+	f := findings045(t, `
+publish:
+  stage: release
+  script:
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+    - gpg --detach-sign dist/app.tar.gz
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when gpg --detach-sign present, got %d", len(f))
+	}
+}
+
+func TestGL045_NpmPublishWithoutSigning(t *testing.T) {
+	f := findings045(t, `
+release-npm:
+  script:
+    - npm publish
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for npm publish without signing, got %d", len(f))
+	}
+}
+
+func TestGL045_CargoPublishWithoutSigning(t *testing.T) {
+	f := findings045(t, `
+publish-crate:
+  stage: publish
+  script:
+    - cargo publish
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for cargo publish without signing, got %d", len(f))
+	}
+}
+
+func TestGL045_GoreleaserWithoutSigning(t *testing.T) {
+	f := findings045(t, `
+release:
+  script:
+    - goreleaser release --clean
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for goreleaser release without signing, got %d", len(f))
+	}
+}
+
+func TestGL045_TwineUploadWithoutSigning(t *testing.T) {
+	f := findings045(t, `
+upload-pypi:
+  stage: upload
+  script:
+    - twine upload dist/*
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for twine upload without signing, got %d", len(f))
+	}
+}
+
+func TestGL045_NotationSignNoFinding(t *testing.T) {
+	f := findings045(t, `
+publish:
+  stage: release
+  script:
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+    - notation sign registry.example.com/app:$CI_COMMIT_TAG
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when notation sign present, got %d", len(f))
+	}
+}
+
+func TestGL045_SigningInBeforeScriptNoFinding(t *testing.T) {
+	f := findings045(t, `
+publish:
+  stage: release
+  before_script:
+    - cosign sign --key $COSIGN_KEY registry.example.com/app:$CI_COMMIT_TAG
+  script:
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when signing in before_script, got %d", len(f))
+	}
+}
+
+func TestGL045_NonReleaseJobNoFinding(t *testing.T) {
+	f := findings045(t, `
+build:
+  stage: build
+  script:
+    - docker build -t myapp .
+    - docker push registry.internal/myapp:latest
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for non-release job, got %d", len(f))
+	}
+}
+
+func TestGL045_NoPushCommandNoFinding(t *testing.T) {
+	f := findings045(t, `
+release:
+  script:
+    - make build
+    - ./create-release.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without push command, got %d", len(f))
+	}
+}
+
+func TestGL045_StageNameMatchNoFinding(t *testing.T) {
+	f := findings045(t, `
+build-image:
+  stage: release
+  script:
+    - docker push registry.example.com/app:$CI_COMMIT_TAG
+    - cosign sign --key $COSIGN_KEY registry.example.com/app:$CI_COMMIT_TAG
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when job matches via stage and has signing, got %d", len(f))
+	}
+}
+
+func TestGL045_HelmPushWithoutSigning(t *testing.T) {
+	f := findings045(t, `
+publish-chart:
+  stage: release
+  script:
+    - helm push mychart-1.0.0.tgz oci://registry.example.com/charts
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for helm push without signing, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -47,6 +47,7 @@ var owaspCategories = map[string][]string{
 	"GL042": {"CICD-SEC-7"},
 	"GL043": {"CICD-SEC-5"},
 	"GL044": {"CICD-SEC-4"},
+	"GL045": {"CICD-SEC-9"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl045-release-signing.yml
+++ b/testdata/fixtures/gl045-release-signing.yml
@@ -1,0 +1,13 @@
+stages:
+  - build
+  - release
+
+build:
+  stage: build
+  script:
+    - docker build -t registry.example.com/app:$CI_COMMIT_TAG .
+
+publish:
+  stage: release
+  script:
+    - docker push registry.example.com/app:$CI_COMMIT_TAG


### PR DESCRIPTION
## What changed

New rule **GL045** detects release and publish jobs that push artifacts to a registry or package index without a cryptographic signing step, making it impossible for consumers to verify artifact integrity.

### Detection logic

Both conditions must be true to trigger a finding:

1. **Job name or `stage:` contains a release keyword** — `release`, `publish`, `deploy`, `push`, `upload`, `dist` (case-insensitive substring match)
2. **Script contains a push command** — `docker push`, `crane push`, `helm push`, `twine upload`, `cargo publish`, `npm publish`, `goreleaser release`

Finding is suppressed if any of these signing commands are present in `script:`, `before_script:`, or `after_script:`: `cosign sign`, `gpg --detach-sign`, `gpg -b`, `notation sign`, `slsa-verifier`.

### False positive analysis

The dual-condition filter (release keyword AND push command) keeps noise low. The issue explicitly acknowledges that staging/dev image pushes are expected false positives — `warn` severity is appropriate. Non-release jobs that happen to contain push commands (e.g. a `build` job pushing to an internal registry) are not flagged since they don't match the release keyword check.

GoReleaser with signing configured in `.goreleaser.yml` (not in the script) will be flagged — noted in the docs as a known limitation.

## Test plan

13 unit tests:
- `docker push` without signing → 1 finding
- `docker push` + `cosign sign` → 0 findings
- `docker push` + `gpg --detach-sign` → 0 findings
- `docker push` + `notation sign` → 0 findings
- Signing in `before_script:` → 0 findings
- `npm publish`, `cargo publish`, `twine upload`, `helm push`, `goreleaser release` without signing → 1 finding each
- Non-release job with `docker push` → 0 findings (must not flag)
- Release job without any push command → 0 findings

```
go test ./rules/ -run TestGL045 -v   # all pass
go test -race ./...                  # all pass
```

## Closes

Closes #161