### PR TITLE
feat: GL051 — unconstrained spec:inputs interpolated into sensitive CI keyword

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -58,6 +58,7 @@ User-controlled inputs and unversioned component references that allow malicious
 | [GL025](rules/GL025.md) | `warn`  | `curl`/`wget` uses a user-controlled CI variable — attacker can redirect the request to an arbitrary host |
 | [GL041](rules/GL041.md) | `warn`  | `include: component:` without a pinned semver tag or commit SHA |
 | [GL044](rules/GL044.md) | `warn`  | MR-triggered job checks out `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` — executes attacker-controlled code with `$CI_JOB_TOKEN` access |
+| [GL051](rules/GL051.md) | `warn`  | Unconstrained `spec:inputs` entry interpolated into `image:`, `script:`, or `environment:name:` — caller can supply arbitrary values |
 
 ---
 

--- a/docs/rules/GL051.md
+++ b/docs/rules/GL051.md
@@ -1,0 +1,64 @@
+# GL051 — Unconstrained `spec:inputs` interpolated into sensitive CI keyword
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)  
+**CWE:** [CWE-829 – Inclusion of Functionality from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html)
+
+## Risk
+
+GitLab CI Catalog components accept caller-supplied values via `spec:inputs`. When an input is interpolated into a sensitive keyword — `image:`, `services:`, `script:`, `before_script:`, `after_script:`, or `environment:name:` — without a `regex:` constraint or an `options:` allowlist, any consumer of the component can supply an arbitrary value.
+
+This differs from GL002 (predefined GitLab variables): here the tainted value originates from whoever _calls_ the component, not from the commit author, making the attack surface wider and the trust model distinct.
+
+Without constraints, an attacker can:
+- Substitute an arbitrary image and execute malicious code (`image:`, `services:`)
+- Inject shell commands into the pipeline (`script:`, `before_script:`, `after_script:`)
+- Redirect deployments to an unintended environment (`environment:name:`)
+
+## Trigger example
+
+```yaml
+spec:
+  inputs:
+    deploy_image:
+      description: "Image to deploy"
+      # no regex, no options
+
+deploy:
+  image: $[[ inputs.deploy_image ]]   # unconstrained caller input
+  script:
+    - ./deploy.sh
+```
+
+## Safe alternatives
+
+```yaml
+# Allowlist with options:
+spec:
+  inputs:
+    environment:
+      options: [staging, production]
+
+deploy:
+  script:
+    - ./deploy.sh $[[ inputs.environment ]]
+```
+
+```yaml
+# Pattern constraint with regex:
+spec:
+  inputs:
+    image_tag:
+      regex: '^[a-zA-Z0-9._-]+$'
+
+deploy:
+  image: myapp:$[[ inputs.image_tag ]]
+  script:
+    - ./deploy.sh
+```
+
+## Notes
+
+- Inputs with a `default:` but without `regex:` or `options:` are still flagged — the default does not constrain what a caller can pass.
+- Inputs used only in non-sensitive positions (e.g. `variables:`, `artifacts:paths:`) are not flagged by this rule.
+- The interpolation syntax `$[[ inputs.NAME ]]` is specific to GitLab CI Catalog components; regular `$VARIABLE` references in normal pipelines are covered by GL002 and GL015.

