### PR TITLE
feat: GL052 — user-controlled variable in environment:name grants protected environment access

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ exclude_paths:
 
 ## Rules
 
-50 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+52 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040 |
+| Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026, GL046 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
 | Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -26,6 +26,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL035](rules/GL035.md) | `warn`  | `git` command uses URL with embedded credentials (`user:token@host`) — token appears in job logs |
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |
 | [GL040](rules/GL040.md) | `warn`  | Script uses plain `ftp://` — credentials and content transmitted unencrypted |
+| [GL052](rules/GL052.md) | `warn`  | User-controlled variable in `environment:name:` — attacker can craft a branch name that resolves to a protected environment and access its secrets |
 
 ---
 

--- a/docs/rules/GL052.md
+++ b/docs/rules/GL052.md
@@ -1,0 +1,62 @@
+# GL052 — User-controlled variable in `environment:name:` grants protected environment access
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
+**CWE:** [CWE-284 – Improper Access Control](https://cwe.mitre.org/data/definitions/284.html)
+
+## Risk
+
+GitLab's dynamic review environments use `environment:name:` with a variable to create per-branch environments — this is the recommended GitLab pattern. However, if the variable is user-controlled (branch name, MR title, commit message), an attacker can craft a value that resolves to the exact name of a protected environment and gain access to its secrets.
+
+Protected environments in GitLab restrict who can deploy and which variables are exposed. Name matching is exact and string-based — there is no further verification that the job was triggered legitimately.
+
+**Example attack:**
+1. Protected environment `review/main` exists with production-scoped secrets
+2. Attacker opens an MR from a branch named `main`
+3. Pipeline runs `environment: name: review/$CI_COMMIT_REF_NAME` → resolves to `review/main`
+4. Job receives the protected environment's variables
+
+## Trigger example
+
+```yaml
+deploy-review:
+  script:
+    - ./deploy.sh
+  environment:
+    name: review/$CI_COMMIT_REF_NAME   # user-controlled — can be spoofed
+```
+
+```yaml
+deploy:
+  script:
+    - ./deploy.sh
+  environment: deploy-$CI_COMMIT_BRANCH   # scalar shorthand, same risk
+```
+
+## Safe alternatives
+
+```yaml
+# Use a static environment name
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+```
+
+```yaml
+# Use a prefix that cannot be a valid branch name, and restrict triggering branches
+deploy-review:
+  rules:
+    - if: $CI_MERGE_REQUEST_IID
+  script:
+    - ./deploy.sh
+  environment:
+    name: review/mr-$CI_MERGE_REQUEST_IID   # MR IID is GitLab-assigned, not user-controlled
+```
+
+## Notes
+
+- `CI_COMMIT_REF_SLUG` is a normalised form of `CI_COMMIT_REF_NAME` (lowercase, special chars replaced) and carries the same spoofing risk — it is included in the flagged variable set.
+- The fix is not to avoid dynamic environments but to ensure no protected environment name can be reached via a user-controlled value. GitLab-assigned identifiers like `$CI_MERGE_REQUEST_IID` are safe alternatives.
+- Variables flagged by this rule are the same user-controlled set as GL002, plus `CI_COMMIT_REF_SLUG`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -55,5 +55,6 @@ func All() []rule.Rule {
 		GL049,
 		GL050,
 		GL051,
+		GL052,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -53,6 +53,7 @@ var cweIDs = map[string]string{
 	"GL049": "CWE-362",
 	"GL050": "CWE-250",
 	"GL051": "CWE-829",
+	"GL052": "CWE-284",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl052.go
+++ b/rules/gl052.go
@@ -1,0 +1,70 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl052 struct{}
+
+var GL052 = &gl052{}
+
+func (r *gl052) ID() string { return "GL052" }
+
+// envNameUserVars extends the GL002 set with CI_COMMIT_REF_SLUG, which is a
+// normalised form of CI_COMMIT_REF_NAME and carries the same spoofing risk.
+var envNameUserVars = append(
+	[]string{"CI_COMMIT_REF_SLUG"},
+	userControlledVars...,
+)
+
+var envNameUserVarRe = regexp.MustCompile(
+	`\$\{?(` + strings.Join(envNameUserVars, "|") + `)\b`,
+)
+
+func (r *gl052) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	parser.EachJob(doc, func(nameNode *yaml.Node, jobNode *yaml.Node) {
+		env := parser.FindKey(jobNode, "environment")
+		if env == nil {
+			return
+		}
+		var nameNode2 *yaml.Node
+		switch env.Kind {
+		case yaml.ScalarNode:
+			nameNode2 = env
+		case yaml.MappingNode:
+			nameNode2 = parser.FindKey(env, "name")
+		}
+		if nameNode2 == nil || nameNode2.Kind != yaml.ScalarNode {
+			return
+		}
+		matches := envNameUserVarRe.FindAllStringSubmatch(nameNode2.Value, -1)
+		seen := map[string]bool{}
+		for _, m := range matches {
+			varName := m[1]
+			if seen[varName] {
+				continue
+			}
+			seen[varName] = true
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL052",
+				Severity: finding.Warn,
+				Job:      nameNode.Value,
+				Message: fmt.Sprintf(
+					"user-controlled variable $%s in environment:name: — attacker can craft a branch name that resolves to a protected environment and access its secrets",
+					varName,
+				),
+				File: file,
+				Line: nameNode2.Line,
+				Col:  nameNode2.Column,
+			})
+		}
+	})
+	return findings
+}

