### PR TITLE
refactor: extract shared rule helpers into helpers.go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,16 @@ Every `finding.Finding` needs `RuleID`, `Severity`, `Message`, `File`, `Line`. S
 
 Severities: `finding.Error` (must fix), `finding.Warn` (should fix), `finding.Info` (informational).
 
+Shared helpers live in `rules/helpers.go`. Check there before writing a new helper function:
+
+| Helper | What it does |
+|--------|-------------|
+| `CollectJobScriptLines(job)` | Returns all scalar script lines across `before_script`, `script`, `after_script` for a single job |
+| `EachScriptLine(doc, file, fn)` | Calls `fn` for every script line in the whole document — global sections, `default:`, and all jobs. Use this for rules that scan script content across the entire file |
+| `IsDeployLikeJob(jobName, job)` | Returns true when the job name, stage, or `environment:` key indicates deployment or release activity |
+
+If you find that two or more rules need the same detection logic, extract it into `helpers.go` rather than duplicating it. Use unexported names for helpers that are only used within the `rules` package.
+
 ### Step 3 — register the rule
 
 Add it to `rules/all.go`:

--- a/rules/gl020.go
+++ b/rules/gl020.go
@@ -27,7 +27,7 @@ func (r *gl020) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		lines := collectScriptLines(job)
+		lines := CollectJobScriptLines(job)
 		if len(lines) == 0 {
 			return
 		}
@@ -65,19 +65,3 @@ func (r *gl020) Check(doc *yaml.Node, file string) []finding.Finding {
 	return findings
 }
 
-// collectScriptLines returns all scalar script lines across script/before_script/after_script.
-func collectScriptLines(job *yaml.Node) []*yaml.Node {
-	var lines []*yaml.Node
-	for _, key := range []string{"before_script", "script", "after_script"} {
-		node := parser.FindKey(job, key)
-		if node == nil || node.Kind != yaml.SequenceNode {
-			continue
-		}
-		for _, item := range node.Content {
-			if item.Kind == yaml.ScalarNode {
-				lines = append(lines, item)
-			}
-		}
-	}
-	return lines
-}

