### PR TITLE
feat: GL054 — Docker-in-Docker service implies privileged runner (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-53 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+54 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -103,7 +103,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -108,3 +108,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL048](rules/GL048.md) | `error` | `StrictHostKeyChecking` disabled in SSH command or config — host identity not verified, enabling MITM attacks |
 | [GL049](rules/GL049.md) | `warn`  | Deploy job with `interruptible: true` — mid-run cancellation leaves the target environment in an undefined state |
 | [GL050](rules/GL050.md) | `warn`  | `sudo` in CI script — escalates to root, amplifying blast radius if the pipeline is compromised |
+| [GL054](rules/GL054.md) | `warn`  | `docker:dind` service (or `DOCKER_HOST` pointing at it) implies a privileged runner with full host root access |

--- a/docs/rules/GL054.md
+++ b/docs/rules/GL054.md
@@ -1,0 +1,65 @@
+# GL054 — Docker-in-Docker service implies a privileged runner
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-250 – Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
+
+## Risk
+
+Using `docker:dind` as a service requires the GitLab Runner to be configured with `privileged = true` in its `config.toml`. A privileged runner grants the job full root access to the host kernel — container isolation is effectively removed. Any compromised dependency, injected script, or malicious image running in that job can escape the container and access the runner host, other jobs' secrets, or the broader network.
+
+`privileged: true` cannot be set in `.gitlab-ci.yml` itself, but the presence of a `docker:dind` service is a reliable indicator that the runner must be privileged. This makes DinD usage the detectable proxy for a privileged-runner requirement.
+
+## Trigger example
+
+```yaml
+build-image:
+  services:
+    - docker:26.0-dind
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - docker build -t myapp .
+    - docker push myapp
+```
+
+The rule also flags a `DOCKER_HOST: tcp://docker:2375` (or `:2376`) variable on its own, since it points at a DinD daemon even when the service is declared elsewhere.
+
+## Safe alternatives
+
+**Kaniko** (runs as non-root, no Docker daemon):
+```yaml
+build-image:
+  image:
+    name: gcr.io/kaniko-project/executor:v1.21.0-debug
+    entrypoint: [""]
+  script:
+    - /kaniko/executor --context $CI_PROJECT_DIR --destination $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+```
+
+**Buildah** (rootless builds):
+```yaml
+build-image:
+  image: quay.io/buildah/stable:v1.35.0
+  script:
+    - buildah bud -t myapp .
+    - buildah push myapp
+```
+
+**GitLab-managed Docker socket binding** (uses the runner host's Docker socket — reduces isolation but avoids full privileged mode):
+```yaml
+build-image:
+  image: docker:26.0
+  variables:
+    DOCKER_HOST: unix:///var/run/docker.sock
+  script:
+    - docker build -t myapp .
+```
+
+## Notes
+
+- Severity is `warn` — DinD is a legitimate pattern in some environments, but should always be a deliberate, documented choice.
+- [GL031](GL031.md) covers the related `DOCKER_TLS_CERTDIR: ""` misconfiguration (TLS disabled on the DinD daemon); GL054 covers the broader DinD usage pattern regardless of TLS configuration.
+- The fix is not always to remove DinD — it is to make the privileged-runner requirement explicit and to consider rootless alternatives.
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL054` when DinD is a justified, documented requirement.

--- a/rules/all.go
+++ b/rules/all.go
@@ -57,5 +57,6 @@ func All() []rule.Rule {
 		GL051,
 		GL052,
 		GL053,
+		GL054,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -55,6 +55,7 @@ var cweIDs = map[string]string{
 	"GL051": "CWE-829",
 	"GL052": "CWE-284",
 	"GL053": "CWE-284",
+	"GL054": "CWE-250",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl054.go
+++ b/rules/gl054.go
@@ -1,0 +1,84 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl054 struct{}
+
+var GL054 = &gl054{}
+
+func (r *gl054) ID() string { return "GL054" }
+
+// dindImageRe matches a docker-in-docker service image: docker:dind,
+// docker:26.0-dind, registry/docker:24-dind, etc.
+var dindImageRe = regexp.MustCompile(`(?:^|/)docker:[\w.-]*dind\b`)
+
+// dockerHostTCPRe matches a DOCKER_HOST value pointing at the dind daemon.
+var dockerHostTCPRe = regexp.MustCompile(`tcp://docker:23(?:75|76)\b`)
+
+func (r *gl054) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkDinD(
+		parser.FindKey(mapping, "services"), parser.FindKey(mapping, "variables"), file, "")...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkDinD(
+			parser.FindKey(def, "services"), parser.FindKey(def, "variables"), file, "")...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		findings = append(findings, checkDinD(
+			parser.FindKey(job, "services"), parser.FindKey(job, "variables"), file, name.Value)...)
+	})
+
+	return findings
+}
+
+// checkDinD flags a docker-in-docker service or, failing that, a DOCKER_HOST
+// variable pointing at the dind daemon. The service is the stronger signal, so
+// when both are present in the same scope only the service is reported.
+func checkDinD(servicesNode, varsNode *yaml.Node, file, job string) []finding.Finding {
+	if servicesNode != nil && servicesNode.Kind == yaml.SequenceNode {
+		for _, item := range servicesNode.Content {
+			ref, line, col := imageRef(item)
+			if ref != "" && dindImageRe.MatchString(ref) {
+				return []finding.Finding{{
+					RuleID:   "GL054",
+					Severity: finding.Warn,
+					Job:      job,
+					Message: fmt.Sprintf(
+						"docker-in-docker service %q requires the runner to run privileged (full host root access) — consider rootless build tools like Kaniko or Buildah, or document the privileged-runner requirement",
+						ref,
+					),
+					File: file, Line: line, Col: col,
+				}}
+			}
+		}
+	}
+
+	if varsNode != nil && varsNode.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(varsNode.Content); i += 2 {
+			key := varsNode.Content[i]
+			val := resolveScalar(varsNode.Content[i+1])
+			if key.Value == "DOCKER_HOST" && val != nil && dockerHostTCPRe.MatchString(val.Value) {
+				return []finding.Finding{{
+					RuleID:   "GL054",
+					Severity: finding.Warn,
+					Job:      job,
+					Message:  "DOCKER_HOST points at a docker-in-docker daemon (tcp://docker:2375/2376) — implies a privileged runner; consider rootless build tools like Kaniko or Buildah",
+					File:     file, Line: key.Line, Col: key.Column,
+				}}
+			}
+		}
+	}
+
+	return nil
+}

