### PR TITLE
feat: ShellCheck integration for script blocks

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/output"
 	"github.com/glsec/glsec/internal/parser"
+	"github.com/glsec/glsec/internal/shellcheck"
 	"github.com/glsec/glsec/internal/suppress"
 	"github.com/glsec/glsec/internal/validate"
 	gitlabver "github.com/glsec/glsec/internal/version"
@@ -328,6 +329,23 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 			findings = append(findings, f)
 		}
 	}
+
+	if cfg.ShellCheck.Enabled {
+		for _, f := range shellcheck.Run(doc.Root, path, cfg.ShellCheck.Path) {
+			if !cfg.RuleEnabled(f.RuleID) {
+				continue
+			}
+			f = cfg.ApplySeverity(f)
+			if !cfg.AboveMinSeverity(f) {
+				continue
+			}
+			if !generateIgnore && sm.IsSuppressed(f.Line, f.RuleID) {
+				continue
+			}
+			findings = append(findings, f)
+		}
+	}
+
 	return findings
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,12 @@ func (r *RuleConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 }
 
+// ShellCheckConfig holds the optional ShellCheck integration settings.
+type ShellCheckConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Path    string `yaml:"path"`
+}
+
 // Config holds the parsed contents of a .glsec.yml file.
 type Config struct {
 	// Rules maps rule ID to a per-rule override.
@@ -58,6 +64,8 @@ type Config struct {
 	GitLabVersion string `yaml:"gitlab-version"`
 	// TrustedHosts is a list of hostnames or CIDRs whose HTTP URLs are never flagged.
 	TrustedHosts []string `yaml:"trusted-hosts"`
+	// ShellCheck holds optional ShellCheck integration settings.
+	ShellCheck ShellCheckConfig `yaml:"shellcheck"`
 	// Strict makes warn findings count as errors for exit-code purposes.
 	Strict bool `yaml:"strict"`
 	// NoExitCodes makes glsec always exit 0 on successful execution,
@@ -141,6 +149,7 @@ var allowedTopLevelKeys = map[string]bool{
 	"exclude_paths":  true,
 	"owasp":          true,
 	"owasp_exclude":  true,
+	"shellcheck":     true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {
@@ -162,8 +171,8 @@ var validSeverities = map[string]bool{
 
 func (c *Config) validate(path string) error {
 	for id, rc := range c.Rules {
-		if !strings.HasPrefix(id, "GL") {
-			return fmt.Errorf("%s: rules: invalid rule ID %q (must start with GL)", path, id)
+		if !strings.HasPrefix(id, "GL") && !strings.HasPrefix(id, "SC") {
+			return fmt.Errorf("%s: rules: invalid rule ID %q (must start with GL or SC)", path, id)
 		}
 		if !validSeverities[rc.Severity] {
 			return fmt.Errorf("%s: rules.%s: invalid severity %q (use error, warn, info, or off)", path, id, rc.Severity)

--- a/internal/shellcheck/shellcheck.go
+++ b/internal/shellcheck/shellcheck.go
@@ -1,0 +1,193 @@
+package shellcheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type scComment struct {
+	Line    int    `json:"line"`
+	Column  int    `json:"column"`
+	Level   string `json:"level"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type scOutput struct {
+	Comments []scComment `json:"comments"`
+}
+
+type scriptLine struct {
+	content  string
+	yamlLine int
+}
+
+type scriptBlock struct {
+	jobName string
+	lines   []scriptLine
+}
+
+// Run extracts all script blocks from doc and passes them to shellcheck.
+// binPath is the path to the shellcheck binary; if empty, PATH is searched.
+// Returns an empty slice and logs a warning to stderr if the binary is not found.
+func Run(doc *yaml.Node, file string, binPath string) []finding.Finding {
+	bin, err := resolveBinary(binPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: shellcheck: %v — skipping\n", err)
+		return nil
+	}
+
+	mapping := parser.Unwrap(doc)
+	var blocks []scriptBlock
+
+	for _, key := range []string{"before_script", "after_script"} {
+		if node := parser.FindKey(mapping, key); node != nil {
+			if lines := extractLines(node); len(lines) > 0 {
+				blocks = append(blocks, scriptBlock{jobName: key, lines: lines})
+			}
+		}
+	}
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		for _, key := range []string{"before_script", "after_script"} {
+			if node := parser.FindKey(def, key); node != nil {
+				if lines := extractLines(node); len(lines) > 0 {
+					blocks = append(blocks, scriptBlock{jobName: "default." + key, lines: lines})
+				}
+			}
+		}
+	}
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, key := range []string{"script", "before_script", "after_script"} {
+			if node := parser.FindKey(job, key); node != nil {
+				if lines := extractLines(node); len(lines) > 0 {
+					blocks = append(blocks, scriptBlock{jobName: name.Value, lines: lines})
+				}
+			}
+		}
+	})
+
+	var findings []finding.Finding
+	for _, block := range blocks {
+		comments, err := invoke(bin, block.lines)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: shellcheck: job %q: %v\n", block.jobName, err)
+			continue
+		}
+		for _, c := range comments {
+			idx := c.Line - 1
+			if idx < 0 || idx >= len(block.lines) {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   fmt.Sprintf("SC%d", c.Code),
+				Severity: mapSeverity(c.Level),
+				Job:      block.jobName,
+				Message:  c.Message,
+				File:     file,
+				Line:     block.lines[idx].yamlLine,
+				Col:      c.Column,
+			})
+		}
+	}
+	return findings
+}
+
+func invoke(bin string, lines []scriptLine) ([]scComment, error) {
+	tmp, err := os.CreateTemp("", "glsec-sc-*.sh")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	var sb strings.Builder
+	for _, l := range lines {
+		sb.WriteString(l.content)
+		sb.WriteByte('\n')
+	}
+	if _, err := tmp.WriteString(sb.String()); err != nil {
+		_ = tmp.Close()
+		return nil, err
+	}
+	_ = tmp.Close()
+
+	out, execErr := exec.Command(bin, "--format=json1", "--shell=bash", "--norc", tmp.Name()).Output() //nolint:gosec
+	if execErr != nil {
+		exit, ok := execErr.(*exec.ExitError)
+		if !ok || exit.ExitCode() > 1 {
+			return nil, execErr
+		}
+		// exit code 1 = findings found — expected
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	var result scOutput
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("parse output: %w", err)
+	}
+	return result.Comments, nil
+}
+
+func resolveBinary(path string) (string, error) {
+	if path != "" {
+		if _, err := os.Stat(path); err != nil {
+			return "", fmt.Errorf("binary not found at %q", path)
+		}
+		return path, nil
+	}
+	bin, err := exec.LookPath("shellcheck")
+	if err != nil {
+		return "", fmt.Errorf("binary not found in PATH")
+	}
+	return bin, nil
+}
+
+func mapSeverity(level string) finding.Severity {
+	switch level {
+	case "error":
+		return finding.Error
+	case "warning":
+		return finding.Warn
+	default:
+		return finding.Info
+	}
+}
+
+// extractLines builds a flat slice of script lines with their YAML line numbers
+// from a YAML sequence node (script:/before_script:/after_script:).
+func extractLines(seqNode *yaml.Node) []scriptLine {
+	if seqNode == nil || seqNode.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var lines []scriptLine
+	for _, item := range seqNode.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		val := item.Value
+		if !strings.Contains(val, "\n") {
+			lines = append(lines, scriptLine{content: val, yamlLine: item.Line})
+			continue
+		}
+		// Multi-line scalar: block scalars (| or >) start content one line after the indicator.
+		startLine := item.Line
+		if item.Style == yaml.LiteralStyle || item.Style == yaml.FoldedStyle {
+			startLine++
+		}
+		parts := strings.Split(val, "\n")
+		for i, part := range parts {
+			if part == "" && i == len(parts)-1 {
+				continue // trailing newline from block scalar
+			}
+			lines = append(lines, scriptLine{content: part, yamlLine: startLine + i})
+		}
+	}
+	return lines
+}

--- a/internal/shellcheck/shellcheck_test.go
+++ b/internal/shellcheck/shellcheck_test.go
@@ -1,0 +1,96 @@
+package shellcheck
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func parseSeq(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &root); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// root → DocumentNode → SequenceNode
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		return root.Content[0]
+	}
+	return &root
+}
+
+func TestExtractLines_SimpleScalars(t *testing.T) {
+	seq := parseSeq(t, "- echo hello\n- echo world\n")
+	lines := extractLines(seq)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	if lines[0].content != "echo hello" {
+		t.Errorf("unexpected content: %q", lines[0].content)
+	}
+	if lines[1].content != "echo world" {
+		t.Errorf("unexpected content: %q", lines[1].content)
+	}
+}
+
+func TestExtractLines_YAMLLineNumbers(t *testing.T) {
+	src := "- echo first\n- echo second\n- echo third\n"
+	seq := parseSeq(t, src)
+	lines := extractLines(seq)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+	for i, l := range lines {
+		expected := i + 1
+		if l.yamlLine != expected {
+			t.Errorf("line %d: expected yamlLine=%d, got %d", i, expected, l.yamlLine)
+		}
+	}
+}
+
+func TestExtractLines_BlockScalar(t *testing.T) {
+	src := "- |\n  set -e\n  apt-get install -y curl\n"
+	seq := parseSeq(t, src)
+	lines := extractLines(seq)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines from block scalar, got %d", len(lines))
+	}
+	if lines[0].content != "set -e" {
+		t.Errorf("unexpected content[0]: %q", lines[0].content)
+	}
+	if lines[1].content != "apt-get install -y curl" {
+		t.Errorf("unexpected content[1]: %q", lines[1].content)
+	}
+	// block scalar: | is on line 1, content starts on line 2
+	if lines[0].yamlLine != 2 {
+		t.Errorf("expected yamlLine=2 for first block line, got %d", lines[0].yamlLine)
+	}
+	if lines[1].yamlLine != 3 {
+		t.Errorf("expected yamlLine=3 for second block line, got %d", lines[1].yamlLine)
+	}
+}
+
+func TestExtractLines_Empty(t *testing.T) {
+	lines := extractLines(nil)
+	if len(lines) != 0 {
+		t.Errorf("expected nil input to return empty slice")
+	}
+}
+
+func TestMapSeverity(t *testing.T) {
+	cases := []struct {
+		level string
+		want  string
+	}{
+		{"error", "error"},
+		{"warning", "warn"},
+		{"info", "info"},
+		{"style", "info"},
+	}
+	for _, tc := range cases {
+		got := string(mapSeverity(tc.level))
+		if got != tc.want {
+			t.Errorf("mapSeverity(%q) = %q, want %q", tc.level, got, tc.want)
+		}
+	}
+}

--- a/internal/suppress/suppress.go
+++ b/internal/suppress/suppress.go
@@ -13,7 +13,8 @@ import (
 // pattern matches:  # glsec:ignore GL001
 //
 //	# glsec:ignore GL001 -- approved, updated monthly
-var pattern = regexp.MustCompile(`glsec:ignore\s+(GL\d{3})(?:\s+--\s+(.+))?`)
+//	# glsec:ignore SC2086
+var pattern = regexp.MustCompile(`glsec:ignore\s+((?:GL|SC)\d+)(?:\s+--\s+(.+))?`)
 
 // IgnoreFile is the default name of the baseline ignore file written by
 // --generate-ignore and read automatically on each run.

--- a/internal/suppress/suppress_test.go
+++ b/internal/suppress/suppress_test.go
@@ -87,6 +87,29 @@ func TestBuild_EmptyDocument(t *testing.T) {
 	}
 }
 
+func TestFromComment_SCCode(t *testing.T) {
+	sups := fromComment("# glsec:ignore SC2086", 7)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if sups[0].RuleID != "SC2086" {
+		t.Errorf("expected SC2086, got %q", sups[0].RuleID)
+	}
+}
+
+func TestFromComment_SCCodeWithReason(t *testing.T) {
+	sups := fromComment("# glsec:ignore SC2086 -- CI variable always set by platform", 3)
+	if len(sups) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(sups))
+	}
+	if sups[0].RuleID != "SC2086" {
+		t.Errorf("expected SC2086, got %q", sups[0].RuleID)
+	}
+	if sups[0].Reason != "CI variable always set by platform" {
+		t.Errorf("unexpected reason: %q", sups[0].Reason)
+	}
+}
+
 func TestIsSuppressed_MissingLine(t *testing.T) {
 	m := Map{}
 	if m.IsSuppressed(99, "GL001") {


### PR DESCRIPTION
## What changed

Implements optional ShellCheck integration for `script:`, `before_script:`, and `after_script:` blocks from #148.

### New files
- `internal/shellcheck/shellcheck.go` — extracts script blocks from the YAML document, writes them to a temp file, invokes ShellCheck with `--format=json1 --shell=bash --norc`, maps ShellCheck line numbers back to original YAML line numbers, and returns `finding.Finding` values
- `internal/shellcheck/shellcheck_test.go` — unit tests for `extractLines` (simple scalars, block scalars `|`, YAML line number mapping) and `mapSeverity`

### Modified files
- `internal/config/config.go` — adds `ShellCheckConfig` struct and `shellcheck:` as an allowed top-level config key; also allows `SC`-prefixed rule IDs in `rules:` overrides (e.g. `SC2086: off`)
- `internal/suppress/suppress.go` — regex extended from `GL\d{3}` to `(?:GL|SC)\d+` so `# glsec:ignore SC2086` works
- `cmd/glsec/main.go` — calls `shellcheck.Run` inside `collectFindings` after the rule loop; ShellCheck findings go through the same `RuleEnabled` / `ApplySeverity` / `AboveMinSeverity` / `IsSuppressed` pipeline as GL findings

## Configuration

```yaml
shellcheck:
  enabled: true
  path: /usr/bin/shellcheck  # optional — defaults to PATH lookup
```

ShellCheck is opt-in (`enabled: false` by default). If the binary is not found, a warning is printed to stderr and scanning continues normally:

```
warning: shellcheck: binary not found in PATH — skipping
```

## Suppression

All existing suppression mechanisms work for SC findings:

```yaml
  script:
    - echo $CI_COMMIT_REF_NAME  # glsec:ignore SC2086 -- platform variable
```

Or globally in `.glsec.yml`:

```yaml
rules:
  SC2086: off
```

Or via ShellCheck's own inline directive (handled by ShellCheck itself before results reach glsec):

```bash
# shellcheck disable=SC2086
echo $CI_COMMIT_REF_NAME
```

## Line number mapping

- Single-line script items: mapped to the YAML line of the item node
- Block scalars (`|`): content lines mapped to `node.Line + 1`, `node.Line + 2`, …

## How to test

```sh
# requires shellcheck to be installed
go build -o glsec ./cmd/glsec

cat > .glsec.yml <<'YAML'
shellcheck:
  enabled: true
YAML

./glsec .gitlab-ci.yml

# Verify warning when binary missing
cat > .glsec.yml <<'YAML'
shellcheck:
  enabled: true
  path: /nonexistent/bin/shellcheck
YAML
./glsec .gitlab-ci.yml  # should warn and still run GL rules

# Verify SC2086 suppression
./glsec .gitlab-ci.yml  # with # glsec:ignore SC2086 on the offending line
```

Closes #148