### PR TITLE
feat: GL057 — docker run --cap-add with dangerous capabilities (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-56 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+57 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -103,7 +103,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -111,3 +111,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL050](rules/GL050.md) | `warn`  | `sudo` in CI script — escalates to root, amplifying blast radius if the pipeline is compromised |
 | [GL054](rules/GL054.md) | `warn`  | `docker:dind` service (or `DOCKER_HOST` pointing at it) implies a privileged runner with full host root access |
 | [GL056](rules/GL056.md) | `warn`  | `docker run --privileged` in a script grants the container full host kernel access |
+| [GL057](rules/GL057.md) | `error`/`warn` | `docker run --cap-add` with dangerous Linux capabilities (`ALL`, `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `NET_ADMIN`) |

--- a/docs/rules/GL057.md
+++ b/docs/rules/GL057.md
@@ -1,0 +1,47 @@
+# GL057 — `docker run --cap-add` with dangerous Linux capabilities
+
+**Severity:** `error` for `--cap-add ALL`; `warn` for individual dangerous capabilities  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-250 – Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250.html)
+
+## Risk
+
+`docker run --cap-add ALL` grants every Linux capability to the container — equivalent to `--privileged` for most practical purposes. Other dangerous individual capabilities can also be abused to escape the container or affect the host:
+
+- `SYS_ADMIN` — mount, `pivot_root`, and many other kernel operations
+- `SYS_PTRACE` — read/write arbitrary process memory
+- `SYS_MODULE` — load/unload kernel modules
+- `NET_ADMIN` — reconfigure network interfaces, iptables, etc.
+
+When passed in a CI script, these capabilities are granted at job runtime. A supply-chain attack or injected variable reaching this job gains greatly elevated access to the runner host.
+
+## Trigger example
+
+```yaml
+test:
+  script:
+    - docker run --cap-add ALL myimage ./test.sh          # error
+    - docker run --cap-add SYS_ADMIN myimage ./mount.sh    # warn
+```
+
+Both `--cap-add NAME` and `--cap-add=NAME` forms are detected, with or without a `CAP_` prefix, case-insensitively.
+
+## Safe alternative
+
+Grant only the specific capability actually needed, and document why:
+
+```yaml
+test:
+  script:
+    - docker run --cap-add NET_BIND_SERVICE myimage ./server-test.sh
+```
+
+Or redesign the test to avoid requiring elevated capabilities.
+
+## Notes
+
+- `--cap-add ALL` is an `error` (equivalent to `--privileged`); individual dangerous capabilities are `warn`.
+- The flagged set is curated: `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `NET_ADMIN`. Common low-risk capabilities such as `NET_BIND_SERVICE` are not flagged.
+- Related: [GL056](GL056.md) (`docker run --privileged`).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL057`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -60,5 +60,6 @@ func All() []rule.Rule {
 		GL054,
 		GL055,
 		GL056,
+		GL057,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -58,6 +58,7 @@ var cweIDs = map[string]string{
 	"GL054": "CWE-250",
 	"GL055": "CWE-250",
 	"GL056": "CWE-250",
+	"GL057": "CWE-250",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl057.go
+++ b/rules/gl057.go
@@ -1,0 +1,67 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl057 struct{}
+
+var GL057 = &gl057{}
+
+func (r *gl057) ID() string { return "GL057" }
+
+// capAddRe captures the capability passed to a --cap-add flag (space or =
+// separated). The value may carry a CAP_ prefix and any case.
+var capAddRe = regexp.MustCompile(`--cap-add[=\s]+([A-Za-z_]+)`)
+
+// dangerousCaps are individual Linux capabilities that meaningfully expand the
+// container's ability to affect the host. Granting any of these is flagged.
+var dangerousCaps = map[string]bool{
+	"SYS_ADMIN":  true,
+	"SYS_PTRACE": true,
+	"SYS_MODULE": true,
+	"NET_ADMIN":  true,
+}
+
+func (r *gl057) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerRunRe.MatchString(v) {
+			return
+		}
+		for _, m := range capAddRe.FindAllStringSubmatch(v, -1) {
+			cap := strings.ToUpper(strings.TrimPrefix(strings.ToUpper(m[1]), "CAP_"))
+			switch {
+			case cap == "ALL":
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL057",
+					Severity: finding.Error,
+					Job:      job,
+					Message:  "docker run --cap-add ALL grants every Linux capability — equivalent to --privileged; grant only the specific capability required",
+					File:     file, Line: line.Line, Col: line.Column,
+				})
+			case dangerousCaps[cap]:
+				findings = append(findings, finding.Finding{
+					RuleID:   "GL057",
+					Severity: finding.Warn,
+					Job:      job,
+					Message: fmt.Sprintf(
+						"docker run --cap-add %s grants a dangerous capability that can be abused to escape the container or affect the runner host — grant only the minimal capability required",
+						cap,
+					),
+					File: file, Line: line.Line, Col: line.Column,
+				})
+			}
+		}
+	})
+	return findings
+}

--- a/rules/gl057_test.go
+++ b/rules/gl057_test.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings057(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL057.Check(doc.Root, "test.yml")
+}
+
+func TestGL057_CapAddAllIsError(t *testing.T) {
+	f := findings057(t, `
+test:
+  script:
+    - docker run --cap-add ALL myimage ./test.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error || f[0].RuleID != "GL057" {
+		t.Errorf("expected error severity for --cap-add ALL, got %+v", f[0])
+	}
+}
+
+func TestGL057_SysAdminIsWarn(t *testing.T) {
+	f := findings057(t, `
+test:
+  script:
+    - docker run --cap-add SYS_ADMIN myimage ./mount-test.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected warn severity for SYS_ADMIN, got %q", f[0].Severity)
+	}
+}
+
+func TestGL057_EqualsAndCapPrefix(t *testing.T) {
+	f := findings057(t, `
+test:
+  script:
+    - docker run --cap-add=CAP_SYS_PTRACE myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --cap-add=CAP_SYS_PTRACE, got %d", len(f))
+	}
+}
+
+func TestGL057_MultipleCapsOneLine(t *testing.T) {
+	f := findings057(t, `
+test:
+  script:
+    - docker run --cap-add ALL --cap-add NET_ADMIN myimage
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL057_SafeCapNotFlagged(t *testing.T) {
+	f := findings057(t, `
+test:
+  script:
+    - docker run --cap-add NET_BIND_SERVICE myimage ./server-test.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for NET_BIND_SERVICE, got %d", len(f))
+	}
+}
+
+func TestGL057_NoDockerRun(t *testing.T) {
+	f := findings057(t, `
+test:
+  script:
+    - echo "--cap-add SYS_ADMIN documented in our README"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without docker run, got %d", len(f))
+	}
+}
+
+func TestGL057_CommentNotFlagged(t *testing.T) {
+	f := findings057(t, `
+test:
+  script:
+    - "# docker run --cap-add ALL would be dangerous"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -59,6 +59,7 @@ var owaspCategories = map[string][]string{
 	"GL054": {"CICD-SEC-7"},
 	"GL055": {"CICD-SEC-5"},
 	"GL056": {"CICD-SEC-7"},
+	"GL057": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl057-docker-run-cap-add.yml
+++ b/testdata/fixtures/gl057-docker-run-cap-add.yml
@@ -1,0 +1,8 @@
+# docker run --cap-add with dangerous Linux capabilities.
+test:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker run --cap-add ALL myimage ./test.sh
+    - docker run --cap-add SYS_ADMIN myimage ./mount-test.sh


### PR DESCRIPTION
## Summary

New rule **GL057**: flags `docker run --cap-add` granting dangerous Linux capabilities in a CI script. Closes #218.

- `--cap-add ALL` → **error** (equivalent to `--privileged`)
- `--cap-add SYS_ADMIN` / `SYS_PTRACE` / `SYS_MODULE` / `NET_ADMIN` → **warn**

## Detection

Script lines invoking `docker run` (reuses GL056's `dockerRunRe`) with a `--cap-add` flag. Handles `--cap-add NAME` and `--cap-add=NAME`, with optional `CAP_` prefix, case-insensitively. Multiple `--cap-add` flags on one line produce one finding each. Comment lines skipped.

The dangerous-capability set is curated (the four from the issue); common low-risk caps like `NET_BIND_SERVICE` are not flagged.

## Mappings

- OWASP: CICD-SEC-7 (Insecure System Configuration)
- CWE: CWE-250 (Execution with Unnecessary Privileges)

## Files

- `rules/gl057.go` + `rules/gl057_test.go` (7 cases: ALL→error, SYS_ADMIN→warn, `=`/`CAP_` form, multiple caps, safe cap skip, no-docker-run skip, comment skip)
- Registered in `all.go`, `owasp.go`, `cwe.go`
- `docs/rules/GL057.md`, `docs/rules.md`, README count 56→57 + table
- `testdata/fixtures/gl057-docker-run-cap-add.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl057-docker-run-cap-add.yml   # ALL→error, SYS_ADMIN→warn
```

Closes #218. Second in the #217–#222 docker-run hardening series.