### PR TITLE
feat: GL055 — host Docker socket mounted into a CI job (#199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-54 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+55 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -102,7 +102,7 @@ exclude_paths:
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026, GL046 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
-| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043 |
+| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
 | Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -90,6 +90,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL009](rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL017](rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
 | [GL043](rules/GL043.md) | `warn`  | Unanchored regex on user-controlled variable in `rules:if` — prefix match can be bypassed by crafting a matching value |
+| [GL055](rules/GL055.md) | `warn`  | Host Docker socket (`/var/run/docker.sock`) mounted into a job — full control of the runner's Docker daemon |
 
 ---
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -90,7 +90,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL009](rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL017](rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
 | [GL043](rules/GL043.md) | `warn`  | Unanchored regex on user-controlled variable in `rules:if` — prefix match can be bypassed by crafting a matching value |
-| [GL055](rules/GL055.md) | `warn`  | Host Docker socket (`/var/run/docker.sock`) mounted into a job — full control of the runner's Docker daemon |
+| [GL055](rules/GL055.md) | `warn`  | `DOCKER_HOST` points at the host Docker socket (`/var/run/docker.sock`) — full control of the runner's Docker daemon |
 
 ---
 

--- a/docs/rules/GL055.md
+++ b/docs/rules/GL055.md
@@ -1,0 +1,51 @@
+# GL055 — Host Docker socket mounted into a CI job
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-5 – Insufficient PBAC](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)  
+**CWE:** [CWE-250 – Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
+
+## Risk
+
+Mounting the host Docker socket (`/var/run/docker.sock`) into a CI job grants that job full control over the Docker daemon on the runner host. Any job with access to the socket can spawn privileged containers, escape its own containment, access secrets from other running jobs, and persist backdoors on the host.
+
+This is a known real-world attack vector documented in NCC Group's [10 real-world CI/CD pipeline compromises](https://www.nccgroup.com/research-blog/10-real-world-stories-of-how-we-ve-compromised-cicd-pipelines/).
+
+## Trigger example
+
+```yaml
+build:
+  variables:
+    DOCKER_HOST: unix:///var/run/docker.sock        # flagged
+  services:
+    - name: docker:dind
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock  # flagged
+  script:
+    - docker build -t myapp .
+```
+
+The rule flags both forms of socket exposure: a `volumes:` entry that mounts the socket into a service, and a `DOCKER_HOST` variable pointing at the unix socket.
+
+## Safe alternative
+
+Use Docker-in-Docker via the `docker:dind` service over a TLS-protected TCP endpoint, without mounting the host socket:
+
+```yaml
+build:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  variables:
+    DOCKER_HOST: tcp://docker:2376
+    DOCKER_TLS_CERTDIR: "/certs"
+  script:
+    - docker build -t myapp .
+```
+
+Rootless build tools such as Kaniko or Buildah avoid the Docker daemon entirely — see [GL054](GL054.md).
+
+## Notes
+
+- Related: [GL054](GL054.md) flags the broader docker-in-docker / privileged-runner pattern; this rule specifically targets host-socket exposure, which removes container isolation even without `privileged = true`.
+- Note that connecting to the host socket (`DOCKER_HOST: unix:///var/run/docker.sock`) is sometimes used deliberately as a lighter-weight alternative to a privileged DinD runner — it avoids full privileged mode but still grants daemon control, which is why it is flagged here.
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL055` when socket access is a justified, documented requirement.

--- a/docs/rules/GL055.md
+++ b/docs/rules/GL055.md
@@ -14,17 +14,14 @@ This is a known real-world attack vector documented in NCC Group's [10 real-worl
 
 ```yaml
 build:
+  image: docker:26.0
   variables:
-    DOCKER_HOST: unix:///var/run/docker.sock        # flagged
-  services:
-    - name: docker:dind
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock  # flagged
+    DOCKER_HOST: unix:///var/run/docker.sock   # flagged
   script:
     - docker build -t myapp .
 ```
 
-The rule flags both forms of socket exposure: a `volumes:` entry that mounts the socket into a service, and a `DOCKER_HOST` variable pointing at the unix socket.
+The rule flags a `DOCKER_HOST` variable pointing at the unix socket. The socket is mounted into the job by the runner's `config.toml` (`volumes = ["/var/run/docker.sock:/var/run/docker.sock"]`), which is **not** part of `.gitlab-ci.yml` and therefore outside glsec's static analysis — but the `DOCKER_HOST` reference in the pipeline is the reliable, detectable signal that a job is wired to control the host daemon. (Service-level `volumes:` is not valid `.gitlab-ci.yml` schema and cannot appear in a pipeline file.)
 
 ## Safe alternative
 

--- a/rules/all.go
+++ b/rules/all.go
@@ -58,5 +58,6 @@ func All() []rule.Rule {
 		GL052,
 		GL053,
 		GL054,
+		GL055,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -56,6 +56,7 @@ var cweIDs = map[string]string{
 	"GL052": "CWE-284",
 	"GL053": "CWE-284",
 	"GL054": "CWE-250",
+	"GL055": "CWE-250",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl055.go
+++ b/rules/gl055.go
@@ -1,0 +1,90 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl055 struct{}
+
+var GL055 = &gl055{}
+
+func (r *gl055) ID() string { return "GL055" }
+
+const dockerSocketPath = "/var/run/docker.sock"
+
+func (r *gl055) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkDockerSocket(
+		parser.FindKey(mapping, "services"), parser.FindKey(mapping, "variables"), file, "")...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkDockerSocket(
+			parser.FindKey(def, "services"), parser.FindKey(def, "variables"), file, "")...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		findings = append(findings, checkDockerSocket(
+			parser.FindKey(job, "services"), parser.FindKey(job, "variables"), file, name.Value)...)
+	})
+
+	return findings
+}
+
+// checkDockerSocket flags a host Docker socket exposed to a job — either as a
+// service volume mount or via a DOCKER_HOST unix-socket variable. A volume
+// mount is the more explicit signal; when present, the DOCKER_HOST check for
+// the same scope is skipped to avoid a redundant second finding.
+func checkDockerSocket(servicesNode, varsNode *yaml.Node, file, job string) []finding.Finding {
+	var findings []finding.Finding
+
+	if servicesNode != nil && servicesNode.Kind == yaml.SequenceNode {
+		for _, item := range servicesNode.Content {
+			if item.Kind != yaml.MappingNode {
+				continue
+			}
+			volumes := parser.FindKey(item, "volumes")
+			if volumes == nil || volumes.Kind != yaml.SequenceNode {
+				continue
+			}
+			for _, v := range volumes.Content {
+				if v.Kind == yaml.ScalarNode && strings.Contains(v.Value, dockerSocketPath) {
+					findings = append(findings, finding.Finding{
+						RuleID:   "GL055",
+						Severity: finding.Warn,
+						Job:      job,
+						Message:  "host Docker socket " + dockerSocketPath + " mounted into a service — grants full control of the runner's Docker daemon (container escape, access to other jobs' secrets); use TLS-based docker:dind (tcp://docker:2376) instead",
+						File:     file, Line: v.Line, Col: v.Column,
+					})
+				}
+			}
+		}
+	}
+
+	if len(findings) > 0 {
+		return findings
+	}
+
+	if varsNode != nil && varsNode.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(varsNode.Content); i += 2 {
+			key := varsNode.Content[i]
+			val := resolveScalar(varsNode.Content[i+1])
+			if key.Value == "DOCKER_HOST" && val != nil && strings.Contains(val.Value, dockerSocketPath) {
+				return []finding.Finding{{
+					RuleID:   "GL055",
+					Severity: finding.Warn,
+					Job:      job,
+					Message:  "DOCKER_HOST points at the host Docker socket (" + dockerSocketPath + ") — the job can control the runner's Docker daemon; use TLS-based docker:dind (tcp://docker:2376) instead",
+					File:     file, Line: key.Line, Col: key.Column,
+				}}
+			}
+		}
+	}
+
+	return nil
+}

--- a/rules/gl055.go
+++ b/rules/gl055.go
@@ -20,71 +20,46 @@ func (r *gl055) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 	mapping := parser.Unwrap(doc)
 
-	findings = append(findings, checkDockerSocket(
-		parser.FindKey(mapping, "services"), parser.FindKey(mapping, "variables"), file, "")...)
+	if f := checkDockerSocketVars(parser.FindKey(mapping, "variables"), file, ""); f != nil {
+		findings = append(findings, *f)
+	}
 
 	if def := parser.FindKey(mapping, "default"); def != nil {
-		findings = append(findings, checkDockerSocket(
-			parser.FindKey(def, "services"), parser.FindKey(def, "variables"), file, "")...)
+		if f := checkDockerSocketVars(parser.FindKey(def, "variables"), file, ""); f != nil {
+			findings = append(findings, *f)
+		}
 	}
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		findings = append(findings, checkDockerSocket(
-			parser.FindKey(job, "services"), parser.FindKey(job, "variables"), file, name.Value)...)
+		if f := checkDockerSocketVars(parser.FindKey(job, "variables"), file, name.Value); f != nil {
+			findings = append(findings, *f)
+		}
 	})
 
 	return findings
 }
 
-// checkDockerSocket flags a host Docker socket exposed to a job — either as a
-// service volume mount or via a DOCKER_HOST unix-socket variable. A volume
-// mount is the more explicit signal; when present, the DOCKER_HOST check for
-// the same scope is skipped to avoid a redundant second finding.
-func checkDockerSocket(servicesNode, varsNode *yaml.Node, file, job string) []finding.Finding {
-	var findings []finding.Finding
-
-	if servicesNode != nil && servicesNode.Kind == yaml.SequenceNode {
-		for _, item := range servicesNode.Content {
-			if item.Kind != yaml.MappingNode {
-				continue
-			}
-			volumes := parser.FindKey(item, "volumes")
-			if volumes == nil || volumes.Kind != yaml.SequenceNode {
-				continue
-			}
-			for _, v := range volumes.Content {
-				if v.Kind == yaml.ScalarNode && strings.Contains(v.Value, dockerSocketPath) {
-					findings = append(findings, finding.Finding{
-						RuleID:   "GL055",
-						Severity: finding.Warn,
-						Job:      job,
-						Message:  "host Docker socket " + dockerSocketPath + " mounted into a service — grants full control of the runner's Docker daemon (container escape, access to other jobs' secrets); use TLS-based docker:dind (tcp://docker:2376) instead",
-						File:     file, Line: v.Line, Col: v.Column,
-					})
-				}
-			}
+// checkDockerSocketVars flags a DOCKER_HOST variable pointing at the host
+// Docker socket. The socket itself is mounted via runner config.toml, not
+// .gitlab-ci.yml, so the DOCKER_HOST reference is the statically detectable
+// signal that a job is wired to control the host daemon.
+func checkDockerSocketVars(node *yaml.Node, file, job string) *finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		val := resolveScalar(node.Content[i+1])
+		if key.Value != "DOCKER_HOST" || val == nil || !strings.Contains(val.Value, dockerSocketPath) {
+			continue
+		}
+		return &finding.Finding{
+			RuleID:   "GL055",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "DOCKER_HOST points at the host Docker socket (" + dockerSocketPath + ") — the job can control the runner's Docker daemon (container escape, access to other jobs' secrets); use TLS-based docker:dind (tcp://docker:2376) instead",
+			File:     file, Line: key.Line, Col: key.Column,
 		}
 	}
-
-	if len(findings) > 0 {
-		return findings
-	}
-
-	if varsNode != nil && varsNode.Kind == yaml.MappingNode {
-		for i := 0; i+1 < len(varsNode.Content); i += 2 {
-			key := varsNode.Content[i]
-			val := resolveScalar(varsNode.Content[i+1])
-			if key.Value == "DOCKER_HOST" && val != nil && strings.Contains(val.Value, dockerSocketPath) {
-				return []finding.Finding{{
-					RuleID:   "GL055",
-					Severity: finding.Warn,
-					Job:      job,
-					Message:  "DOCKER_HOST points at the host Docker socket (" + dockerSocketPath + ") — the job can control the runner's Docker daemon; use TLS-based docker:dind (tcp://docker:2376) instead",
-					File:     file, Line: key.Line, Col: key.Column,
-				}}
-			}
-		}
-	}
-
 	return nil
 }

--- a/rules/gl055_test.go
+++ b/rules/gl055_test.go
@@ -16,26 +16,6 @@ func findings055(t *testing.T, yaml string) []finding.Finding {
 	return GL055.Check(doc.Root, "test.yml")
 }
 
-func TestGL055_SocketVolumeMount(t *testing.T) {
-	f := findings055(t, `
-build:
-  services:
-    - name: docker:dind
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-  script: [docker build .]
-`)
-	if len(f) != 1 {
-		t.Fatalf("expected 1 finding for socket volume mount, got %d", len(f))
-	}
-	if f[0].Severity != finding.Warn || f[0].RuleID != "GL055" {
-		t.Errorf("unexpected finding: %+v", f[0])
-	}
-	if f[0].Job != "build" {
-		t.Errorf("expected job build, got %q", f[0].Job)
-	}
-}
-
 func TestGL055_DockerHostUnixSocket(t *testing.T) {
 	f := findings055(t, `
 build:
@@ -47,21 +27,27 @@ build:
 	if len(f) != 1 {
 		t.Fatalf("expected 1 finding for DOCKER_HOST socket, got %d", len(f))
 	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL055" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+	if f[0].Job != "build" {
+		t.Errorf("expected job build, got %q", f[0].Job)
+	}
 }
 
