### PR TITLE
feat: glsec explain <RULE-ID> subcommand

### DIFF
--- a/cmd/glsec/explain.go
+++ b/cmd/glsec/explain.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	glsecdocs "github.com/glsec/glsec/docs"
+	"github.com/glsec/glsec/internal/color"
+	"github.com/glsec/glsec/rules"
+)
+
+func runExplain(ruleID string, noColor bool) {
+	id := strings.ToUpper(ruleID)
+
+	found := false
+	for _, r := range rules.All() {
+		if r.ID() == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		fmt.Fprintf(os.Stderr, "error: unknown rule %q\n", id)
+		os.Exit(2)
+	}
+
+	raw, err := glsecdocs.FS.ReadFile("rules/" + id + ".md")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: no documentation found for %s\n", id)
+		os.Exit(2)
+	}
+
+	doc := parseExplainDoc(raw)
+	colorEnabled := color.IsEnabled(noColor, os.Stdout)
+	renderExplainDoc(id, doc, colorEnabled)
+}
+
+var (
+	reExplainTitle    = regexp.MustCompile(`^#\s+\S+\s+[—–-]+\s+(.+)$`)
+	reExplainSeverity = regexp.MustCompile(`^\*\*Severity:\*\*\s+(.+)$`)
+	reExplainOWASP    = regexp.MustCompile(`^\*\*OWASP:\*\*\s+\[([^\]]+)\]`)
+)
+
+type explainDoc struct {
+	title    string
+	severity string
+	owasp    string
+	risk     string
+	safeAlt  string
+}
+
+func parseExplainDoc(content []byte) explainDoc {
+	lines := strings.Split(string(content), "\n")
+	var doc explainDoc
+	var section string
+	var inCode bool
+	var riskDone, safeAltDone bool
+	var riskParts []string
+
+	for _, line := range lines {
+		if doc.title == "" {
+			if m := reExplainTitle.FindStringSubmatch(line); m != nil {
+				doc.title = strings.TrimSpace(m[1])
+				continue
+			}
+		}
+		if doc.severity == "" {
+			if m := reExplainSeverity.FindStringSubmatch(line); m != nil {
+				sev := strings.ReplaceAll(m[1], "`", "")
+				doc.severity = strings.TrimSpace(sev)
+				continue
+			}
+		}
+		if doc.owasp == "" {
+			if m := reExplainOWASP.FindStringSubmatch(line); m != nil {
+				doc.owasp = m[1]
+				continue
+			}
+		}
+
+		if strings.HasPrefix(line, "## ") {
+			if section == "Risk" || section == "What glsec checks" {
+				riskDone = true
+			}
+			section = strings.TrimPrefix(line, "## ")
+			inCode = false
+			continue
+		}
+
+		switch section {
+		case "Risk", "What glsec checks":
+			if riskDone {
+				continue
+			}
+			if line == "" && len(riskParts) > 0 {
+				riskDone = true
+			} else if line != "" {
+				riskParts = append(riskParts, strings.ReplaceAll(line, "`", ""))
+			}
+		case "Safe alternative", "Safe alternatives":
+			if safeAltDone {
+				continue
+			}
+			if strings.HasPrefix(line, "```") {
+				if !inCode {
+					inCode = true
+				} else {
+					inCode = false
+					safeAltDone = true
+				}
+				continue
+			}
+			if inCode {
+				if doc.safeAlt != "" {
+					doc.safeAlt += "\n" + line
+				} else {
+					doc.safeAlt = line
+				}
+			}
+		}
+	}
+
+	doc.risk = strings.Join(riskParts, " ")
+	return doc
+}
+
+func renderExplainDoc(id string, doc explainDoc, colorEnabled bool) {
+	fmt.Printf("%s\n", color.Bold(id+" — "+doc.title, colorEnabled))
+	fmt.Printf("Severity: %s\n", doc.severity)
+	if doc.owasp != "" {
+		fmt.Printf("OWASP:    %s\n", doc.owasp)
+	}
+	if doc.risk != "" {
+		fmt.Printf("\nRisk:\n")
+		for _, line := range wrapWords(doc.risk, 70) {
+			fmt.Printf("  %s\n", line)
+		}
+	}
+	if doc.safeAlt != "" {
+		fmt.Printf("\nSafe alternative:\n")
+		for _, line := range strings.Split(strings.TrimRight(doc.safeAlt, "\n"), "\n") {
+			fmt.Printf("  %s\n", line)
+		}
+	}
+	fmt.Printf("\nDocs: https://glsec.dev/rules/%s\n", id)
+}
+
+func wrapWords(text string, width int) []string {
+	words := strings.Fields(text)
+	var lines []string
+	var cur strings.Builder
+	for _, w := range words {
+		if cur.Len() > 0 && cur.Len()+1+len(w) > width {
+			lines = append(lines, cur.String())
+			cur.Reset()
+		}
+		if cur.Len() > 0 {
+			cur.WriteByte(' ')
+		}
+		cur.WriteString(w)
+	}
+	if cur.Len() > 0 {
+		lines = append(lines, cur.String())
+	}
+	return lines
+}

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -28,6 +28,31 @@ var (
 )
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "explain" {
+		if len(os.Args) < 3 {
+			fmt.Fprintln(os.Stderr, "usage: glsec explain <RULE-ID>")
+			os.Exit(2)
+		}
+		noColor := false
+		ruleID := ""
+		for _, arg := range os.Args[2:] {
+			switch arg {
+			case "--no-color", "-no-color":
+				noColor = true
+			default:
+				if !strings.HasPrefix(arg, "-") && ruleID == "" {
+					ruleID = arg
+				}
+			}
+		}
+		if ruleID == "" {
+			fmt.Fprintln(os.Stderr, "usage: glsec explain <RULE-ID>")
+			os.Exit(2)
+		}
+		runExplain(ruleID, noColor)
+		return
+	}
+
 	formatFlag := flag.String("format", "text", "output format: text, json, sarif")
 	configFlag := flag.String("config", config.DefaultFile, "path to .glsec.yml config file")
 	versionFlag := flag.Bool("version", false, "print version and exit")
