### PR TITLE
docs: note POSIX-shell assumption for script rules (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ exclude_paths:
 
 **Not covered:** [CICD-SEC-2](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-02-Inadequate-Identity-And-Access-Management) (Identity & Access Management) and [CICD-SEC-10](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-10-Insufficient-Logging-And-Visibility) (Insufficient Logging & Visibility) are not detectable from static `.gitlab-ci.yml` analysis — they require platform-level context such as GitLab group/project settings, audit logs, or API access.
 
+### Shell assumptions
+
+The script-analysis rules (e.g. GL002, GL011, GL024, GL025, GL047, GL048, GL050) assume **POSIX shell** (`bash`/`sh`) semantics — the default for Linux and macOS runners. PowerShell pipelines on Windows runners use different syntax (`$env:VAR` instead of `$VAR`, `Invoke-WebRequest` instead of `curl`, etc.), so these rules will not match them. **A Windows-runner job that emits no findings has not been meaningfully checked for shell issues** — don't treat the absence of findings there as a clean bill of health.
+
 ## ShellCheck integration
 
 glsec can optionally pass `script:`, `before_script:`, and `after_script:` blocks to [ShellCheck](https://www.shellcheck.net/) for deeper shell analysis. This is **opt-in** and requires ShellCheck to be installed separately.


### PR DESCRIPTION
## Summary

Addresses **part 1** of #243 — documents that glsec's script-analysis rules assume POSIX shell semantics.

Adds a short *Shell assumptions* subsection to the README *Rules* section, making explicit that:

- Script rules (GL002, GL011, GL024, GL025, GL047, GL048, GL050, …) target `bash`/`sh` — the Linux/macOS runner default
- PowerShell pipelines on Windows runners use different syntax and will not match
- Absence of findings on a Windows-runner job is **not** a clean bill of health

## Scope

This PR is documentation only. **Part 2** of #243 (detecting Windows-tagged jobs and skipping shell-only rules with an info-level diagnostic) is a larger architectural change and remains open in the issue.

## Test

Render the README and confirm the new subsection appears under *Rules*, after the "Not covered" note.