--- a/rules/all.go
+++ b/rules/all.go
@@ -54,5 +54,6 @@ func All() []rule.Rule {
 		GL048,
 		GL049,
 		GL050,
+		GL051,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -52,6 +52,7 @@ var cweIDs = map[string]string{
 	"GL048": "CWE-295",
 	"GL049": "CWE-362",
 	"GL050": "CWE-250",
+	"GL051": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl051.go
+++ b/rules/gl051.go
@@ -1,0 +1,158 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl051 struct{}
+
+var GL051 = &gl051{}
+
+func (r *gl051) ID() string { return "GL051" }
+
+func (r *gl051) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+
+	unconstrained := gl051UnconstrainedInputs(mapping)
+	if len(unconstrained) == 0 {
+		return nil
+	}
+
+	patterns := make(map[string]*regexp.Regexp, len(unconstrained))
+	for _, name := range unconstrained {
+		patterns[name] = regexp.MustCompile(`\$\[\[\s*inputs\.` + regexp.QuoteMeta(name) + `\s*\]\]`)
+	}
+
+	var findings []finding.Finding
+
+	findings = append(findings, gl051CheckImage(parser.FindKey(mapping, "image"), file, "", patterns)...)
+	findings = append(findings, gl051CheckServices(parser.FindKey(mapping, "services"), file, "", patterns)...)
+	for _, key := range []string{"before_script", "after_script"} {
+		findings = append(findings, gl051CheckScripts(parser.FindKey(mapping, key), file, "", key, patterns)...)
+	}
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, gl051CheckImage(parser.FindKey(def, "image"), file, "", patterns)...)
+		findings = append(findings, gl051CheckServices(parser.FindKey(def, "services"), file, "", patterns)...)
+		for _, key := range []string{"before_script", "after_script"} {
+			findings = append(findings, gl051CheckScripts(parser.FindKey(def, key), file, "", key, patterns)...)
+		}
+	}
+
+	parser.EachJob(doc, func(nameNode *yaml.Node, jobNode *yaml.Node) {
+		job := nameNode.Value
+		findings = append(findings, gl051CheckImage(parser.FindKey(jobNode, "image"), file, job, patterns)...)
+		findings = append(findings, gl051CheckServices(parser.FindKey(jobNode, "services"), file, job, patterns)...)
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			findings = append(findings, gl051CheckScripts(parser.FindKey(jobNode, key), file, job, key, patterns)...)
+		}
+		findings = append(findings, gl051CheckEnvironment(parser.FindKey(jobNode, "environment"), file, job, patterns)...)
+	})
+
+	return findings
+}
+
+// gl051UnconstrainedInputs returns spec:inputs names that have neither a
+// regex: constraint nor an options: allowlist.
+func gl051UnconstrainedInputs(mapping *yaml.Node) []string {
+	spec := parser.FindKey(mapping, "spec")
+	if spec == nil {
+		return nil
+	}
+	inputs := parser.FindKey(spec, "inputs")
+	if inputs == nil || inputs.Kind != yaml.MappingNode {
+		return nil
+	}
+	var unconstrained []string
+	for i := 0; i+1 < len(inputs.Content); i += 2 {
+		name := inputs.Content[i].Value
+		def := inputs.Content[i+1]
+		if def.Kind != yaml.MappingNode {
+			unconstrained = append(unconstrained, name)
+			continue
+		}
+		if parser.FindKey(def, "regex") == nil && parser.FindKey(def, "options") == nil {
+			unconstrained = append(unconstrained, name)
+		}
+	}
+	return unconstrained
+}
+
+func gl051CheckScalar(node *yaml.Node, file, job, keyword string, patterns map[string]*regexp.Regexp) []finding.Finding {
+	if node == nil || node.Kind != yaml.ScalarNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for inputName, re := range patterns {
+		if re.MatchString(node.Value) {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL051",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  fmt.Sprintf("unconstrained spec:inputs entry %q interpolated into %s — add regex: or options: to restrict caller-supplied values", inputName, keyword),
+				File:     file,
+				Line:     node.Line,
+				Col:      node.Column,
+			})
+		}
+	}
+	return findings
+}
+
+func gl051CheckImage(node *yaml.Node, file, job string, patterns map[string]*regexp.Regexp) []finding.Finding {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return gl051CheckScalar(node, file, job, "image:", patterns)
+	case yaml.MappingNode:
+		return gl051CheckScalar(parser.FindKey(node, "name"), file, job, "image:", patterns)
+	}
+	return nil
+}
+
+func gl051CheckServices(node *yaml.Node, file, job string, patterns map[string]*regexp.Regexp) []finding.Finding {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		switch item.Kind {
+		case yaml.ScalarNode:
+			findings = append(findings, gl051CheckScalar(item, file, job, "services:", patterns)...)
+		case yaml.MappingNode:
+			findings = append(findings, gl051CheckScalar(parser.FindKey(item, "name"), file, job, "services:", patterns)...)
+		}
+	}
+	return findings
+}
+
+func gl051CheckScripts(node *yaml.Node, file, job, keyword string, patterns map[string]*regexp.Regexp) []finding.Finding {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		findings = append(findings, gl051CheckScalar(item, file, job, keyword+":", patterns)...)
+	}
+	return findings
+}
+
+func gl051CheckEnvironment(node *yaml.Node, file, job string, patterns map[string]*regexp.Regexp) []finding.Finding {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return gl051CheckScalar(node, file, job, "environment:name:", patterns)
+	case yaml.MappingNode:
+		return gl051CheckScalar(parser.FindKey(node, "name"), file, job, "environment:name:", patterns)
+	}
+	return nil
+}

