### PR TITLE
feat: add GL047 rule for SSH connection as root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ exclude_paths:
 
 ## Rules
 
-46 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+47 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -100,7 +100,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -101,3 +101,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL030](rules/GL030.md) | `warn`  | `ssh-keyscan` at runtime blindly trusts the remote host key — MITM risk on shared runner networks |
 | [GL031](rules/GL031.md) | `error` | `DOCKER_TLS_CERTDIR: ""` disables Docker daemon TLS — exposes port 2375 unauthenticated on the runner network |
 | [GL042](rules/GL042.md) | `warn`  | TLS certificate verification disabled (`curl -k`, `wget --no-check-certificate`, `GIT_SSL_NO_VERIFY`, etc.) |
+| [GL047](rules/GL047.md) | `warn`  | SSH connection to remote host as `root` — use a least-privilege service account instead |

--- a/docs/rules/GL047.md
+++ b/docs/rules/GL047.md
@@ -1,0 +1,46 @@
+# GL047 — SSH connection to remote host as root user
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-250 – Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
+
+## Risk
+
+Connecting to a remote server as `root` from a CI job grants full, unrestricted access to the target host. If the pipeline is compromised — via a supply-chain attack, variable injection, or a malicious dependency — the attacker gains root access to production infrastructure, not just the CI runner. This amplifies the blast radius far beyond the pipeline environment.
+
+## What is flagged
+
+Script lines (in `script:`, `before_script:`, `after_script:`) that invoke `ssh` with `root` as the login user, in any common form:
+
+```
+ssh root@host
+ssh -i key root@host
+ssh -p 2222 root@host
+ssh -o StrictHostKeyChecking=no root@host
+ssh root@$DEPLOY_HOST
+```
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - ssh root@$PRODUCTION_HOST "cd /app && git pull && systemctl restart app"
+```
+
+## Safe alternative
+
+Create a dedicated service account on the target host with access limited to exactly the operations needed:
+
+```yaml
+deploy:
+  script:
+    - ssh deploy@$PRODUCTION_HOST "cd /app && git pull && systemctl restart app"
+```
+
+Configure the `deploy` user with `sudoers` access restricted to the specific commands required (e.g. `NOPASSWD: /usr/bin/systemctl restart app`). Use a short-lived SSH key stored as a masked, protected CI/CD variable.
+
+## Notes
+
+- The rule matches `ssh ... root@` regardless of flags or options between `ssh` and the username
+- Only `root@` is flagged; `root` appearing elsewhere (e.g. in the hostname: `ssh deploy@rootserver.example.com`) does not trigger the rule

--- a/rules/all.go
+++ b/rules/all.go
@@ -50,5 +50,6 @@ func All() []rule.Rule {
 		GL044,
 		GL045,
 		GL046,
+		GL047,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -48,6 +48,7 @@ var cweIDs = map[string]string{
 	"GL044": "CWE-829",
 	"GL045": "CWE-494",
 	"GL046": "CWE-494",
+	"GL047": "CWE-250",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -66,6 +67,7 @@ var cweNames = map[string]string{
 	"CWE-538":  "Insertion of Sensitive Information into Externally-Accessible File or Directory",
 	"CWE-691":  "Insufficient Control Flow Management",
 	"CWE-798":  "Use of Hard-coded Credentials",
+	"CWE-250":  "Execution with Unnecessary Privileges",
 	"CWE-625":  "Permissive Regular Expression",
 	"CWE-829":  "Inclusion of Functionality from Untrusted Control Sphere",
 	"CWE-1104": "Use of Unmaintained Third-Party Components",

--- a/rules/gl047.go
+++ b/rules/gl047.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl047 struct{}
+
+var GL047 = &gl047{}
+
+func (r *gl047) ID() string { return "GL047" }
+
+// sshRootRe matches an ssh invocation with root as the login user.
+// It allows arbitrary flags between ssh and root@ to cover common forms like
+// ssh -i key root@host, ssh -p 2222 root@host, ssh -o ... root@host.
+var sshRootRe = regexp.MustCompile(`\bssh\b.*\broot@`)
+
+func (r *gl047) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(parser.Unwrap(doc), key); node != nil {
+			findings = append(findings, checkSSHRootLines(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(parser.Unwrap(doc), "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkSSHRootLines(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				for _, f := range checkSSHRootLines(node, file, "") {
+					f.Job = name.Value
+					findings = append(findings, f)
+				}
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkSSHRootLines(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if sshRootRe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL047",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "SSH connection as root — use a dedicated least-privilege service account instead of root to limit blast radius if the pipeline is compromised",
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl047_test.go
+++ b/rules/gl047_test.go
@@ -1,0 +1,124 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings047(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL047.Check(doc.Root, "test.yml")
+}
+
+func TestGL047_BasicSSHRoot(t *testing.T) {
+	f := findings047(t, `
+deploy:
+  script:
+    - ssh root@$PRODUCTION_HOST "systemctl restart app"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL047_SSHRootWithKey(t *testing.T) {
+	f := findings047(t, `
+deploy:
+  script:
+    - ssh -i /tmp/key root@192.168.1.1 "cd /app && git pull"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for ssh -i key root@host, got %d", len(f))
+	}
+}
+
+func TestGL047_SSHRootWithPort(t *testing.T) {
+	f := findings047(t, `
+deploy:
+  script:
+    - ssh -p 2222 root@$DEPLOY_HOST "make deploy"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for ssh -p port root@host, got %d", len(f))
+	}
+}
+
+func TestGL047_SSHRootWithOptions(t *testing.T) {
+	f := findings047(t, `
+deploy:
+  script:
+    - ssh -o StrictHostKeyChecking=no root@server.example.com "deploy.sh"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for ssh -o options root@host, got %d", len(f))
+	}
+}
+
+func TestGL047_NonRootUserNoFinding(t *testing.T) {
+	f := findings047(t, `
+deploy:
+  script:
+    - ssh deploy@$PRODUCTION_HOST "systemctl restart app"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for non-root user, got %d", len(f))
+	}
+}
+
+func TestGL047_NoSSHNoFinding(t *testing.T) {
+	f := findings047(t, `
+build:
+  script:
+    - make build
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without ssh, got %d", len(f))
+	}
+}
+
+func TestGL047_SSHRootInBeforeScript(t *testing.T) {
+	f := findings047(t, `
+deploy:
+  before_script:
+    - ssh root@$HOST "prepare"
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for root ssh in before_script, got %d", len(f))
+	}
+}
+
+func TestGL047_JobNameInFinding(t *testing.T) {
+	f := findings047(t, `
+deploy-prod:
+  script:
+    - ssh root@$HOST "restart"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Job != "deploy-prod" {
+		t.Errorf("expected job 'deploy-prod', got %q", f[0].Job)
+	}
+}
+
+func TestGL047_RootInHostnameNoFinding(t *testing.T) {
+	f := findings047(t, `
+deploy:
+  script:
+    - ssh deploy@rootserver.example.com "restart"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when 'root' only appears in hostname, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -49,6 +49,7 @@ var owaspCategories = map[string][]string{
 	"GL044": {"CICD-SEC-4"},
 	"GL045": {"CICD-SEC-9"},
 	"GL046": {"CICD-SEC-3"},
+	"GL047": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl047-ssh-root.yml
+++ b/testdata/fixtures/gl047-ssh-root.yml
@@ -1,0 +1,7 @@
+stages:
+  - deploy
+
+deploy:
+  stage: deploy
+  script:
+    - ssh root@$PRODUCTION_HOST "cd /app && git pull && systemctl restart app"


### PR DESCRIPTION
## What changed

New rule **GL047** detects `ssh root@...` invocations in CI scripts. Connecting to a remote server as root from a CI job grants full, unrestricted host access — if the pipeline is compromised the blast radius extends to production infrastructure.

### Detection

Matches any script line (in `script:`, `before_script:`, `after_script:`) where `ssh` is followed by `root@`, handling all common flag combinations:

```
ssh root@host
ssh -i key root@host
ssh -p 2222 root@host
ssh -o StrictHostKeyChecking=no root@host
ssh root@$DEPLOY_HOST
```

### False positive analysis

- Non-root users (`ssh deploy@host`) → not flagged
- `root` in hostname only (`ssh deploy@rootserver.example.com`) → not flagged (regex requires `root@`)
- No ssh command → not flagged

## Test plan

9 unit tests covering all flag variants, non-root user, root in hostname only, before_script, job name propagation.

```
go test ./rules/ -run TestGL047 -v   # all pass
go test -race ./...                  # all pass
```

## Closes

Closes #169