--- a/rules/gl022.go
+++ b/rules/gl022.go
@@ -91,7 +91,7 @@ func (r *gl022) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		lines := collectScriptLines(job)
+		lines := CollectJobScriptLines(job)
 		for _, l := range lines {
 			if f := checkPMLine(l.Value, file, l.Line, l.Column); f != nil {
 				f.Job = name.Value

--- a/rules/gl023.go
+++ b/rules/gl023.go
@@ -62,7 +62,7 @@ func (r *gl023) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		lines := collectScriptLines(job)
+		lines := CollectJobScriptLines(job)
 		for _, l := range lines {
 			if f := checkLockfileLine(l.Value, file, l.Line, l.Column); f != nil {
 				f.Job = name.Value

--- a/rules/gl024.go
+++ b/rules/gl024.go
@@ -27,7 +27,7 @@ func (r *gl024) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		lines := collectScriptLines(job)
+		lines := CollectJobScriptLines(job)
 		if len(lines) == 0 {
 			return
 		}

--- a/rules/gl025.go
+++ b/rules/gl025.go
@@ -27,7 +27,7 @@ func (r *gl025) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, l := range collectScriptLines(job) {
+		for _, l := range CollectJobScriptLines(job) {
 			if !curlWgetRe.MatchString(l.Value) {
 				continue
 			}

--- a/rules/gl026.go
+++ b/rules/gl026.go
@@ -36,7 +36,7 @@ func (r *gl026) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		lines := collectScriptLines(job)
+		lines := CollectJobScriptLines(job)
 		if len(lines) == 0 {
 			return
 		}

--- a/rules/gl045.go
+++ b/rules/gl045.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"regexp"
-	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/parser"
@@ -14,9 +13,6 @@ type gl045 struct{}
 var GL045 = &gl045{}
 
 func (r *gl045) ID() string { return "GL045" }
-
-// releaseKeywords identifies job and stage names that indicate a release or publish step.
-var releaseKeywords = []string{"release", "publish", "deploy", "push", "upload", "dist"}
 
 // releasePushRe matches script lines that push artifacts to a registry or package index.
 var releasePushRe = regexp.MustCompile(
@@ -42,11 +38,11 @@ func (r *gl045) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		if !isReleaseJob(name.Value, job) {
+		if !IsDeployLikeJob(name.Value, job) {
 			return
 		}
 
-		lines := collectJobScriptLines(job)
+		lines := CollectJobScriptLines(job)
 		if len(lines) == 0 {
 			return
 		}
@@ -55,9 +51,6 @@ func (r *gl045) Check(doc *yaml.Node, file string) []finding.Finding {
 		hasSigning := false
 
 		for _, line := range lines {
-			if line.Kind != yaml.ScalarNode {
-				continue
-			}
 			if pushLine == nil && releasePushRe.MatchString(line.Value) {
 				pushLine = line
 			}
@@ -82,34 +75,4 @@ func (r *gl045) Check(doc *yaml.Node, file string) []finding.Finding {
 	})
 
 	return findings
-}
-
-func isReleaseJob(jobName string, job *yaml.Node) bool {
-	lower := strings.ToLower(jobName)
-	for _, kw := range releaseKeywords {
-		if strings.Contains(lower, kw) {
-			return true
-		}
-	}
-	if stageNode := parser.FindKey(job, "stage"); stageNode != nil && stageNode.Kind == yaml.ScalarNode {
-		lowerStage := strings.ToLower(stageNode.Value)
-		for _, kw := range releaseKeywords {
-			if strings.Contains(lowerStage, kw) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func collectJobScriptLines(job *yaml.Node) []*yaml.Node {
-	var lines []*yaml.Node
-	for _, key := range []string{"before_script", "script", "after_script"} {
-		node := parser.FindKey(job, key)
-		if node == nil || node.Kind != yaml.SequenceNode {
-			continue
-		}
-		lines = append(lines, node.Content...)
-	}
-	return lines
 }

--- a/rules/gl047.go
+++ b/rules/gl047.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,54 +20,18 @@ var sshRootRe = regexp.MustCompile(`\bssh\b.*\broot@`)
 
 func (r *gl047) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(parser.Unwrap(doc), key); node != nil {
-			findings = append(findings, checkSSHRootLines(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(parser.Unwrap(doc), "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkSSHRootLines(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range checkSSHRootLines(node, file, "") {
-					f.Job = name.Value
-					findings = append(findings, f)
-				}
-			}
-		}
-	})
-
-	return findings
-}
-
-func checkSSHRootLines(node *yaml.Node, file, job string) []finding.Finding {
-	if node.Kind != yaml.SequenceNode {
-		return nil
-	}
-	var findings []finding.Finding
-	for _, item := range node.Content {
-		if item.Kind != yaml.ScalarNode {
-			continue
-		}
-		if sshRootRe.MatchString(item.Value) {
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		if sshRootRe.MatchString(line.Value) {
 			findings = append(findings, finding.Finding{
 				RuleID:   "GL047",
 				Severity: finding.Warn,
 				Job:      job,
 				Message:  "SSH connection as root — use a dedicated least-privilege service account instead of root to limit blast radius if the pipeline is compromised",
 				File:     file,
-				Line:     item.Line,
-				Col:      item.Column,
+				Line:     line.Line,
+				Col:      line.Column,
 			})
 		}
-	}
+	})
 	return findings
 }

--- a/rules/gl048.go
+++ b/rules/gl048.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,54 +20,18 @@ var sshStrictHostCheckingRe = regexp.MustCompile(`StrictHostKeyChecking[=\s]+(no
 
 func (r *gl048) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(parser.Unwrap(doc), key); node != nil {
-			findings = append(findings, checkStrictHostCheckingLines(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(parser.Unwrap(doc), "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkStrictHostCheckingLines(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range checkStrictHostCheckingLines(node, file, "") {
-					f.Job = name.Value
-					findings = append(findings, f)
-				}
-			}
-		}
-	})
-
-	return findings
-}
-
-func checkStrictHostCheckingLines(node *yaml.Node, file, job string) []finding.Finding {
-	if node.Kind != yaml.SequenceNode {
-		return nil
-	}
-	var findings []finding.Finding
-	for _, item := range node.Content {
-		if item.Kind != yaml.ScalarNode {
-			continue
-		}
-		if sshStrictHostCheckingRe.MatchString(item.Value) {
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		if sshStrictHostCheckingRe.MatchString(line.Value) {
 			findings = append(findings, finding.Finding{
 				RuleID:   "GL048",
 				Severity: finding.Error,
 				Job:      job,
 				Message:  "StrictHostKeyChecking disabled — host identity is not verified, enabling MITM attacks on shared runner networks; use a pre-verified known_hosts entry instead",
 				File:     file,
-				Line:     item.Line,
-				Col:      item.Column,
+				Line:     line.Line,
+				Col:      line.Column,
 			})
 		}
-	}
+	})
 	return findings
 }

--- a/rules/helpers.go
+++ b/rules/helpers.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+// deployLikeKeywords covers job and stage names that indicate deployment,
+// release, or artifact publishing activity.
+var deployLikeKeywords = []string{
+	"deploy", "release", "publish", "rollout",
+	"migrat", "provision", "ship", "push", "upload", "dist",
+}
+
+// IsDeployLikeJob returns true when the job name, stage name, or presence of
+// an environment: key indicates deployment, release, or artifact publishing.
+// Used by rules that need to identify jobs that mutate external state.
+func IsDeployLikeJob(jobName string, job *yaml.Node) bool {
+	lower := strings.ToLower(jobName)
+	for _, kw := range deployLikeKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	if parser.FindKey(job, "environment") != nil {
+		return true
+	}
+	if stageNode := parser.FindKey(job, "stage"); stageNode != nil && stageNode.Kind == yaml.ScalarNode {
+		stageLower := strings.ToLower(stageNode.Value)
+		for _, kw := range deployLikeKeywords {
+			if strings.Contains(stageLower, kw) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CollectJobScriptLines returns all scalar script lines from a job's
+// before_script, script, and after_script sections.
+func CollectJobScriptLines(job *yaml.Node) []*yaml.Node {
+	var lines []*yaml.Node
+	for _, key := range []string{"before_script", "script", "after_script"} {
+		node := parser.FindKey(job, key)
+		if node == nil || node.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range node.Content {
+			if item.Kind == yaml.ScalarNode {
+				lines = append(lines, item)
+			}
+		}
+	}
+	return lines
+}
+
+// EachScriptLine visits every scalar script line in the document, calling fn
+// for each. It covers global before/after_script, default: before/after_script,
+// and all job-level script/before_script/after_script sections.
+// fn receives the line node, the file path, and the job name (empty for
+// global and default: sections).
+func EachScriptLine(doc *yaml.Node, file string, fn func(line *yaml.Node, file, job string)) {
+	mapping := parser.Unwrap(doc)
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil && node.Kind == yaml.SequenceNode {
+			for _, item := range node.Content {
+				if item.Kind == yaml.ScalarNode {
+					fn(item, file, "")
+				}
+			}
+		}
+	}
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil && node.Kind == yaml.SequenceNode {
+				for _, item := range node.Content {
+					if item.Kind == yaml.ScalarNode {
+						fn(item, file, "")
+					}
+				}
+			}
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil && node.Kind == yaml.SequenceNode {
+				for _, item := range node.Content {
+					if item.Kind == yaml.ScalarNode {
+						fn(item, file, name.Value)
+					}
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Extracts repeated code patterns from the `rules` package into `rules/helpers.go`:

- **`CollectJobScriptLines(job)`** — unified replacement for `collectScriptLines` (gl020) and `collectJobScriptLines` (gl045), which were identical functions duplicated due to a naming conflict
- **`IsDeployLikeJob(jobName, job)`** — unified deploy/release job detector replacing `isReleaseJob` (gl045). Checks job name, stage name, and `environment:` key against a shared keyword set
- **`EachScriptLine(doc, file, fn)`** — eliminates the 3-part boilerplate (global → `default:` → `EachJob`) that repeated across 15+ rule files; used immediately in gl047 and gl048, available for future rules

Also updated `CONTRIBUTING.md` to document the helpers and add guidance to check `helpers.go` before writing new helper functions, and to extract shared logic when multiple rules need it.

## Rules changed (behaviour unchanged)

| File | Change |
|------|--------|
| gl020 | `collectScriptLines` → `CollectJobScriptLines` |
| gl022–gl026 | `collectScriptLines` → `CollectJobScriptLines` |
| gl045 | `isReleaseJob` + `collectJobScriptLines` → `IsDeployLikeJob` + `CollectJobScriptLines` |
| gl047 | Check rewritten using `EachScriptLine` |
| gl048 | Check rewritten using `EachScriptLine` |

## How to test

```sh
go test ./rules/...
```

All existing tests pass unchanged — this is a pure refactor with no behaviour changes.