--- a/rules/gl051_test.go
+++ b/rules/gl051_test.go
@@ -1,0 +1,278 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings051(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL051.Check(doc.Root, "test.yml")
+}
+
+func TestGL051_UnconstrainedInputInImage(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    deploy_image:
+      description: "Image to use"
+
+deploy:
+  image: $[[ inputs.deploy_image ]]
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+	if f[0].Job != "deploy" {
+		t.Errorf("expected job 'deploy', got %q", f[0].Job)
+	}
+}
+
+func TestGL051_ConstrainedByOptions_NoFinding(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    environment:
+      options:
+        - staging
+        - production
+
+deploy:
+  image: alpine:3.19
+  script:
+    - echo $[[ inputs.environment ]]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for options-constrained input, got %d", len(f))
+	}
+}
+
+func TestGL051_ConstrainedByRegex_NoFinding(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    image_tag:
+      regex: '^[a-zA-Z0-9._-]+$'
+
+deploy:
+  image: alpine:$[[ inputs.image_tag ]]
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for regex-constrained input, got %d", len(f))
+	}
+}
+
+func TestGL051_UnconstrainedInputInScript(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    command:
+      description: "Command to run"
+
+run:
+  script:
+    - $[[ inputs.command ]]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for script injection, got %d", len(f))
+	}
+}
+
+func TestGL051_UnconstrainedInputInBeforeScript(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    setup_cmd:
+
+run:
+  before_script:
+    - $[[ inputs.setup_cmd ]]
+  script:
+    - ./build.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for before_script injection, got %d", len(f))
+	}
+}
+
+func TestGL051_UnconstrainedInputInAfterScript(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    cleanup_cmd:
+
+run:
+  script:
+    - ./build.sh
+  after_script:
+    - $[[ inputs.cleanup_cmd ]]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for after_script injection, got %d", len(f))
+	}
+}
+
+func TestGL051_UnconstrainedInputInEnvironmentName(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    deploy_env:
+      description: "Target environment"
+
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: $[[ inputs.deploy_env ]]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for environment:name: injection, got %d", len(f))
+	}
+}
+
+func TestGL051_UnconstrainedInputInEnvironmentScalar(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    deploy_env:
+
+deploy:
+  script:
+    - ./deploy.sh
+  environment: $[[ inputs.deploy_env ]]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for environment scalar injection, got %d", len(f))
+	}
+}
+
+func TestGL051_UnconstrainedInputInServices(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    svc_image:
+
+test:
+  services:
+    - $[[ inputs.svc_image ]]
+  script:
+    - ./test.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for services: injection, got %d", len(f))
+	}
+}
+
+func TestGL051_NoSpecInputs_NoFinding(t *testing.T) {
+	f := findings051(t, `
+deploy:
+  image: alpine:3.19
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without spec:inputs, got %d", len(f))
+	}
+}
+
+func TestGL051_ImageMappingForm(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    runner_image:
+
+build:
+  image:
+    name: $[[ inputs.runner_image ]]
+    entrypoint: [""]
+  script:
+    - make build
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for image mapping form, got %d", len(f))
+	}
+}
+
+func TestGL051_MultipleUnconstrainedInputs(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    image_name:
+    run_cmd:
+
+job:
+  image: $[[ inputs.image_name ]]
+  script:
+    - $[[ inputs.run_cmd ]]
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings for two unconstrained inputs, got %d", len(f))
+	}
+}
+
+func TestGL051_ConstrainedInputNotUsedInSensitiveKey_NoFinding(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    version:
+      regex: '^\d+\.\d+\.\d+$'
+    env:
+      options:
+        - staging
+        - production
+
+deploy:
+  image: myapp:$[[ inputs.version ]]
+  script:
+    - echo "Deploying to $[[ inputs.env ]]"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for fully constrained inputs, got %d", len(f))
+	}
+}
+
+func TestGL051_InputWithDefaultButNoConstraint(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    deploy_image:
+      default: "alpine:3.19"
+
+deploy:
+  image: $[[ inputs.deploy_image ]]
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for input with only default (no regex/options), got %d", len(f))
+	}
+}
+
+func TestGL051_WhitespaceVariantsInInterpolation(t *testing.T) {
+	f := findings051(t, `
+spec:
+  inputs:
+    img:
+
+build:
+  image: $[[inputs.img]]
+  script:
+    - make
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for compact interpolation syntax, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -53,6 +53,7 @@ var owaspCategories = map[string][]string{
 	"GL048": {"CICD-SEC-7"},
 	"GL049": {"CICD-SEC-7"},
 	"GL050": {"CICD-SEC-7"},
+	"GL051": {"CICD-SEC-4"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl051-unconstrained-input.yml
+++ b/testdata/fixtures/gl051-unconstrained-input.yml
@@ -1,0 +1,9 @@
+spec:
+  inputs:
+    deploy_image:
+      description: "Docker image to use for deployment"
+
+deploy:
+  image: $[[ inputs.deploy_image ]]
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
## Summary

Implements issue #164.

Adds rule **GL051** to detect `spec:inputs` entries in GitLab CI Catalog components that are interpolated into sensitive keywords (`image:`, `services:`, `script:`, `before_script:`, `after_script:`, `environment:name:`) without a `regex:` constraint or `options:` allowlist.

- **OWASP:** CICD-SEC-4 — Poisoned Pipeline Execution
- **CWE:** CWE-829 — Inclusion of Functionality from Untrusted Control Sphere
- **Severity:** `warn`

## What changed

- `rules/gl051.go` — rule implementation: parses `spec:inputs`, identifies unconstrained entries (no `regex:`, no `options:`), then checks each sensitive keyword for `$[[ inputs.NAME ]]` interpolations
- `rules/gl051_test.go` — 15 test cases covering all sensitive keywords, both safe forms (`options:`, `regex:`), mapping-form image, multiple inputs, compact interpolation syntax
- `testdata/fixtures/gl051-unconstrained-input.yml` — fixture that triggers the rule
- `docs/rules/GL051.md` — full rule documentation
- `rules/all.go`, `rules/owasp.go`, `rules/cwe.go`, `docs/rules.md` — registration and metadata

## Detection logic

1. Find all `spec:inputs` entries with neither `regex:` nor `options:` (inputs with only `description:` or `default:` are unconstrained and flagged)
2. Build a per-input regex matching `$[[ inputs.NAME ]]` (with flexible whitespace)
3. Scan `image:`, `services:`, `script:`, `before_script:`, `after_script:`, `environment:name:` at global, `default:`, and per-job level

## Test plan

- `go test ./rules/... -run GL051 -v` — all 15 unit tests pass
- `go test ./rules/... -run TestRuleConsistency/GL051` — consistency check passes (doc, fixture, OWASP/CWE mapping, rules.md link)
- `go test ./...` — full suite green