@@ -45,6 +70,7 @@ func main() {
 	})
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: glsec [flags] [file]")
+		fmt.Fprintln(os.Stderr, "       glsec explain <RULE-ID>")
 		fmt.Fprintln(os.Stderr, "       If no file is given, glsec looks for .gitlab-ci.yml in the current directory.")
 		flag.PrintDefaults()
 	}

--- a/docs/doc.go
+++ b/docs/doc.go
@@ -1,0 +1,6 @@
+package docs
+
+import "embed"
+
+//go:embed rules
+var FS embed.FS


### PR DESCRIPTION
## What changed

Implements the `glsec explain <RULE-ID>` subcommand from #202.

- `docs/doc.go` — embeds `docs/rules/` into the binary via `embed.FS` so the docs are available without the source tree
- `cmd/glsec/explain.go` — markdown parser and terminal renderer: extracts title, severity, OWASP category, first risk paragraph, and safe-alternative code block from the rule docs
- `cmd/glsec/main.go` — subcommand detection before `flag.Parse()`, updated usage string

## Behaviour

```
$ glsec explain GL001

GL001 — Mutable image tag
Severity: error
OWASP:    CICD-SEC-3 – Dependency Chain Abuse

Risk:
  Using latest, a branch name, or no tag at all means the image pulled
  by the runner can change between pipeline runs without any code
  change. A compromised or hijacked registry tag silently introduces
  malicious code into your build environment.

Safe alternative:
  build:
    image: node:20.11.0       # pinned version

  test:
    image: alpine@sha256:c5b1261d...

Docs: https://glsec.dev/rules/GL001
```

- Rule IDs are case-insensitive (`gl001` works)
- Falls back to `## What glsec checks` when no `## Risk` section exists (e.g. GL010)
- Respects `--no-color` and `NO_COLOR`
- Exits 2 with a clear error for unknown rule IDs or missing argument

## How to test

```sh
go build -o glsec ./cmd/glsec

./glsec explain GL001      # error rule with Safe alternative
./glsec explain GL010      # warn rule using "What glsec checks" section
./glsec explain GL005      # rule with multi-part severity string
./glsec explain gl001      # lowercase — should work
./glsec explain GL999      # unknown rule — should exit 2 with error
./glsec explain            # missing arg — should print usage and exit 2
./glsec explain GL001 --no-color
```

Closes #202