### PR TITLE
feat: honor FORCE_COLOR and CLICOLOR_FORCE env vars (#241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ stages:
 
 Pin to an explicit component tag (not `@~latest`) — glsec's own GL003 / GL041 rules flag floating refs.
 
+**Coloured output in CI logs:** glsec auto-disables ANSI colors when stdout is not a terminal (the standard convention). Force colors back on by setting `FORCE_COLOR=1` (or `CLICOLOR_FORCE=1`) in your pipeline variables:
+
+```yaml
+variables:
+  FORCE_COLOR: "1"
+```
+
 **Component repo and full input reference:** https://gitlab.com/glsec-io/glsec
 
 **Runnable example projects:** https://gitlab.com/glsec-io/examples

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -13,13 +13,17 @@ const (
 )
 
 // IsEnabled returns true if color output should be used.
-// Color is disabled when:
-//   - noColor is true (--no-color flag)
-//   - NO_COLOR env var is set (https://no-color.org)
-//   - w is not a terminal
+//
+// Precedence (highest first):
+//  1. noColor (--no-color flag) or NO_COLOR env → disabled
+//  2. FORCE_COLOR or CLICOLOR_FORCE env set to a non-empty, non-"0" value → enabled
+//  3. Auto-detect: w must be a terminal
 func IsEnabled(noColor bool, w io.Writer) bool {
 	if noColor || os.Getenv("NO_COLOR") != "" {
 		return false
+	}
+	if forceColor("FORCE_COLOR") || forceColor("CLICOLOR_FORCE") {
+		return true
 	}
 	f, ok := w.(*os.File)
 	if !ok {
@@ -30,6 +34,11 @@ func IsEnabled(noColor bool, w io.Writer) bool {
 		return false
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func forceColor(env string) bool {
+	v := os.Getenv(env)
+	return v != "" && v != "0"
 }
 
 // Red wraps s in red ANSI codes if enabled.

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -1,0 +1,54 @@
+package color
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// nonTTYWriter ensures IsEnabled hits the "w is not *os.File" branch
+// without needing real TTY detection.
+type nonTTYWriter struct{ bytes.Buffer }
+
+func TestIsEnabled_NoColorWins(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("FORCE_COLOR", "1")
+	if IsEnabled(false, os.Stdout) {
+		t.Error("NO_COLOR must take precedence over FORCE_COLOR")
+	}
+	if IsEnabled(true, os.Stdout) {
+		t.Error("--no-color must take precedence")
+	}
+}
+
+func TestIsEnabled_ForceColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	for _, env := range []string{"FORCE_COLOR", "CLICOLOR_FORCE"} {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv("FORCE_COLOR", "")
+			t.Setenv("CLICOLOR_FORCE", "")
+			t.Setenv(env, "1")
+			if !IsEnabled(false, &nonTTYWriter{}) {
+				t.Errorf("%s=1 should enable color even for non-TTY writer", env)
+			}
+		})
+	}
+}
+
+func TestIsEnabled_ForceColorZero(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("CLICOLOR_FORCE", "")
+	t.Setenv("FORCE_COLOR", "0")
+	if IsEnabled(false, &nonTTYWriter{}) {
+		t.Error("FORCE_COLOR=0 should NOT enable color (treated as off)")
+	}
+}
+
+func TestIsEnabled_NonTTYDefault(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("CLICOLOR_FORCE", "")
+	if IsEnabled(false, &nonTTYWriter{}) {
+		t.Error("non-TTY writer with no env should be disabled")
+	}
+}


### PR DESCRIPTION
## Summary

Adds opt-in support for ANSI colors when stdout is not a terminal — primarily useful for CI logs. Closes #241.

## Behavior

Precedence (highest first):

1. `--no-color` flag or `NO_COLOR` env var → **disabled** (unchanged, always wins)
2. `FORCE_COLOR` or `CLICOLOR_FORCE` env set to a non-empty, non-"0" value → **enabled**
3. Auto-detect: stdout is a TTY → **enabled** (unchanged default)

`FORCE_COLOR=0` is treated as "off" (matching Node.js / npm convention), so `FORCE_COLOR=0` is a no-op — it does not force colors.

## Files

- `internal/color/color.go` — `IsEnabled` checks `FORCE_COLOR` / `CLICOLOR_FORCE` between the disable-checks and the TTY check
- `internal/color/color_test.go` — new test file covering the four interaction cases (no-color wins, force enables both env names, FORCE_COLOR=0 is off, non-TTY default unchanged)
- `README.md` — short subsection in *CI Catalog component* section showing the GitLab variable snippet

## Test plan

```sh
go test ./internal/color/...   # 4 cases pass

# Manual sanity:
go build -o /tmp/glsec ./cmd/glsec
/tmp/glsec testdata/fixtures/gl025-uservar-curl.yml | cat              # no color (piped)
FORCE_COLOR=1 /tmp/glsec testdata/fixtures/gl025-uservar-curl.yml | cat # colored
NO_COLOR=1 FORCE_COLOR=1 /tmp/glsec ... | cat                          # no color (NO_COLOR wins)
```

## Follow-up

After merge: update the four example pipelines at https://gitlab.com/glsec-io/examples to set `FORCE_COLOR: "1"` in `variables:` so the demo logs show colored output.