### PR TITLE
feat: GL056 — docker run --privileged in CI script (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-55 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+56 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -103,7 +103,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -110,3 +110,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL049](rules/GL049.md) | `warn`  | Deploy job with `interruptible: true` — mid-run cancellation leaves the target environment in an undefined state |
 | [GL050](rules/GL050.md) | `warn`  | `sudo` in CI script — escalates to root, amplifying blast radius if the pipeline is compromised |
 | [GL054](rules/GL054.md) | `warn`  | `docker:dind` service (or `DOCKER_HOST` pointing at it) implies a privileged runner with full host root access |
+| [GL056](rules/GL056.md) | `warn`  | `docker run --privileged` in a script grants the container full host kernel access |

--- a/docs/rules/GL056.md
+++ b/docs/rules/GL056.md
@@ -1,0 +1,39 @@
+# GL056 — `docker run --privileged` in CI script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-250 – Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
+
+## Risk
+
+Running `docker run --privileged` inside a CI script grants the container full access to the host kernel — all Linux capabilities are enabled and device access is unrestricted. Any compromised dependency, injected variable, or malicious script running in that job can escape the container, access the runner host filesystem, read secrets from other jobs, or pivot to the broader network.
+
+This is distinct from [GL031](GL031.md) (TLS disabled on the Docker daemon) and [GL054](GL054.md) (docker-in-docker service implies a privileged runner) — it is a direct, explicit privilege escalation in the script itself, not an implied runner configuration.
+
+## Trigger example
+
+```yaml
+test:
+  script:
+    - docker run --privileged myimage ./run-tests.sh
+```
+
+`--privileged=true` is also flagged; `--privileged=false` and `--privileged=0` are not.
+
+## Safe alternative
+
+Use the minimal set of capabilities actually required:
+
+```yaml
+test:
+  script:
+    - docker run --cap-add NET_ADMIN myimage ./run-tests.sh
+```
+
+Or redesign the job to avoid requiring elevated privileges entirely — e.g. rootless container tools (Podman, Buildah, Kaniko).
+
+## Notes
+
+- Severity is `warn` — there are legitimate uses (e.g. system-level integration tests), but `--privileged` in a pipeline script should always be a deliberate, documented decision.
+- This is a script-line rule and assumes POSIX shell; see the README *Shell assumptions* note.
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL056` when privileged execution is a justified requirement.

--- a/rules/all.go
+++ b/rules/all.go
@@ -59,5 +59,6 @@ func All() []rule.Rule {
 		GL053,
 		GL054,
 		GL055,
+		GL056,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -57,6 +57,7 @@ var cweIDs = map[string]string{
 	"GL053": "CWE-284",
 	"GL054": "CWE-250",
 	"GL055": "CWE-250",
+	"GL056": "CWE-250",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl056.go
+++ b/rules/gl056.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl056 struct{}
+
+var GL056 = &gl056{}
+
+func (r *gl056) ID() string { return "GL056" }
+
+var (
+	dockerRunRe          = regexp.MustCompile(`\bdocker\s+(?:container\s+)?run\b`)
+	privilegedFlagRe     = regexp.MustCompile(`--privileged\b`)
+	privilegedDisabledRe = regexp.MustCompile(`--privileged=(?:false|0)\b`)
+)
+
+func (r *gl056) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerRunRe.MatchString(v) {
+			return
+		}
+		if !privilegedFlagRe.MatchString(v) || privilegedDisabledRe.MatchString(v) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL056",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "docker run --privileged grants the container full host kernel access (all capabilities, unrestricted devices) — use --cap-add for the specific capabilities needed, or a rootless tool like Podman/Buildah",
+			File:     file,
+			Line:     line.Line,
+			Col:      line.Column,
+		})
+	})
+	return findings
+}

--- a/rules/gl056_test.go
+++ b/rules/gl056_test.go
@@ -1,0 +1,113 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings056(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL056.Check(doc.Root, "test.yml")
+}
+
+func TestGL056_PrivilegedFlag(t *testing.T) {
+	f := findings056(t, `
+test:
+  script:
+    - docker run --privileged myimage ./run-tests.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL056" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+	if f[0].Job != "test" {
+		t.Errorf("expected job test, got %q", f[0].Job)
+	}
+}
+
+func TestGL056_PrivilegedTrue(t *testing.T) {
+	f := findings056(t, `
+test:
+  script:
+    - docker run --privileged=true myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --privileged=true, got %d", len(f))
+	}
+}
+
+func TestGL056_ContainerRunSubcommand(t *testing.T) {
+	f := findings056(t, `
+test:
+  script:
+    - docker container run --privileged myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 'docker container run', got %d", len(f))
+	}
+}
+
+func TestGL056_BeforeScript(t *testing.T) {
+	f := findings056(t, `
+test:
+  before_script:
+    - docker run --privileged setup
+  script:
+    - true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in before_script, got %d", len(f))
+	}
+}
+
+func TestGL056_PrivilegedDisabledNotFlagged(t *testing.T) {
+	f := findings056(t, `
+test:
+  script:
+    - docker run --privileged=false myimage
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for --privileged=false, got %d", len(f))
+	}
+}
+
+func TestGL056_CapAddNotFlagged(t *testing.T) {
+	f := findings056(t, `
+test:
+  script:
+    - docker run --cap-add NET_ADMIN myimage ./run-tests.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for --cap-add, got %d", len(f))
+	}
+}
+
+func TestGL056_CommentNotFlagged(t *testing.T) {
+	f := findings056(t, `
+test:
+  script:
+    - "# docker run --privileged is not allowed here"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}
+
+func TestGL056_PlainDockerRunNotFlagged(t *testing.T) {
+	f := findings056(t, `
+test:
+  script:
+    - docker run myimage ./run-tests.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for plain docker run, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -58,6 +58,7 @@ var owaspCategories = map[string][]string{
 	"GL053": {"CICD-SEC-4"},
 	"GL054": {"CICD-SEC-7"},
 	"GL055": {"CICD-SEC-5"},
+	"GL056": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl056-docker-run-privileged.yml
+++ b/testdata/fixtures/gl056-docker-run-privileged.yml
@@ -1,0 +1,7 @@
+# docker run --privileged grants full host kernel access from within the job.
+test:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker run --privileged myimage ./run-tests.sh


### PR DESCRIPTION
## Summary

New rule **GL056**: warns on `docker run --privileged` in a CI script line. Privileged containers get full host kernel access (all capabilities, unrestricted devices) — a direct, explicit privilege escalation that enables container escape. Closes #217.

## Detection

Script lines (`script:`, `before_script:`, `after_script:`) that invoke `docker run` (or `docker container run`) with `--privileged` / `--privileged=true`. `--privileged=false` and `--privileged=0` are not flagged; comment lines are skipped.

Distinct from:
- **GL031** — `DOCKER_TLS_CERTDIR: ""` (daemon TLS disabled)
- **GL054** — `docker:dind` service (implied privileged runner)
- **GL056** — explicit `--privileged` in the script itself

## Severity

`warn` — legitimate for some system-level integration tests, but should be deliberate and documented. Suppressible via `.glsec-ignore` / inline `# glsec:ignore GL056`. Script-line rule → POSIX-shell assumption (per README note).

## Mappings

- OWASP: CICD-SEC-7 (Insecure System Configuration)
- CWE: CWE-250 (Execution with Unnecessary Privileges)

## Files

- `rules/gl056.go` + `rules/gl056_test.go` (8 cases: flag, =true, `docker container run`, before_script, =false skip, --cap-add skip, comment skip, plain run skip)
- Registered in `all.go`, `owasp.go`, `cwe.go`
- `docs/rules/GL056.md`, `docs/rules.md`, README count 55→56 + table
- `testdata/fixtures/gl056-docker-run-privileged.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl056-docker-run-privileged.yml   # one GL056 finding
```

Closes #217.

## Note

This is the first of the #217–#222 docker-run hardening series. Follow-ups (`--cap-add`, `--network host`, `--pid host`, sensitive host mounts, build-arg secrets) can share the `dockerRunRe` matcher.