--- a/rules/gl054_test.go
+++ b/rules/gl054_test.go
@@ -1,0 +1,127 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings054(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL054.Check(doc.Root, "test.yml")
+}
+
+func TestGL054_DinDServiceScalar(t *testing.T) {
+	f := findings054(t, `
+build-image:
+  services:
+    - docker:26.0-dind
+  script:
+    - docker build -t myapp .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL054" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+	if f[0].Job != "build-image" {
+		t.Errorf("expected job build-image, got %q", f[0].Job)
+	}
+}
+
+func TestGL054_DinDServiceBareTag(t *testing.T) {
+	f := findings054(t, `
+build:
+  services:
+    - docker:dind
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for docker:dind, got %d", len(f))
+	}
+}
+
+func TestGL054_DinDServiceMappingForm(t *testing.T) {
+	f := findings054(t, `
+build:
+  services:
+    - name: docker:24-dind
+      alias: docker
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for mapping-form dind service, got %d", len(f))
+	}
+}
+
+func TestGL054_DinDServiceRegistryPrefixed(t *testing.T) {
+	f := findings054(t, `
+build:
+  services:
+    - docker.io/library/docker:dind
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for registry-prefixed dind, got %d", len(f))
+	}
+}
+
+func TestGL054_DockerHostVariableOnly(t *testing.T) {
+	f := findings054(t, `
+build:
+  image: docker:26.0
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for DOCKER_HOST, got %d", len(f))
+	}
+}
+
+func TestGL054_ServiceAndDockerHostDeduped(t *testing.T) {
+	f := findings054(t, `
+build-image:
+  services:
+    - docker:26.0-dind
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding when both service and DOCKER_HOST present, got %d", len(f))
+	}
+}
+
+func TestGL054_NonDinDDockerImage(t *testing.T) {
+	f := findings054(t, `
+build:
+  image: docker:26.0
+  variables:
+    DOCKER_HOST: unix:///var/run/docker.sock
+  script: [docker build .]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for socket-binding docker (no dind), got %d", len(f))
+	}
+}
+
+func TestGL054_Kaniko(t *testing.T) {
+	f := findings054(t, `
+build-image:
+  image:
+    name: gcr.io/kaniko-project/executor:v1.21.0-debug
+    entrypoint: [""]
+  script:
+    - /kaniko/executor --context . --destination myapp
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for Kaniko, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -56,6 +56,7 @@ var owaspCategories = map[string][]string{
 	"GL051": {"CICD-SEC-4"},
 	"GL052": {"CICD-SEC-6"},
 	"GL053": {"CICD-SEC-4"},
+	"GL054": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl054-dind-service.yml
+++ b/testdata/fixtures/gl054-dind-service.yml
@@ -1,0 +1,10 @@
+# docker-in-docker build job — requires a privileged runner.
+build-image:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+  script:
+    - docker build -t myapp .
+    - docker push myapp


### PR DESCRIPTION
## Summary

New rule **GL054**: warns when a job uses a `docker:dind` service (or a `DOCKER_HOST` variable pointing at one), which requires the GitLab Runner to run `privileged = true` — full host root access, no container isolation. Closes #168.

## Detection

- `services:` entry whose image matches `docker:*dind` (scalar or `name:` mapping form, registry-prefixed too)
- `DOCKER_HOST` variable set to `tcp://docker:2375` or `:2376`

The service is the stronger signal — when both appear in the same scope, only the service is reported (no double-warning). Checked at top-level, `default:`, and per-job scopes.

## Severity

`warn` — DinD is legitimate in some environments but should be a deliberate, documented choice. Suppressible via `.glsec-ignore` / inline `# glsec:ignore GL054`.

## Relationship to GL031

GL031 flags `DOCKER_TLS_CERTDIR: ""` (TLS disabled on the DinD daemon). GL054 covers the broader DinD usage pattern regardless of TLS config — they can both fire on the same job, addressing different aspects.

## Mappings

- OWASP: CICD-SEC-7 (Insecure System Configuration)
- CWE: CWE-250 (Execution with Unnecessary Privileges)

## Files

- `rules/gl054.go` + `rules/gl054_test.go` (8 cases incl. scalar/mapping/registry forms, DOCKER_HOST-only, dedup, and negative cases for socket-binding docker + Kaniko)
- Registered in `all.go`, `owasp.go`, `cwe.go`
- `docs/rules/GL054.md`, `docs/rules.md`, README count 53→54 + table
- `testdata/fixtures/gl054-dind-service.yml`

## Test

```sh
go test ./...   # all pass incl. consistency check
/tmp/glsec --no-exit-codes testdata/fixtures/gl054-dind-service.yml   # one GL054 finding
```

Closes #168.