--- a/rules/gl052_test.go
+++ b/rules/gl052_test.go
@@ -1,0 +1,164 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings052(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL052.Check(doc.Root, "test.yml")
+}
+
+func TestGL052_CommitRefNameInEnvName(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: review/$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity")
+	}
+	if f[0].Job != "deploy" {
+		t.Errorf("expected job 'deploy', got %q", f[0].Job)
+	}
+}
+
+func TestGL052_CommitRefSlugInEnvName(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_REF_SLUG, got %d", len(f))
+	}
+}
+
+func TestGL052_CommitBranchInEnvName(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: deploy-$CI_COMMIT_BRANCH
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_BRANCH, got %d", len(f))
+	}
+}
+
+func TestGL052_MRSourceBranchInEnvName(t *testing.T) {
+	f := findings052(t, `
+review:
+  script:
+    - ./deploy.sh
+  environment:
+    name: $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_MERGE_REQUEST_SOURCE_BRANCH_NAME, got %d", len(f))
+	}
+}
+
+func TestGL052_ScalarEnvironmentShorthand(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment: review/$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for scalar environment shorthand, got %d", len(f))
+	}
+}
+
+func TestGL052_StaticEnvName_NoFinding(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for static environment name, got %d", len(f))
+	}
+}
+
+func TestGL052_NoEnvironment_NoFinding(t *testing.T) {
+	f := findings052(t, `
+build:
+  script:
+    - make build
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without environment, got %d", len(f))
+	}
+}
+
+func TestGL052_BraceForm(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: review/${CI_COMMIT_REF_NAME}
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for brace form, got %d", len(f))
+	}
+}
+
+func TestGL052_DeduplicateSameVar(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: $CI_COMMIT_REF_NAME-$CI_COMMIT_REF_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (deduped), got %d", len(f))
+	}
+}
+
+func TestGL052_MultipleVars(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: $CI_COMMIT_BRANCH/$CI_MERGE_REQUEST_TITLE
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings for two user-controlled vars, got %d", len(f))
+	}
+}
+
+func TestGL052_URLInEnvName_NoFinding(t *testing.T) {
+	f := findings052(t, `
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: production
+    url: https://prod.example.com
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for static env name with url, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -54,6 +54,7 @@ var owaspCategories = map[string][]string{
 	"GL049": {"CICD-SEC-7"},
 	"GL050": {"CICD-SEC-7"},
 	"GL051": {"CICD-SEC-4"},
+	"GL052": {"CICD-SEC-6"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl052-environment-name-user-var.yml
+++ b/testdata/fixtures/gl052-environment-name-user-var.yml
@@ -1,0 +1,6 @@
+deploy:
+  script:
+    - ./deploy.sh
+  environment:
+    name: review/$CI_COMMIT_REF_NAME
+    on_stop: stop-review


### PR DESCRIPTION
## Summary

Implements issue #172.

Adds rule **GL052** to detect user-controlled predefined variables (same set as GL002, plus `CI_COMMIT_REF_SLUG`) interpolated into `environment:name:`. An attacker can craft a branch name that resolves to a protected environment's exact name and receive its secrets.

- **OWASP:** CICD-SEC-6 — Insufficient Credential Hygiene
- **CWE:** CWE-284 — Improper Access Control
- **Severity:** `warn`

Also updates README from 50 → 52 rules (includes GL051 from #226).

## What changed

- `rules/gl052.go` — rule implementation: reuses the `userControlledVars` set from GL002, adds `CI_COMMIT_REF_SLUG`, checks `environment:name:` (both scalar shorthand and mapping form) in every job
- `rules/gl052_test.go` — 11 test cases covering all flagged variables, scalar/mapping forms, brace syntax, deduplication, and safe static names
- `testdata/fixtures/gl052-environment-name-user-var.yml` — fixture triggering the rule
- `docs/rules/GL052.md` — full rule documentation including attack scenario
- `rules/all.go`, `rules/owasp.go`, `rules/cwe.go`, `docs/rules.md`, `README.md` — registration, metadata, and count update

## Test plan

- `go test ./rules/... -run GL052 -v` — all 11 unit tests pass
- `go test ./rules/... -run TestRuleConsistency/GL052` — consistency check passes
- `go test ./...` — full suite green