### PR TITLE
docs: add GitLab CI Catalog component to README (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,31 @@ ShellCheck's own inline directives (`# shellcheck disable=SC2086`) are also resp
 
 ## CI integration
 
-### GitLab CI — Docker image (recommended)
+### GitLab CI Catalog component (recommended)
+
+Use the official component from the [GitLab CI Catalog](https://gitlab.com/explore/catalog/glsec-io/glsec) — no need to manage image pins or script wiring yourself:
+
+```yaml
+include:
+  - component: gitlab.com/glsec-io/glsec/glsec@~latest
+
+stages:
+  - test
+```
+
+For inline findings on merge request diffs, add the `glsec-code-quality` template — works on **all GitLab tiers**, no Ultimate required:
+
+```yaml
+include:
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@~latest
+
+stages:
+  - test
+```
+
+**Component repo and full input reference:** https://gitlab.com/glsec-io/glsec
+
+### GitLab CI — Docker image
 
 The fastest way: use the pre-built image from GHCR. No Go toolchain needed.
 


### PR DESCRIPTION
## Summary

Promotes the new GitLab CI Catalog component to first-class citizen in the CI integration docs. Closes #150.

## Context

The component is now published at https://gitlab.com/glsec-io/glsec and listed in the public Catalog. v1.0.1 defaults to glsec image `1.2.0`, which includes the `codeclimate` output format (#236 / #237). Catalog versions:

- `v1.0.0` — initial release
- `v1.0.1` — bumped default to glsec 1.2.0

## What changed

- New section **"GitLab CI Catalog component (recommended)"** at the top of *CI integration*, showing both:
  - `glsec` template — standard scan
  - `glsec-code-quality` template — inline MR findings via Code Quality (no Ultimate required)
- Demoted the existing Docker-image section from `(recommended)` to plain — Catalog is the preferred path now, Docker image stays as an option for users who can't use the catalog.

## Why Catalog as the primary recommendation

- Single-line `include:` is the GitLab-idiomatic install — easier than copy-pasting an image + script + artifacts block
- Component pins the image internally, so users get reproducible pipelines without thinking about image tags
- `glsec-code-quality` template gives **inline MR diff findings** on all GitLab tiers — much better UX than reading the job log
- Component bumps decouple from glsec releases: a new glsec image doesn't force a Catalog release unless we want to bump the default

## How to test

Render the README on GitHub and check both code blocks are valid and link to the Catalog correctly:

- https://gitlab.com/explore/catalog/glsec-io/glsec
- https://gitlab.com/glsec-io/glsec

Closes #150.