### PR TITLE
feat: GL048 — SSH with StrictHostKeyChecking disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ exclude_paths:
 
 ## Rules
 
-47 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+48 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -100,7 +100,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -102,3 +102,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL031](rules/GL031.md) | `error` | `DOCKER_TLS_CERTDIR: ""` disables Docker daemon TLS — exposes port 2375 unauthenticated on the runner network |
 | [GL042](rules/GL042.md) | `warn`  | TLS certificate verification disabled (`curl -k`, `wget --no-check-certificate`, `GIT_SSL_NO_VERIFY`, etc.) |
 | [GL047](rules/GL047.md) | `warn`  | SSH connection to remote host as `root` — use a least-privilege service account instead |
+| [GL048](rules/GL048.md) | `error` | `StrictHostKeyChecking` disabled in SSH command or config — host identity not verified, enabling MITM attacks |

--- a/docs/rules/GL048.md
+++ b/docs/rules/GL048.md
@@ -1,0 +1,61 @@
+# GL048 — SSH with StrictHostKeyChecking disabled
+
+**Severity:** `error`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-295 – Improper Certificate Validation](https://cwe.mitre.org/data/definitions/295.html)
+
+## Risk
+
+Passing `-o StrictHostKeyChecking=no` to `ssh`, `scp`, `sftp`, or `rsync` disables host key verification entirely. The SSH client will connect to any host without checking whether its key matches a previously trusted entry, making the connection vulnerable to man-in-the-middle attacks on shared runner networks.
+
+The same risk applies when `StrictHostKeyChecking no` is written to `~/.ssh/config` at pipeline runtime, which affects all subsequent SSH connections in the job.
+
+GL030 flags `ssh-keyscan` (which blindly trusts whatever key the remote host presents at scan time). This rule covers the complementary pattern: disabling the check at connection time.
+
+## What is flagged
+
+Script lines (in `script:`, `before_script:`, `after_script:`) that contain `StrictHostKeyChecking` set to `no` or `off`, in any common form:
+
+```sh
+ssh -o StrictHostKeyChecking=no deploy@host
+scp -o StrictHostKeyChecking=no dist/ deploy@host:/var/www/
+sftp -o StrictHostKeyChecking=no deploy@host
+rsync -e "ssh -o StrictHostKeyChecking=no" dist/ deploy@host:/var/www/
+echo "StrictHostKeyChecking no" >> ~/.ssh/config
+```
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - ssh -o StrictHostKeyChecking=no deploy@$HOST "systemctl restart app"
+    - scp -o StrictHostKeyChecking=no dist/ deploy@$HOST:/var/www/
+```
+
+## Safe alternative
+
+Store a pre-verified `known_hosts` entry as a masked, protected CI/CD variable and install it before connecting:
+
+```yaml
+deploy:
+  before_script:
+    - mkdir -p ~/.ssh && chmod 700 ~/.ssh
+    - echo "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+    - chmod 644 ~/.ssh/known_hosts
+  script:
+    - ssh deploy@$HOST "systemctl restart app"
+```
+
+Generate `$SSH_KNOWN_HOSTS` once from a trusted network:
+
+```sh
+ssh-keyscan -H your-server.example.com
+```
+
+Store the output as a protected, masked CI/CD variable.
+
+## Notes
+
+- Related: GL030 (`ssh-keyscan` at runtime trusts whatever key the host presents)
+- `StrictHostKeyChecking=yes` and `StrictHostKeyChecking=accept-new` are not flagged — only `no` and `off` disable verification entirely

--- a/rules/all.go
+++ b/rules/all.go
@@ -51,5 +51,6 @@ func All() []rule.Rule {
 		GL045,
 		GL046,
 		GL047,
+		GL048,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -49,6 +49,7 @@ var cweIDs = map[string]string{
 	"GL045": "CWE-494",
 	"GL046": "CWE-494",
 	"GL047": "CWE-250",
+	"GL048": "CWE-295",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl048.go
+++ b/rules/gl048.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl048 struct{}
+
+var GL048 = &gl048{}
+
+func (r *gl048) ID() string { return "GL048" }
+
+// sshStrictHostCheckingRe matches any script line that disables SSH host key
+// verification, either via command-line option (-o StrictHostKeyChecking=no/off)
+// or by writing the option into an SSH config file.
+var sshStrictHostCheckingRe = regexp.MustCompile(`StrictHostKeyChecking[=\s]+(no|off)\b`)
+
+func (r *gl048) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(parser.Unwrap(doc), key); node != nil {
+			findings = append(findings, checkStrictHostCheckingLines(node, file, "")...)
+		}
+	}
+	if def := parser.FindKey(parser.Unwrap(doc), "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				findings = append(findings, checkStrictHostCheckingLines(node, file, "")...)
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				for _, f := range checkStrictHostCheckingLines(node, file, "") {
+					f.Job = name.Value
+					findings = append(findings, f)
+				}
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkStrictHostCheckingLines(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if sshStrictHostCheckingRe.MatchString(item.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL048",
+				Severity: finding.Error,
+				Job:      job,
+				Message:  "StrictHostKeyChecking disabled — host identity is not verified, enabling MITM attacks on shared runner networks; use a pre-verified known_hosts entry instead",
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
+			})
+		}
+	}
+	return findings
+}

--- a/rules/gl048_test.go
+++ b/rules/gl048_test.go
@@ -1,0 +1,153 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings048(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL048.Check(doc.Root, "test.yml")
+}
+
+func TestGL048_SSHOptionNo(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  script:
+    - ssh -o StrictHostKeyChecking=no deploy@$HOST "systemctl restart app"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity")
+	}
+}
+
+func TestGL048_SSHOptionOff(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  script:
+    - ssh -o StrictHostKeyChecking=off deploy@$HOST "systemctl restart app"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for StrictHostKeyChecking=off, got %d", len(f))
+	}
+}
+
+func TestGL048_SCPOption(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  script:
+    - scp -o StrictHostKeyChecking=no dist/ deploy@$HOST:/var/www/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for scp with StrictHostKeyChecking=no, got %d", len(f))
+	}
+}
+
+func TestGL048_SFTPOption(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  script:
+    - sftp -o StrictHostKeyChecking=no deploy@$HOST
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for sftp with StrictHostKeyChecking=no, got %d", len(f))
+	}
+}
+
+func TestGL048_RsyncOption(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  script:
+    - rsync -e "ssh -o StrictHostKeyChecking=no" dist/ deploy@$HOST:/var/www/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for rsync with StrictHostKeyChecking=no, got %d", len(f))
+	}
+}
+
+func TestGL048_EchoToSSHConfig(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  before_script:
+    - echo "StrictHostKeyChecking no" >> ~/.ssh/config
+  script:
+    - ssh deploy@$HOST "deploy.sh"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for echo StrictHostKeyChecking no to config, got %d", len(f))
+	}
+}
+
+func TestGL048_EchoOffToSSHConfig(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  script:
+    - echo "StrictHostKeyChecking off" >> ~/.ssh/config
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for StrictHostKeyChecking off, got %d", len(f))
+	}
+}
+
+func TestGL048_YesValueNoFinding(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  script:
+    - ssh -o StrictHostKeyChecking=yes deploy@$HOST "systemctl restart app"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for StrictHostKeyChecking=yes, got %d", len(f))
+	}
+}
+
+func TestGL048_KnownHostsSetupNoFinding(t *testing.T) {
+	f := findings048(t, `
+deploy:
+  before_script:
+    - mkdir -p ~/.ssh && chmod 700 ~/.ssh
+    - echo "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+    - chmod 644 ~/.ssh/known_hosts
+  script:
+    - ssh deploy@$HOST "systemctl restart app"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for proper known_hosts setup, got %d", len(f))
+	}
+}
+
+func TestGL048_GlobalBeforeScript(t *testing.T) {
+	f := findings048(t, `
+before_script:
+  - echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+deploy:
+  script:
+    - ssh deploy@$HOST "deploy.sh"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for global before_script, got %d", len(f))
+	}
+}
+
+func TestGL048_JobNameInFinding(t *testing.T) {
+	f := findings048(t, `
+deploy-prod:
+  script:
+    - ssh -o StrictHostKeyChecking=no deploy@$HOST "restart"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Job != "deploy-prod" {
+		t.Errorf("expected job 'deploy-prod', got %q", f[0].Job)
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -50,6 +50,7 @@ var owaspCategories = map[string][]string{
 	"GL045": {"CICD-SEC-9"},
 	"GL046": {"CICD-SEC-3"},
 	"GL047": {"CICD-SEC-7"},
+	"GL048": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl048-ssh-strict-host-checking.yml
+++ b/testdata/fixtures/gl048-ssh-strict-host-checking.yml
@@ -1,0 +1,7 @@
+stages:
+  - deploy
+
+deploy:
+  stage: deploy
+  script:
+    - ssh -o StrictHostKeyChecking=no deploy@$PRODUCTION_HOST "systemctl restart app"


### PR DESCRIPTION
## Summary

- Adds GL048: detects `StrictHostKeyChecking=no` / `StrictHostKeyChecking=off` in SSH commands and SSH config writes
- Covers `ssh`, `scp`, `sftp`, `rsync -e "ssh ..."`, and `echo "StrictHostKeyChecking no" >> ~/.ssh/config`
- Severity: `error` (unlike GL030 which is `warn` — disabling verification entirely provides zero host verification)
- OWASP: CICD-SEC-7, CWE-295

Closes #170

## How to test

```sh
go test ./rules/ -run TestGL048
```

11 unit tests covering all trigger forms and no-finding cases (StrictHostKeyChecking=yes, proper known_hosts setup).