### PR TITLE
fix: correct CI integration snippets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ ShellCheck's own inline directives (`# shellcheck disable=SC2086`) are also resp
 
 ## CI integration
 
+> **Runnable examples for every pattern below:** [gitlab.com/glsec-io/examples](https://gitlab.com/glsec-io/examples) — [Catalog component](https://gitlab.com/glsec-io/examples/component) · [Catalog + Code Quality](https://gitlab.com/glsec-io/examples/component-code-quality) · [Docker image](https://gitlab.com/glsec-io/examples/docker) · [Binary download](https://gitlab.com/glsec-io/examples/binary)
+
 ### GitLab CI Catalog component (recommended)
 
 Use the official component from the [GitLab CI Catalog](https://gitlab.com/explore/catalog/glsec-io/glsec) — no need to manage image pins or script wiring yourself:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@~latest
+  - component: gitlab.com/glsec-io/glsec/glsec@1.0.2
 
 stages:
   - test
@@ -165,49 +165,51 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@~latest
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@1.0.2
 
 stages:
   - test
 ```
 
+Pin to an explicit component tag (not `@~latest`) — glsec's own GL003 / GL041 rules flag floating refs.
+
 **Component repo and full input reference:** https://gitlab.com/glsec-io/glsec
+
+**Runnable example projects:** https://gitlab.com/glsec-io/examples
 
 ### GitLab CI — Docker image
 
-The fastest way: use the pre-built image from GHCR. No Go toolchain needed.
+If you need more control than the Catalog component offers, use the pre-built image from GHCR directly:
 
 ```yaml
 glsec:
   stage: test
-  image: ghcr.io/glsec/glsec:latest
+  image:
+    name: ghcr.io/glsec/glsec:1.2.0
+    entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-Pin to a specific release for reproducible pipelines:
-
-```yaml
-glsec:
-  stage: test
-  image: ghcr.io/glsec/glsec:0.1.0
-  script:
-    - glsec .gitlab-ci.yml
-```
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.2.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
 For pipelines that cannot pull from GHCR:
 
 ```yaml
+variables:
+  GLSEC_VERSION: "1.2.0"
+
 glsec:
   stage: test
-  image: alpine:3.19
+  image: alpine:3.20
+  before_script:
+    - apk add --no-cache curl tar
+    - curl -sSLO "https://github.com/glsec/glsec/releases/download/v${GLSEC_VERSION}/glsec_${GLSEC_VERSION}_linux_amd64.tar.gz"
+    - curl -sSL "https://github.com/glsec/glsec/releases/download/v${GLSEC_VERSION}/checksums.txt" | grep "glsec_${GLSEC_VERSION}_linux_amd64.tar.gz" | sha256sum -c
+    - tar xzf "glsec_${GLSEC_VERSION}_linux_amd64.tar.gz"
   script:
-    - |
-      curl -sSLO https://github.com/glsec/glsec/releases/latest/download/glsec_linux_amd64.tar.gz
-      echo "$(curl -sSL https://github.com/glsec/glsec/releases/latest/download/checksums.txt | grep glsec_linux_amd64.tar.gz)" | sha256sum -c
-      tar xzf glsec_linux_amd64.tar.gz
     - ./glsec .gitlab-ci.yml
 ```
 
@@ -218,7 +220,9 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 ```yaml
 glsec:
   stage: test
-  image: ghcr.io/glsec/glsec:latest
+  image:
+    name: ghcr.io/glsec/glsec:1.2.0
+    entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
   artifacts:
@@ -230,12 +234,14 @@ Findings appear in the pipeline Security tab and the project Security Dashboard.
 
 ### GitLab Code Quality integration
 
-Show findings **inline on merge request diffs** using GitLab's Code Quality widget — works on all GitLab tiers (no Ultimate required, unlike SAST):
+Show findings **inline on merge request diffs** using GitLab's Code Quality widget — works on all GitLab tiers (no Ultimate required, unlike SAST). The easiest path is the `glsec-code-quality` template from the [Catalog component](#gitlab-ci-catalog-component-recommended) above. The equivalent manual setup:
 
 ```yaml
 glsec:
   stage: test
-  image: ghcr.io/glsec/glsec:latest
+  image:
+    name: ghcr.io/glsec/glsec:1.2.0
+    entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true
   artifacts:


### PR DESCRIPTION
## Summary

Three real bugs in the *CI integration* section of the README — the copy-paste snippets there did not actually work when tried against gitlab.com. Verified by setting up working example pipelines at https://gitlab.com/glsec-io/examples.

## Bugs fixed

### 1. Docker image ENTRYPOINT collision with GitLab Runner

The image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience. GitLab Runner generates a shell wrapper around `script:` blocks and passes it as args to the image entrypoint — so the wrapper script becomes glsec's arguments, and glsec prints its usage error and exits 2.

**Fix:** every Docker-based snippet (plain Docker, SAST, Code Quality) now uses the `entrypoint: [""]` override form:

```yaml
image:
  name: ghcr.io/glsec/glsec:1.2.0
  entrypoint: [""]
```

### 2. Catalog component included with `@~latest`

glsec's own GL003 (mutable include ref) and GL041 (tilde semver range) rules flag `@~latest`. The Catalog snippets in the README were dogfooding-incompatible. Now pinned to `@1.0.2`.

### 3. Binary download URL wrong

The snippet downloaded `glsec_linux_amd64.tar.gz`, but GoReleaser archives include the version in the filename (e.g. `glsec_1.2.0_linux_amd64.tar.gz`). The GitHub `releases/latest/download/` short-link returned an HTML 404, which tar then failed to extract (`gzip: invalid magic`).

**Fix:** introduced `GLSEC_VERSION` variable, downloads from the explicit versioned URL, and adjusts the checksum verification to use the same versioned path. Also bumped the Alpine version from `3.19` to `3.20` for current support.

## How to test

```sh
# Render the README and check each YAML block is internally consistent
# Then verify each pattern by checking the example projects:

#  Catalog component
git clone https://gitlab.com/glsec-io/examples/component && cat component/.gitlab-ci.yml

#  Catalog code-quality variant
git clone https://gitlab.com/glsec-io/examples/component-code-quality

#  Docker
git clone https://gitlab.com/glsec-io/examples/docker

#  Binary
git clone https://gitlab.com/glsec-io/examples/binary
```

All four example repos have green pipelines on gitlab.com today.

## Related

- Catalog component repo: https://gitlab.com/glsec-io/glsec
- Example repos: https://gitlab.com/glsec-io/examples
- Component v1.0.2 release added the `entrypoint: [""]` override inside both templates — manual Docker users still need to add it themselves.