### PR TITLE
feat: add GL046 rule for cache key derived from user-controlled variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ exclude_paths:
 
 ## Rules
 
-45 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+46 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040 |
-| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026 |
+| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026, GL046 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -41,6 +41,7 @@ Mutable references that allow silent substitution of images, templates, or packa
 | [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
 | [GL022](rules/GL022.md) | `warn`  | Package manager install without version pin or explicit update-to-latest in CI |
 | [GL023](rules/GL023.md) | `warn`  | Lockfile not enforced (`npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, etc.) |
+| [GL046](rules/GL046.md) | `warn`  | `cache: key:` derived from user-controlled variable — attacker can craft a branch name to collide with and poison the cache of a protected pipeline |
 | [GL026](rules/GL026.md) | `warn`  | `git clone`/`checkout` uses a mutable ref (branch or tag) instead of a pinned commit SHA |
 
 ---

--- a/docs/rules/GL046.md
+++ b/docs/rules/GL046.md
@@ -1,0 +1,66 @@
+# GL046 — Cache key derived from user-controlled variable
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)  
+**CWE:** [CWE-494 – Download of Code Without Integrity Check](https://cwe.mitre.org/data/definitions/494.html)
+
+## Risk
+
+A `cache:` block whose `key:` is derived from a user-controlled variable allows an attacker to poison the cache for other pipelines. By creating a branch whose name is crafted to match the cache key of a protected branch or release pipeline, an attacker can pre-fill the cache with malicious build artefacts (e.g. tampered `node_modules/`, compiled binaries). A subsequent legitimate build will restore and execute those artefacts without integrity verification.
+
+`CI_COMMIT_REF_SLUG` is a URL-safe normalisation of `CI_COMMIT_REF_NAME` and carries the same risk — an attacker can craft a branch name whose slug matches the target key.
+
+## What is flagged
+
+Any `cache: key:` value (at job level or under `default:`) that contains a user-controlled predefined variable, and any `cache: key: prefix:` field that contains such a variable.
+
+**Flagged variables:**
+
+| Variable | Controlled by |
+|----------|--------------|
+| `$CI_COMMIT_REF_NAME` | Pusher (branch or tag name) |
+| `$CI_COMMIT_REF_SLUG` | Pusher (normalised branch/tag name) |
+| `$CI_COMMIT_BRANCH` | Pusher (branch name) |
+| `$CI_COMMIT_TAG` | Pusher (tag name) |
+| `$CI_COMMIT_TITLE` / `$CI_COMMIT_MESSAGE` | Commit author |
+| `$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | MR author |
+| `$CI_MERGE_REQUEST_TITLE` | MR author |
+| `$CI_PIPELINE_NAME` | API caller |
+
+## Trigger examples
+
+```yaml
+build:
+  cache:
+    key: $CI_COMMIT_REF_NAME        # branch name controls the cache slot
+    paths:
+      - node_modules/
+
+build:
+  cache:
+    key:
+      files:
+        - package-lock.json
+      prefix: $CI_COMMIT_REF_NAME   # prefix derived from branch name
+    paths:
+      - node_modules/
+```
+
+## Safe alternative
+
+Key the cache on a file hash instead of a branch name. This makes the key deterministic and independent of attacker-controlled input:
+
+```yaml
+build:
+  cache:
+    key:
+      files:
+        - package-lock.json   # cache invalidates when lockfile changes
+    paths:
+      - node_modules/
+```
+
+## Notes
+
+- Per-branch caches using `$CI_COMMIT_REF_NAME` are a common and documented GitLab CI pattern; this rule flags them because the security risk depends on the pipeline's trust model and whether fork-based MR pipelines have cache write access
+- A static key or a key based on only internal variables (e.g. `$CI_PROJECT_ID`) is safe

--- a/rules/all.go
+++ b/rules/all.go
@@ -49,5 +49,6 @@ func All() []rule.Rule {
 		GL043,
 		GL044,
 		GL045,
+		GL046,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -47,6 +47,7 @@ var cweIDs = map[string]string{
 	"GL043": "CWE-625",
 	"GL044": "CWE-829",
 	"GL045": "CWE-494",
+	"GL046": "CWE-494",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl046.go
+++ b/rules/gl046.go
@@ -1,0 +1,106 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl046 struct{}
+
+var GL046 = &gl046{}
+
+func (r *gl046) ID() string { return "GL046" }
+
+// cacheKeyVars extends the GL002 user-controlled variable set with CI_COMMIT_REF_SLUG,
+// which is a normalised form of CI_COMMIT_REF_NAME and carries the same cache-poisoning risk.
+var cacheKeyVars = append(append([]string{}, userControlledVars...), "CI_COMMIT_REF_SLUG")
+
+var cacheKeyVarRe = regexp.MustCompile(
+	`\$\{?(` + strings.Join(cacheKeyVars, "|") + `)\b`,
+)
+
+func (r *gl046) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkCacheNode(parser.FindKey(def, "cache"), file, "")...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range checkCacheNode(parser.FindKey(job, "cache"), file, "") {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func checkCacheNode(node *yaml.Node, file, job string) []finding.Finding {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		return checkCacheMapping(node, file, job)
+	case yaml.SequenceNode:
+		var findings []finding.Finding
+		for _, item := range node.Content {
+			if item.Kind == yaml.MappingNode {
+				findings = append(findings, checkCacheMapping(item, file, job)...)
+			}
+		}
+		return findings
+	}
+	return nil
+}
+
+func checkCacheMapping(node *yaml.Node, file, job string) []finding.Finding {
+	keyNode := parser.FindKey(node, "key")
+	if keyNode == nil {
+		return nil
+	}
+
+	switch keyNode.Kind {
+	case yaml.ScalarNode:
+		if m := cacheKeyVarRe.FindStringSubmatch(keyNode.Value); m != nil {
+			return []finding.Finding{{
+				RuleID:   "GL046",
+				Severity: finding.Warn,
+				Job:      job,
+				Message: fmt.Sprintf(
+					"cache key contains user-controlled variable $%s — an attacker can craft a branch name to collide with the cache key of a protected pipeline and inject malicious build artefacts",
+					m[1],
+				),
+				File: file,
+				Line: keyNode.Line,
+				Col:  keyNode.Column,
+			}}
+		}
+	case yaml.MappingNode:
+		prefixNode := parser.FindKey(keyNode, "prefix")
+		if prefixNode != nil && prefixNode.Kind == yaml.ScalarNode {
+			if m := cacheKeyVarRe.FindStringSubmatch(prefixNode.Value); m != nil {
+				return []finding.Finding{{
+					RuleID:   "GL046",
+					Severity: finding.Warn,
+					Job:      job,
+					Message: fmt.Sprintf(
+						"cache key prefix contains user-controlled variable $%s — an attacker can craft a branch name to collide with the cache key of a protected pipeline and inject malicious build artefacts",
+						m[1],
+					),
+					File: file,
+					Line: prefixNode.Line,
+					Col:  prefixNode.Column,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/rules/gl046_test.go
+++ b/rules/gl046_test.go
@@ -1,0 +1,173 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings046(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL046.Check(doc.Root, "test.yml")
+}
+
+func TestGL046_RefNameAsKey(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    key: $CI_COMMIT_REF_NAME
+    paths:
+      - node_modules/
+  script: [npm ci]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL046_RefSlugAsKey(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths: [.cache/]
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_REF_SLUG, got %d", len(f))
+	}
+}
+
+func TestGL046_BranchAsKey(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    key: "$CI_COMMIT_BRANCH-node"
+    paths: [node_modules/]
+  script: [npm ci]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_BRANCH, got %d", len(f))
+	}
+}
+
+func TestGL046_UserControlledPrefix(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    key:
+      files:
+        - package-lock.json
+      prefix: $CI_COMMIT_REF_NAME
+    paths: [node_modules/]
+  script: [npm ci]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for user-controlled prefix, got %d", len(f))
+	}
+}
+
+func TestGL046_FilesOnlyKeyNoFinding(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    key:
+      files:
+        - package-lock.json
+    paths: [node_modules/]
+  script: [npm ci]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for files-only key, got %d", len(f))
+	}
+}
+
+func TestGL046_StaticKeyNoFinding(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    key: "node-modules-v1"
+    paths: [node_modules/]
+  script: [npm ci]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for static key, got %d", len(f))
+	}
+}
+
+func TestGL046_DefaultBlockFlagged(t *testing.T) {
+	f := findings046(t, `
+default:
+  cache:
+    key: $CI_COMMIT_REF_NAME
+    paths: [.cache/]
+
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in default: cache:, got %d", len(f))
+	}
+}
+
+func TestGL046_MultipleCachesOneUserControlled(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    - key: $CI_COMMIT_REF_NAME
+      paths: [node_modules/]
+    - key: "static-key"
+      paths: [.cache/]
+  script: [npm ci]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (only the user-controlled key), got %d", len(f))
+	}
+}
+
+func TestGL046_MRSourceBranchAsKey(t *testing.T) {
+	f := findings046(t, `
+build:
+  cache:
+    key: $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+    paths: [node_modules/]
+  script: [npm ci]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for MR source branch variable, got %d", len(f))
+	}
+}
+
+func TestGL046_NoCacheNoFinding(t *testing.T) {
+	f := findings046(t, `
+build:
+  script: [npm ci, npm run build]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without cache block, got %d", len(f))
+	}
+}
+
+func TestGL046_JobNameInFinding(t *testing.T) {
+	f := findings046(t, `
+my-build-job:
+  cache:
+    key: $CI_COMMIT_REF_NAME
+    paths: [node_modules/]
+  script: [npm ci]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Job != "my-build-job" {
+		t.Errorf("expected job name 'my-build-job', got %q", f[0].Job)
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -48,6 +48,7 @@ var owaspCategories = map[string][]string{
 	"GL043": {"CICD-SEC-5"},
 	"GL044": {"CICD-SEC-4"},
 	"GL045": {"CICD-SEC-9"},
+	"GL046": {"CICD-SEC-3"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl046-cache-key-uservar.yml
+++ b/testdata/fixtures/gl046-cache-key-uservar.yml
@@ -1,0 +1,12 @@
+stages:
+  - build
+
+build:
+  stage: build
+  cache:
+    key: $CI_COMMIT_REF_NAME
+    paths:
+      - node_modules/
+  script:
+    - npm ci
+    - npm run build


### PR DESCRIPTION
## What changed

New rule **GL046** detects `cache: key:` values (at job level and under `default:`) that contain user-controlled predefined variables, enabling cache poisoning attacks.

### Attack scenario

An attacker creates a branch whose name is crafted to match the cache key of a protected branch pipeline. If MR or fork pipelines have cache write access, the attacker can pre-fill the cache slot with malicious build artefacts (e.g. tampered `node_modules/`). A subsequent legitimate build restores and executes those artefacts without integrity verification.

### Detection

Flags any `cache: key:` scalar or `cache: key: prefix:` value containing one of the user-controlled variables from the GL002 set, plus `CI_COMMIT_REF_SLUG` (explicitly called out in the issue as carrying the same risk as `CI_COMMIT_REF_NAME`).

Both scalar keys (`key: $CI_COMMIT_REF_NAME`) and files-based prefix keys (`key: {files: [...], prefix: $CI_COMMIT_REF_NAME}`) are checked. Multiple caches per job (sequence syntax) are also handled.

### False positive note

Per-branch caches using `$CI_COMMIT_REF_NAME` are a common and documented GitLab CI pattern. This rule flags them because the actual risk depends on the project's trust model (whether fork MR pipelines can write to the cache). The `warn` severity and informative message point users toward the safer files-based key alternative.

## Test plan

11 unit tests:
- `$CI_COMMIT_REF_NAME` as key → 1 finding
- `$CI_COMMIT_REF_SLUG` as key → 1 finding
- `$CI_COMMIT_BRANCH` in composite key → 1 finding
- User-controlled `prefix:` in files-based key → 1 finding
- Files-only key (no prefix) → 0 findings
- Static string key → 0 findings
- `default:` block → 1 finding
- Multiple caches, one user-controlled → 1 finding
- `$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` → 1 finding
- No cache block → 0 findings
- Job name propagated correctly

```
go test ./rules/ -run TestGL046 -v   # all pass
go test -race ./...                  # all pass
```

## Closes

Closes #162