### PR TITLE
feat: GL049 + GL050 — interruptible deploy job and sudo in CI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ exclude_paths:
 
 ## Rules
 
-48 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+50 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -100,7 +100,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -103,3 +103,5 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL042](rules/GL042.md) | `warn`  | TLS certificate verification disabled (`curl -k`, `wget --no-check-certificate`, `GIT_SSL_NO_VERIFY`, etc.) |
 | [GL047](rules/GL047.md) | `warn`  | SSH connection to remote host as `root` — use a least-privilege service account instead |
 | [GL048](rules/GL048.md) | `error` | `StrictHostKeyChecking` disabled in SSH command or config — host identity not verified, enabling MITM attacks |
+| [GL049](rules/GL049.md) | `warn`  | Deploy job with `interruptible: true` — mid-run cancellation leaves the target environment in an undefined state |
+| [GL050](rules/GL050.md) | `warn`  | `sudo` in CI script — escalates to root, amplifying blast radius if the pipeline is compromised |

--- a/docs/rules/GL049.md
+++ b/docs/rules/GL049.md
@@ -1,0 +1,46 @@
+# GL049 — Deploy job marked interruptible: true
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-362 – Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')](https://cwe.mitre.org/data/definitions/362.html)
+
+## Risk
+
+When a deployment job is marked `interruptible: true`, GitLab may cancel it mid-execution if a newer pipeline starts (depending on [`workflow:auto_cancel`](https://docs.gitlab.com/ci/yaml/#workflowauto_cancel) settings). A deployment interrupted halfway leaves the target environment in an undefined state: database migrations may be partially applied, containers partially updated, or load-balancer state inconsistent.
+
+`interruptible: true` is appropriate for build, test, and lint jobs — not for jobs that mutate external state.
+
+## What is flagged
+
+Jobs whose name, stage, or [`environment:`](https://docs.gitlab.com/ci/yaml/#environment) key indicates deployment activity and that have `interruptible: true` explicitly set. Matched keywords: `deploy`, `release`, `publish`, `rollout`, `migrate`, `provision`.
+
+## Trigger example
+
+```yaml
+deploy-production:
+  stage: deploy
+  interruptible: true
+  script:
+    - kubectl apply -f k8s/
+    - kubectl rollout status deployment/app
+```
+
+## Safe alternative
+
+Omit `interruptible` (default is `false`) or set it explicitly, and pair with `resource_group:` to prevent concurrent runs:
+
+```yaml
+deploy-production:
+  stage: deploy
+  interruptible: false
+  resource_group: production
+  script:
+    - kubectl apply -f k8s/
+    - kubectl rollout status deployment/app
+```
+
+## Notes
+
+- Jobs without an explicit `interruptible: true` are not flagged (default is `false`)
+- Non-deployment jobs with `interruptible: true` are not flagged — this is the intended use case
+- See also: GL019 (deploy job without `resource_group:`)

--- a/docs/rules/GL050.md
+++ b/docs/rules/GL050.md
@@ -1,0 +1,51 @@
+# GL050 — sudo usage in CI script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-250 – Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
+
+## Risk
+
+`sudo` in a CI script signals one of two problems:
+
+1. **Runner runs as non-root, script escalates to root** — any compromise in the executed code (malicious dependency, injected variable, supply-chain attack) gains full root access to the runner host. Privilege escalation turns a contained incident into a full runner compromise.
+
+2. **Runner already runs as root, `sudo` is unnecessary** — common on shared GitLab.com runners. The `sudo` is redundant and signals a misconfigured or poorly understood runner setup.
+
+In both cases `sudo` in a pipeline script is a security smell.
+
+## What is flagged
+
+Script lines (in `script:`, `before_script:`, `after_script:`) that contain `sudo` as a standalone word. Shell comment lines (starting with `#`) are not flagged.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - sudo apt-get install -y nodejs
+    - sudo make install
+```
+
+## Safe alternatives
+
+```yaml
+# Use a purpose-built image that already has the tools installed
+build:
+  image: node:20.11.1
+  script:
+    - make install
+```
+
+```yaml
+# On shared runners that already run as root, drop sudo entirely
+build:
+  script:
+    - apt-get install -y nodejs
+    - make install
+```
+
+## Notes
+
+- `sudo` as a substring of another word (e.g. `pseudocode`) is not flagged
+- The root fix is usually to use a container image with required tools pre-installed, avoiding system package installation in CI entirely

--- a/rules/all.go
+++ b/rules/all.go
@@ -52,5 +52,7 @@ func All() []rule.Rule {
 		GL046,
 		GL047,
 		GL048,
+		GL049,
+		GL050,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -50,6 +50,8 @@ var cweIDs = map[string]string{
 	"GL046": "CWE-494",
 	"GL047": "CWE-250",
 	"GL048": "CWE-295",
+	"GL049": "CWE-362",
+	"GL050": "CWE-250",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl049.go
+++ b/rules/gl049.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl049 struct{}
+
+var GL049 = &gl049{}
+
+func (r *gl049) ID() string { return "GL049" }
+
+func (r *gl049) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if !IsDeployLikeJob(name.Value, job) {
+			return
+		}
+		interruptible := parser.FindKey(job, "interruptible")
+		if interruptible == nil || interruptible.Kind != yaml.ScalarNode {
+			return
+		}
+		if strings.ToLower(interruptible.Value) != "true" {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL049",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message: fmt.Sprintf(
+				"deploy job %q has interruptible: true — a mid-run cancellation leaves the target environment in an undefined state; set interruptible: false or omit it (default is false)",
+				name.Value,
+			),
+			File: file,
+			Line: interruptible.Line,
+			Col:  interruptible.Column,
+		})
+	})
+
+	return findings
+}

--- a/rules/gl049_test.go
+++ b/rules/gl049_test.go
@@ -1,0 +1,148 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings049(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL049.Check(doc.Root, "test.yml")
+}
+
+func TestGL049_DeployJobInterruptibleTrue(t *testing.T) {
+	f := findings049(t, `
+deploy-production:
+  stage: deploy
+  interruptible: true
+  script:
+    - kubectl apply -f k8s/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL049_DeployJobInterruptibleFalse(t *testing.T) {
+	f := findings049(t, `
+deploy-production:
+  stage: deploy
+  interruptible: false
+  script:
+    - kubectl apply -f k8s/
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for interruptible: false, got %d", len(f))
+	}
+}
+
+func TestGL049_DeployJobNoInterruptible(t *testing.T) {
+	f := findings049(t, `
+deploy-production:
+  stage: deploy
+  script:
+    - kubectl apply -f k8s/
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings when interruptible is absent, got %d", len(f))
+	}
+}
+
+func TestGL049_BuildJobInterruptibleTrueNoFinding(t *testing.T) {
+	f := findings049(t, `
+build:
+  stage: build
+  interruptible: true
+  script:
+    - make build
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for non-deploy job with interruptible: true, got %d", len(f))
+	}
+}
+
+func TestGL049_ReleaseJobNameMatch(t *testing.T) {
+	f := findings049(t, `
+release-binaries:
+  interruptible: true
+  script:
+    - goreleaser release
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for release job name, got %d", len(f))
+	}
+}
+
+func TestGL049_PublishJobNameMatch(t *testing.T) {
+	f := findings049(t, `
+publish-npm:
+  interruptible: true
+  script:
+    - npm publish
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for publish job name, got %d", len(f))
+	}
+}
+
+func TestGL049_MigrateJobNameMatch(t *testing.T) {
+	f := findings049(t, `
+run-migrations:
+  interruptible: true
+  script:
+    - ./migrate up
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for migrate in job name, got %d", len(f))
+	}
+}
+
+func TestGL049_EnvironmentKeyMatch(t *testing.T) {
+	f := findings049(t, `
+push-to-prod:
+  environment: production
+  interruptible: true
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for job with environment key, got %d", len(f))
+	}
+}
+
+func TestGL049_JobNameInFinding(t *testing.T) {
+	f := findings049(t, `
+deploy-prod:
+  interruptible: true
+  script:
+    - kubectl apply -f k8s/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Job != "deploy-prod" {
+		t.Errorf("expected job 'deploy-prod', got %q", f[0].Job)
+	}
+}
+
+func TestGL049_TestJobInterruptibleTrueNoFinding(t *testing.T) {
+	f := findings049(t, `
+unit-tests:
+  stage: test
+  interruptible: true
+  script:
+    - go test ./...
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for test job with interruptible: true, got %d", len(f))
+	}
+}

--- a/rules/gl050.go
+++ b/rules/gl050.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl050 struct{}
+
+var GL050 = &gl050{}
+
+func (r *gl050) ID() string { return "GL050" }
+
+var sudoRe = regexp.MustCompile(`\bsudo\b`)
+
+func (r *gl050) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		if strings.HasPrefix(strings.TrimSpace(line.Value), "#") {
+			return
+		}
+		if sudoRe.MatchString(line.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL050",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "sudo in CI script escalates privileges — use a container image with required tools pre-installed instead",
+				File:     file,
+				Line:     line.Line,
+				Col:      line.Column,
+			})
+		}
+	})
+	return findings
+}

--- a/rules/gl050_test.go
+++ b/rules/gl050_test.go
@@ -1,0 +1,142 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings050(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL050.Check(doc.Root, "test.yml")
+}
+
+func TestGL050_SudoAptGet(t *testing.T) {
+	f := findings050(t, `
+build:
+  script:
+    - sudo apt-get install -y nodejs
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+}
+
+func TestGL050_SudoMakeInstall(t *testing.T) {
+	f := findings050(t, `
+build:
+  script:
+    - sudo make install
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for sudo make install, got %d", len(f))
+	}
+}
+
+func TestGL050_NoSudoNoFinding(t *testing.T) {
+	f := findings050(t, `
+build:
+  image: node:20.11.1
+  script:
+    - make install
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without sudo, got %d", len(f))
+	}
+}
+
+func TestGL050_SubstringNoFinding(t *testing.T) {
+	f := findings050(t, `
+build:
+  script:
+    - echo "pseudocode example"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for sudo as substring, got %d", len(f))
+	}
+}
+
+func TestGL050_ShellCommentNoFinding(t *testing.T) {
+	f := findings050(t, `
+build:
+  script:
+    - "# sudo apt-get install nodejs"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for sudo in shell comment, got %d", len(f))
+	}
+}
+
+func TestGL050_SudoInBeforeScript(t *testing.T) {
+	f := findings050(t, `
+build:
+  before_script:
+    - sudo apt-get update
+  script:
+    - make build
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for sudo in before_script, got %d", len(f))
+	}
+}
+
+func TestGL050_SudoInAfterScript(t *testing.T) {
+	f := findings050(t, `
+build:
+  script:
+    - make build
+  after_script:
+    - sudo rm -rf /tmp/build
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for sudo in after_script, got %d", len(f))
+	}
+}
+
+func TestGL050_GlobalBeforeScript(t *testing.T) {
+	f := findings050(t, `
+before_script:
+  - sudo apt-get update
+
+build:
+  script:
+    - make build
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for sudo in global before_script, got %d", len(f))
+	}
+}
+
+func TestGL050_JobNameInFinding(t *testing.T) {
+	f := findings050(t, `
+build-app:
+  script:
+    - sudo apt-get install -y build-essential
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Job != "build-app" {
+		t.Errorf("expected job 'build-app', got %q", f[0].Job)
+	}
+}
+
+func TestGL050_MultipleSudoLines(t *testing.T) {
+	f := findings050(t, `
+setup:
+  script:
+    - sudo apt-get update
+    - sudo apt-get install -y nodejs
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings for two sudo lines, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -51,6 +51,8 @@ var owaspCategories = map[string][]string{
 	"GL046": {"CICD-SEC-3"},
 	"GL047": {"CICD-SEC-7"},
 	"GL048": {"CICD-SEC-7"},
+	"GL049": {"CICD-SEC-7"},
+	"GL050": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl049-interruptible-deploy.yml
+++ b/testdata/fixtures/gl049-interruptible-deploy.yml
@@ -1,0 +1,9 @@
+stages:
+  - deploy
+
+deploy-production:
+  stage: deploy
+  interruptible: true
+  script:
+    - kubectl apply -f k8s/
+    - kubectl rollout status deployment/app

--- a/testdata/fixtures/gl050-sudo.yml
+++ b/testdata/fixtures/gl050-sudo.yml
@@ -1,0 +1,8 @@
+stages:
+  - build
+
+build:
+  stage: build
+  script:
+    - sudo apt-get install -y nodejs
+    - sudo make install


### PR DESCRIPTION
## Summary

- **GL049**: Flags deploy/release jobs with `interruptible: true` — mid-run cancellation can leave the target environment in a broken state (partial migration, half-deployed containers). Uses `IsDeployLikeJob` from helpers.go for job detection.
- **GL050**: Flags `sudo` in CI script lines — signals either unnecessary privilege escalation (runner already root) or blast-radius amplification (runner non-root, sudo grants full host access). Uses `EachScriptLine` from helpers.go.

Closes #166, closes #167

## Detection logic

**GL049** identifies deploy jobs via `IsDeployLikeJob` (job name, stage name, or `environment:` key). Only fires when `interruptible: true` is explicitly set (the default is `false`). Build/test/lint jobs with `interruptible: true` are not flagged.

**GL050** matches `\bsudo\b` in any script line. Shell comment lines (`# ...`) are skipped. `sudo` as a substring (`pseudocode`) is not flagged.

## How to test

```sh
go test ./rules/ -run "TestGL049|TestGL050" -v
```

10 tests for GL049, 10 tests for GL050.