### PR TITLE
fix: catalog component include must use @v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@1.0.2
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.2
 
 stages:
   - test
@@ -167,7 +167,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@1.0.2
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.2
 
 stages:
   - test


### PR DESCRIPTION
## Summary

Follow-up to #239. The Catalog snippets in the README use `@1.0.2`, but GitLab's catalog resolver expects the include version to match the git tag *exactly*. Our component tags are `v1.0.0`, `v1.0.1`, `v1.0.2` (with leading `v`), so `@1.0.2` resolves to *"content not found"*.

Confirmed via the GitLab CI Lint API:

| Include | Result |
|---|---|
| `@1.0.2` | ❌ `content not found` |
| `@v1.0.2` | ✅ valid |
| `@~latest` | ✅ valid (but flagged by GL003/GL041) |

## Fix

Change the two Catalog snippets from `@1.0.2` to `@v1.0.2`.

## Test

Reproduced via:

```sh
curl -s -H "Content-Type: application/json" \
  -d '{"content":"include:\n  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.2\nstages:\n  - test\n"}' \
  "https://gitlab.com/api/v4/projects/<any-project-id>/ci/lint"
# → valid: true
```

Also verified end-to-end: pushed `@v1.0.2` to https://gitlab.com/glsec-io/examples/component and https://gitlab.com/glsec-io/examples/component-code-quality — both pipelines green.

## Related

Same fix also applied to:
- Component repo README (gitlab.com/glsec-io/glsec)
- Both example repos (gitlab.com/glsec-io/examples/{component,component-code-quality})