### PR TITLE
feat: codeclimate output format for GitLab Code Quality (#236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ glsec --format json .gitlab-ci.yml
 # SARIF output for GitHub Code Scanning / GitLab SAST
 glsec --format sarif .gitlab-ci.yml > gl.sarif
 
+# Code Climate output for GitLab Code Quality (inline MR findings, works on all tiers)
+glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json
+
 # treat warn findings as hard failures (exit 1)
 glsec --strict .gitlab-ci.yml
 
@@ -200,6 +203,23 @@ glsec:
 ```
 
 Findings appear in the pipeline Security tab and the project Security Dashboard. Use `|| true` to prevent the glsec job itself from blocking the pipeline — the SAST report is uploaded regardless.
+
+### GitLab Code Quality integration
+
+Show findings **inline on merge request diffs** using GitLab's Code Quality widget — works on all GitLab tiers (no Ultimate required, unlike SAST):
+
+```yaml
+glsec:
+  stage: test
+  image: ghcr.io/glsec/glsec:latest
+  script:
+    - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true
+  artifacts:
+    reports:
+      codequality: gl-code-quality.json
+```
+
+Severity mapping (glsec → Code Climate): `error` → `critical`, `warn` → `major`, `info` → `info`.
 
 ### GitHub Actions
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -54,7 +54,7 @@ func main() {
 		return
 	}
 
-	formatFlag := flag.String("format", "text", "output format: text, json, sarif")
+	formatFlag := flag.String("format", "text", "output format: text, json, sarif, codeclimate")
 	configFlag := flag.String("config", config.DefaultFile, "path to .glsec.yml config file")
 	versionFlag := flag.Bool("version", false, "print version and exit")
 	gitlabVersionFlag := flag.String("gitlab-version", "", "target GitLab version, e.g. 16.0 (skips rules not available in that version)")
@@ -98,7 +98,7 @@ func main() {
 
 	format, ok := output.ParseFormat(*formatFlag)
 	if !ok {
-		fmt.Fprintf(os.Stderr, "unknown format %q — use text, json, or sarif\n", *formatFlag)
+		fmt.Fprintf(os.Stderr, "unknown format %q — use text, json, sarif, or codeclimate\n", *formatFlag)
 		os.Exit(2)
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,14 +15,15 @@ import (
 type Format string
 
 const (
-	FormatText Format = "text"
-	FormatJSON Format = "json"
-	FormatSARIF Format = "sarif"
+	FormatText        Format = "text"
+	FormatJSON        Format = "json"
+	FormatSARIF       Format = "sarif"
+	FormatCodeClimate Format = "codeclimate"
 )
 
 func ParseFormat(s string) (Format, bool) {
 	switch Format(s) {
-	case FormatText, FormatJSON, FormatSARIF:
+	case FormatText, FormatJSON, FormatSARIF, FormatCodeClimate:
 		return Format(s), true
 	default:
 		return "", false
@@ -33,6 +36,8 @@ func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int,
 		return writeJSON(w, findings, nil)
 	case FormatSARIF:
 		return writeSARIF(w, findings, nil, nil, nil, nil)
+	case FormatCodeClimate:
+		return writeCodeClimate(w, findings)
 	default:
 		return writeText(w, findings, jobCount, colorEnabled)
 	}
@@ -312,4 +317,69 @@ func writeSARIF(w io.Writer, findings []finding.Finding,
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(log)
+}
+
+// Code Climate JSON — consumed natively by GitLab's Code Quality widget
+// (artifacts:reports:codequality). Spec:
+// https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md
+type codeClimateIssue struct {
+	Type        string               `json:"type"`
+	CheckName   string               `json:"check_name"`
+	Description string               `json:"description"`
+	Categories  []string             `json:"categories"`
+	Severity    string               `json:"severity"`
+	Fingerprint string               `json:"fingerprint"`
+	Location    codeClimateLocation  `json:"location"`
+}
+
+type codeClimateLocation struct {
+	Path  string           `json:"path"`
+	Lines codeClimateLines `json:"lines"`
+}
+
+type codeClimateLines struct {
+	Begin int `json:"begin"`
+}
+
+func severityToCodeClimate(s finding.Severity) string {
+	switch s {
+	case finding.Error:
+		return "critical"
+	case finding.Warn:
+		return "major"
+	default:
+		return "info"
+	}
+}
+
+func codeClimateFingerprint(f finding.Finding) string {
+	h := sha256.Sum256([]byte(f.RuleID + "|" + f.File + "|" + f.Job + "|" + f.Message + "|" + fmt.Sprintf("%d", f.Line)))
+	return hex.EncodeToString(h[:])
+}
+
+// WriteCodeClimate writes findings in the Code Climate JSON format
+// consumed by GitLab's Code Quality (artifacts:reports:codequality).
+func WriteCodeClimate(w io.Writer, findings []finding.Finding) error {
+	return writeCodeClimate(w, findings)
+}
+
+func writeCodeClimate(w io.Writer, findings []finding.Finding) error {
+	out := make([]codeClimateIssue, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, codeClimateIssue{
+			Type:        "issue",
+			CheckName:   f.RuleID,
+			Description: f.Message,
+			Categories:  []string{"Security"},
+			Severity:    severityToCodeClimate(f.Severity),
+			Fingerprint: codeClimateFingerprint(f),
+			Location: codeClimateLocation{
+				Path:  f.File,
+				Lines: codeClimateLines{Begin: f.Line},
+			},
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -160,6 +160,7 @@ func TestParseFormat(t *testing.T) {
 		{"text", FormatText, true},
 		{"json", FormatJSON, true},
 		{"sarif", FormatSARIF, true},
+		{"codeclimate", FormatCodeClimate, true},
 		{"xml", "", false},
 		{"", "", false},
 	} {
@@ -251,6 +252,110 @@ func TestWriteJSON_WithOWASP(t *testing.T) {
 	}
 	if len(out.Findings[1].OWASP) != 1 || out.Findings[1].OWASP[0] != "CICD-SEC-6" {
 		t.Errorf("unexpected OWASP for GL002: %v", out.Findings[1].OWASP)
+	}
+}
+
+func TestWriteCodeClimate(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatCodeClimate, testFindings, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	var issues []codeClimateIssue
+	if err := json.Unmarshal(buf.Bytes(), &issues); err != nil {
+		t.Fatalf("invalid Code Climate JSON: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+
+	got := issues[0]
+	if got.Type != "issue" {
+		t.Errorf("expected type=issue, got %q", got.Type)
+	}
+	if got.CheckName != "GL001" {
+		t.Errorf("expected check_name=GL001, got %q", got.CheckName)
+	}
+	if got.Description != testFindings[0].Message {
+		t.Errorf("description mismatch: %q", got.Description)
+	}
+	if got.Severity != "critical" {
+		t.Errorf("expected severity=critical for Error finding, got %q", got.Severity)
+	}
+	if len(got.Categories) != 1 || got.Categories[0] != "Security" {
+		t.Errorf("expected categories=[Security], got %v", got.Categories)
+	}
+	if got.Location.Path != "ci.yml" || got.Location.Lines.Begin != 4 {
+		t.Errorf("unexpected location: %+v", got.Location)
+	}
+	if len(got.Fingerprint) != 64 {
+		t.Errorf("expected 64-char sha256 fingerprint, got %d chars", len(got.Fingerprint))
+	}
+
+	if issues[1].Severity != "major" {
+		t.Errorf("expected severity=major for Warn finding, got %q", issues[1].Severity)
+	}
+}
+
+func TestWriteCodeClimate_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatCodeClimate, nil, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	var issues []codeClimateIssue
+	if err := json.Unmarshal(buf.Bytes(), &issues); err != nil {
+		t.Fatalf("invalid Code Climate JSON: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected empty array, got %d", len(issues))
+	}
+	if !strings.HasPrefix(strings.TrimSpace(buf.String()), "[") {
+		t.Errorf("expected JSON array, got %q", buf.String())
+	}
+}
+
+func TestWriteCodeClimate_FingerprintStable(t *testing.T) {
+	var buf1, buf2 bytes.Buffer
+	if err := WriteCodeClimate(&buf1, testFindings); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCodeClimate(&buf2, testFindings); err != nil {
+		t.Fatal(err)
+	}
+	if buf1.String() != buf2.String() {
+		t.Error("two runs over identical findings produced different output (fingerprints not deterministic)")
+	}
+}
+
+func TestWriteCodeClimate_FingerprintUnique(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteCodeClimate(&buf, testFindingsWithJob); err != nil {
+		t.Fatal(err)
+	}
+	var issues []codeClimateIssue
+	if err := json.Unmarshal(buf.Bytes(), &issues); err != nil {
+		t.Fatalf("invalid Code Climate JSON: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, issue := range issues {
+		if seen[issue.Fingerprint] {
+			t.Errorf("duplicate fingerprint %s — distinct findings collided", issue.Fingerprint)
+		}
+		seen[issue.Fingerprint] = true
+	}
+}
+
+func TestSeverityToCodeClimate(t *testing.T) {
+	for _, tc := range []struct {
+		in   finding.Severity
+		want string
+	}{
+		{finding.Error, "critical"},
+		{finding.Warn, "major"},
+		{finding.Info, "info"},
+	} {
+		if got := severityToCodeClimate(tc.in); got != tc.want {
+			t.Errorf("severityToCodeClimate(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a new `--format codeclimate` output that emits findings in the [Code Climate JSON format](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md). GitLab consumes this natively via `artifacts:reports:codequality` and renders findings **inline on MR diffs** — available on **all GitLab tiers**, unlike SARIF/SAST which requires Ultimate.

Closes #236.

## What changed

- `internal/output/output.go`: new `FormatCodeClimate` constant, `WriteCodeClimate` exported writer, Code Climate types, severity mapping, deterministic fingerprint helper.
- `cmd/glsec/main.go`: `--format` flag help and error message now list `codeclimate`. New format flows through the existing default routing in `writeAndExit` → `output.Write`.
- `internal/output/output_test.go`: tests for `ParseFormat`, basic write, severity mapping, fingerprint stability across runs, fingerprint uniqueness across distinct findings, empty output.
- `README.md`: added a usage example in the *Usage* block and a dedicated *GitLab Code Quality integration* section under *CI integration*.

## Severity mapping

| glsec | Code Climate |
|---|---|
| `error` | `critical` |
| `warn` | `major` |
| `info` | `info` |

Matches the convention used by GitLab's own SAST analyzers (High→critical, Medium→major, Low→minor, Unknown→info), treating glsec warn findings as `major` since they are still security issues, not stylistic notes.

## Fingerprint

`sha256(rule_id | file | job | message | line)` — deterministic across runs (verified by `TestWriteCodeClimate_FingerprintStable`) and unique across distinct findings (verified by `TestWriteCodeClimate_FingerprintUnique`). The issue spec mentioned `line_content` but glsec's `Finding` struct doesn't carry the source line; using the rule + location + message gives the same stability properties without an extra parse step.

## How to test

```bash
go test ./internal/output/...

# end-to-end smoke test
go build -o /tmp/glsec ./cmd/glsec
/tmp/glsec --format codeclimate --no-exit-codes testdata/fixtures/gl025-uservar-curl.yml
```

Expect a JSON array, each object containing `type`, `check_name` (`GL…`), `description`, `categories: ["Security"]`, `severity`, `fingerprint` (64-char hex), and `location.path` / `location.lines.begin`.

## GitLab pipeline usage (added to README)

```yaml
glsec:
  stage: test
  image: ghcr.io/glsec/glsec:latest
  script:
    - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true
  artifacts:
    reports:
      codequality: gl-code-quality.json
```

## Follow-up

Unblocks #150 — the GitLab CI Catalog component template can now offer `codeclimate` as a `format` input from v1.0, so users get inline MR findings out of the box.