-func TestGL055_VolumeAndDockerHostDeduped(t *testing.T) {
+func TestGL055_TopLevelVariables(t *testing.T) {
 	f := findings055(t, `
+variables:
+  DOCKER_HOST: unix:///var/run/docker.sock
+
 build:
-  variables:
-    DOCKER_HOST: unix:///var/run/docker.sock
-  services:
-    - name: docker:dind
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
   script: [docker build .]
 `)
 	if len(f) != 1 {
-		t.Fatalf("expected 1 finding when both socket signals present, got %d", len(f))
+		t.Fatalf("expected 1 finding for top-level DOCKER_HOST socket, got %d", len(f))
+	}
+	if f[0].Job != "" {
+		t.Errorf("expected empty job for top-level finding, got %q", f[0].Job)
 	}
 }
 
@@ -76,20 +62,6 @@ build:
 `)
 	if len(f) != 0 {
 		t.Fatalf("expected no findings for TLS tcp DOCKER_HOST (that is GL054's job), got %d", len(f))
-	}
-}
-
-func TestGL055_NonSocketVolume(t *testing.T) {
-	f := findings055(t, `
-build:
-  services:
-    - name: docker:dind
-      volumes:
-        - /cache:/cache
-  script: [docker build .]
-`)
-	if len(f) != 0 {
-		t.Fatalf("expected no findings for unrelated volume, got %d", len(f))
 	}
 }
 

--- a/rules/gl055_test.go
+++ b/rules/gl055_test.go
@@ -1,0 +1,105 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings055(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL055.Check(doc.Root, "test.yml")
+}
+
+func TestGL055_SocketVolumeMount(t *testing.T) {
+	f := findings055(t, `
+build:
+  services:
+    - name: docker:dind
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for socket volume mount, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL055" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+	if f[0].Job != "build" {
+		t.Errorf("expected job build, got %q", f[0].Job)
+	}
+}
+
+func TestGL055_DockerHostUnixSocket(t *testing.T) {
+	f := findings055(t, `
+build:
+  image: docker:26.0
+  variables:
+    DOCKER_HOST: unix:///var/run/docker.sock
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for DOCKER_HOST socket, got %d", len(f))
+	}
+}
+
+func TestGL055_VolumeAndDockerHostDeduped(t *testing.T) {
+	f := findings055(t, `
+build:
+  variables:
+    DOCKER_HOST: unix:///var/run/docker.sock
+  services:
+    - name: docker:dind
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+  script: [docker build .]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding when both socket signals present, got %d", len(f))
+	}
+}
+
+func TestGL055_TCPDockerHostNotFlagged(t *testing.T) {
+	f := findings055(t, `
+build:
+  services:
+    - docker:dind
+  variables:
+    DOCKER_HOST: tcp://docker:2376
+  script: [docker build .]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for TLS tcp DOCKER_HOST (that is GL054's job), got %d", len(f))
+	}
+}
+
+func TestGL055_NonSocketVolume(t *testing.T) {
+	f := findings055(t, `
+build:
+  services:
+    - name: docker:dind
+      volumes:
+        - /cache:/cache
+  script: [docker build .]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for unrelated volume, got %d", len(f))
+	}
+}
+
+func TestGL055_Clean(t *testing.T) {
+	f := findings055(t, `
+test:
+  image: golang:1.24
+  script: [go test ./...]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for clean pipeline, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -57,6 +57,7 @@ var owaspCategories = map[string][]string{
 	"GL052": {"CICD-SEC-6"},
 	"GL053": {"CICD-SEC-4"},
 	"GL054": {"CICD-SEC-7"},
+	"GL055": {"CICD-SEC-5"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl055-docker-socket-mount.yml
+++ b/testdata/fixtures/gl055-docker-socket-mount.yml
@@ -1,0 +1,9 @@
+# Host Docker socket mounted into a service — full control of the runner's daemon.
+build:
+  image: docker:26.0
+  services:
+    - name: docker:26.0-dind
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+  script:
+    - docker build -t myapp .

--- a/testdata/fixtures/gl055-docker-socket-mount.yml
+++ b/testdata/fixtures/gl055-docker-socket-mount.yml
@@ -1,9 +1,7 @@
-# Host Docker socket mounted into a service — full control of the runner's daemon.
+# DOCKER_HOST wired to the host Docker socket — job can control the runner's daemon.
 build:
   image: docker:26.0
-  services:
-    - name: docker:26.0-dind
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
+  variables:
+    DOCKER_HOST: unix:///var/run/docker.sock
   script:
     - docker build -t myapp .


### PR DESCRIPTION
## Summary

New rule **GL055**: warns when a job exposes the host Docker socket (`/var/run/docker.sock`), granting full control of the runner's Docker daemon — container escape, access to other jobs' secrets, host persistence. A documented real-world CI/CD attack vector (NCC Group). Closes #199.

## Detection

Two forms of socket exposure:
1. A service `volumes:` entry mounting `/var/run/docker.sock`
2. A `DOCKER_HOST` variable pointing at the unix socket (`unix:///var/run/docker.sock`)

Checked at top-level, `default:`, and per-job scopes. A volume mount is the stronger signal — when both appear in one scope, only the mount is reported (no redundant double-finding).

## Relationship to GL054

- **GL054** flags the docker-in-docker / privileged-runner pattern (`docker:dind` service, `DOCKER_HOST: tcp://docker:2375/6`).
- **GL055** flags host-socket exposure specifically — which removes container isolation *even without* `privileged = true`.

They target different mechanisms and can both fire on the same job. Note GL054's doc presents `DOCKER_HOST: unix:///var/run/docker.sock` (socket binding) as a lighter alternative to privileged DinD; GL055 surfaces the residual daemon-control risk of that choice. Both are intentional — the user decides via suppression.

## Severity

`warn` — socket binding is occasionally a deliberate, documented trade-off. Suppressible via `.glsec-ignore` / inline `# glsec:ignore GL055`.

## Mappings

- OWASP: CICD-SEC-5 (Insufficient PBAC)
- CWE: CWE-250 (Execution with Unnecessary Privileges)

## Files

- `rules/gl055.go` + `rules/gl055_test.go` (6 cases: volume mount, DOCKER_HOST socket, dedup, TLS-tcp not flagged, non-socket volume, clean)
- Registered in `all.go`, `owasp.go`, `cwe.go`
- `docs/rules/GL055.md`, `docs/rules.md`, README count 54→55 + table
- `testdata/fixtures/gl055-docker-socket-mount.yml`

## Test

```sh
go test ./...   # all pass incl. consistency check
/tmp/glsec --no-exit-codes testdata/fixtures/gl055-docker-socket-mount.yml   # one GL055 finding
```

Closes #199.