### PR TITLE
docs: document ShellCheck integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ exclude_paths:
 
 **Not covered:** [CICD-SEC-2](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-02-Inadequate-Identity-And-Access-Management) (Identity & Access Management) and [CICD-SEC-10](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-10-Insufficient-Logging-And-Visibility) (Insufficient Logging & Visibility) are not detectable from static `.gitlab-ci.yml` analysis — they require platform-level context such as GitLab group/project settings, audit logs, or API access.
 
+## ShellCheck integration
+
+glsec can optionally pass `script:`, `before_script:`, and `after_script:` blocks to [ShellCheck](https://www.shellcheck.net/) for deeper shell analysis. This is **opt-in** and requires ShellCheck to be installed separately.
+
+Enable it in `.glsec.yml`:
+
+```yaml
+shellcheck:
+  enabled: true
+  path: /usr/bin/shellcheck  # optional — defaults to PATH lookup
+```
+
+ShellCheck findings are reported alongside GL findings and use `SC` rule IDs:
+
+```
+WARN   .gitlab-ci.yml:12  SC2086  [build]  Double quote to prevent globbing and word splitting.
+```
+
+If the ShellCheck binary is not found, glsec prints a warning to stderr and continues scanning normally.
+
+**Suppressing specific codes** — inline:
+
+```yaml
+  script:
+    - echo $CI_COMMIT_REF_NAME  # glsec:ignore SC2086 -- set by platform
+```
+
+Or globally in `.glsec.yml`:
+
+```yaml
+rules:
+  SC2086: off
+```
+
+ShellCheck's own inline directives (`# shellcheck disable=SC2086`) are also respected.
+
 ---
 
 ## CI integration

--- a/docs/rules/GL002.md
+++ b/docs/rules/GL002.md
@@ -45,3 +45,7 @@ deploy:
 ## Notes
 
 The rule uses shell quote-masking to detect unquoted occurrences: the contents of `"..."` and `'...'` strings and `\X` escape sequences are replaced with spaces before checking for variable references. Only variables that remain visible after masking are flagged, so `"Branch: $CI_COMMIT_REF_NAME"` and `'$CI_COMMIT_REF_NAME'` are not flagged.
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL004.md
+++ b/docs/rules/GL004.md
@@ -39,3 +39,7 @@ upload:
 - GitLab.com and `*.gitlab.com` subdomains are always considered safe
 - Self-hosted GitLab instances contacted via `$CI_SERVER_URL` or `$CI_API_V4_URL` are safe
 - This rule does not flag token usage in `variables:` blocks — only in `script:`, `before_script:`, and `after_script:`
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL011.md
+++ b/docs/rules/GL011.md
@@ -44,3 +44,7 @@ Or better: commit the script to the repository and reference it locally, removin
 ## Why this matters
 
 HTTPS provides transport-level security but no content integrity guarantee. If the script host is compromised, the pipeline will silently execute malicious code in the CI environment with access to all secrets, tokens, and build artifacts. Unlike a committed dependency, the executed code is unversioned and cannot be audited in pull request reviews or git history.
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL014.md
+++ b/docs/rules/GL014.md
@@ -49,3 +49,7 @@ GitLab's `dotenv` report artifact is designed to pass a small set of computed va
 - Cloud provider credentials, deploy keys, and any other secret injected into the job
 
 Any project member with the Reporter role or above can download pipeline artifacts through the GitLab UI or API.
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL015.md
+++ b/docs/rules/GL015.md
@@ -52,3 +52,7 @@ Unlike a SHA-based tag, a branch-name tag is mutable and can be overwritten repe
 ## Distinct from GL007
 
 GL007 checks the `image:` YAML field for variable interpolation. GL015 specifically checks Docker CLI commands in scripts — a job may use a safe `image:` but still build and push with a dangerous tag.
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL016.md
+++ b/docs/rules/GL016.md
@@ -63,3 +63,7 @@ trusted-hosts:
 ```
 
 Hosts and CIDRs on the allowlist are never flagged regardless of protocol.
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL021.md
+++ b/docs/rules/GL021.md
@@ -50,3 +50,7 @@ If a variable name matches the pattern but its value is intentionally public (e.
 script:
   - echo $ENVIRONMENT_KEY  # glsec:ignore GL021 -- not a secret, public config key name
 ```
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL029.md
+++ b/docs/rules/GL029.md
@@ -30,3 +30,7 @@ deploy:
 - [Docker docs: `docker login --password-stdin`](https://docs.docker.com/reference/cli/docker/login/#password-stdin)
 - GL006: hardcoded secret in `variables:` block
 - GL027: secret-like variable missing `masked: true`
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL030.md
+++ b/docs/rules/GL030.md
@@ -34,3 +34,7 @@ To obtain the entry: run `ssh-keyscan <host>` once from a trusted machine, verif
 
 - [GitLab docs: Using SSH keys with GitLab CI/CD](https://docs.gitlab.com/ee/ci/ssh_keys/)
 - GL032: SSH private key written to file via `echo`
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL032.md
+++ b/docs/rules/GL032.md
@@ -33,3 +33,7 @@ Alternatively, use a [GitLab file-type variable](https://docs.gitlab.com/ee/ci/v
 - GL021: secret variable printed to log via `echo`/`printf`
 - GL030: `ssh-keyscan` executed dynamically (MITM risk)
 - GL033: `CI_DEBUG_TRACE` enabled in committed pipeline YAML
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL035.md
+++ b/docs/rules/GL035.md
@@ -40,3 +40,7 @@ Or use SSH remotes with a key stored in a protected CI variable (see GL030, GL03
 - GL004: `CI_JOB_TOKEN` forwarded to a non-GitLab host
 - GL032: SSH private key written to file via `echo`
 - GL036: connection string with embedded credentials in `variables:` block
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL038.md
+++ b/docs/rules/GL038.md
@@ -44,3 +44,7 @@ Store the password as a masked, protected CI/CD variable in GitLab project or gr
 - GL006: hardcoded secret value in `variables:` block
 - GL035: git URL with embedded credentials in script
 - GL036: connection string with embedded credentials in `variables:` block
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL039.md
+++ b/docs/rules/GL039.md
@@ -39,3 +39,7 @@ security:
 
 - GL008: `allow_failure: true` on a GitLab security scan job
 - GL024: shell pipe without `set -o pipefail`
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL040.md
+++ b/docs/rules/GL040.md
@@ -42,3 +42,7 @@ deploy:
 - [RFC 4217 — Securing FTP with TLS](https://www.rfc-editor.org/rfc/rfc4217)
 - GL016: HTTP instead of HTTPS in `include:remote`, scripts, variables
 - GL038: hardcoded credential literals in script commands
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL042.md
+++ b/docs/rules/GL042.md
@@ -63,3 +63,7 @@ build:
 - The most common reason teams disable TLS verification is self-signed certificates on internal infrastructure. The correct fix is to distribute the CA certificate, not to disable verification globally.
 - Suppress intentional uses with: `# glsec:ignore GL042 -- internal CA not yet provisioned, tracked in INFRA-123`.
 - Related: GL030 (`ssh-keyscan` blindly trusts SSH host keys), GL016 (HTTP instead of HTTPS).
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL044.md
+++ b/docs/rules/GL044.md
@@ -56,3 +56,7 @@ deploy:
 
 - This rule only flags `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` — the specific commit SHA of the MR source. The branch name variable (`CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`) is not flagged as it is also commonly used for logging and artifact naming
 - The risk exists regardless of whether explicit secrets are referenced; `$CI_JOB_TOKEN` is always available and grants read access to the GitLab API on behalf of the pipeline
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL051.md
+++ b/docs/rules/GL051.md
@@ -62,3 +62,7 @@ deploy:
 - Inputs with a `default:` but without `regex:` or `options:` are still flagged — the default does not constrain what a caller can pass.
 - Inputs used only in non-sensitive positions (e.g. `variables:`, `artifacts:paths:`) are not flagged by this rule.
 - The interpolation syntax `$[[ inputs.NAME ]]` is specific to GitLab CI Catalog components; regular `$VARIABLE` references in normal pipelines are covered by GL002 and GL015.
+
+## See also
+
+Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.


### PR DESCRIPTION
Follows up on #234 (ShellCheck integration).

## What changed

- `README.md` — new **ShellCheck integration** section covering: how to enable, example output with `SC` rule IDs, behavior when binary is missing, and all suppression mechanisms (`glsec:ignore SC2086`, `rules: SC2086: off`, ShellCheck inline directives)

- `docs/rules/GL002.md` + 16 other rule docs that scan `script:`/`before_script:`/`after_script:` blocks — added a short `## See also` note at the end of each, pointing to the ShellCheck integration for additional shell analysis

The 17 rules that received the note are the ones whose implementations actually inspect script block content: GL002, GL004, GL011, GL014, GL015, GL016, GL021, GL029, GL030, GL032, GL035, GL038, GL039, GL040, GL042, GL044, GL051.