### PR TITLE
feat: GL058 — docker run --network host (#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-57 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+58 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -103,7 +103,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -112,3 +112,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL054](rules/GL054.md) | `warn`  | `docker:dind` service (or `DOCKER_HOST` pointing at it) implies a privileged runner with full host root access |
 | [GL056](rules/GL056.md) | `warn`  | `docker run --privileged` in a script grants the container full host kernel access |
 | [GL057](rules/GL057.md) | `error`/`warn` | `docker run --cap-add` with dangerous Linux capabilities (`ALL`, `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `NET_ADMIN`) |
+| [GL058](rules/GL058.md) | `warn`  | `docker run --network host` removes network isolation from the runner host |

--- a/docs/rules/GL058.md
+++ b/docs/rules/GL058.md
@@ -1,0 +1,39 @@
+# GL058 — `docker run --network host` in CI script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-653 – Improper Isolation or Compartmentalization](https://cwe.mitre.org/data/definitions/653.html)
+
+## Risk
+
+`docker run --network host` removes all network isolation between the container and the runner host. The container shares the host's network stack directly — it can bind to any port, intercept traffic on the host interface, reach services bound to localhost (metadata APIs, internal databases, other containers' exposed ports), and potentially communicate with the broader runner network without any firewall boundary.
+
+In CI this pattern is often used for performance (avoiding NAT overhead) but silently eliminates a meaningful security boundary.
+
+## Trigger example
+
+```yaml
+test:
+  script:
+    - docker run --network host myimage ./integration-test.sh
+```
+
+Both `--network host` and the `--net host` short form are detected, space- or `=`-separated.
+
+## Safe alternative
+
+Use a named network or the default bridge:
+
+```yaml
+test:
+  script:
+    - docker network create test-net
+    - docker run --network test-net myimage ./integration-test.sh
+```
+
+## Notes
+
+- Severity is `warn` — sometimes a deliberate performance choice, but it removes a security boundary and should be justified.
+- Related: [GL056](GL056.md) (`--privileged`), [GL057](GL057.md) (`--cap-add`).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL058`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -61,5 +61,6 @@ func All() []rule.Rule {
 		GL055,
 		GL056,
 		GL057,
+		GL058,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -59,6 +59,7 @@ var cweIDs = map[string]string{
 	"GL055": "CWE-250",
 	"GL056": "CWE-250",
 	"GL057": "CWE-250",
+	"GL058": "CWE-653",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -80,6 +81,7 @@ var cweNames = map[string]string{
 	"CWE-250":  "Execution with Unnecessary Privileges",
 	"CWE-625":  "Permissive Regular Expression",
 	"CWE-829":  "Inclusion of Functionality from Untrusted Control Sphere",
+	"CWE-653":  "Improper Isolation or Compartmentalization",
 	"CWE-1104": "Use of Unmaintained Third-Party Components",
 }
 

--- a/rules/gl058.go
+++ b/rules/gl058.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl058 struct{}
+
+var GL058 = &gl058{}
+
+func (r *gl058) ID() string { return "GL058" }
+
+// networkHostRe matches --network host / --net host (space or = separated).
+var networkHostRe = regexp.MustCompile(`--net(?:work)?[=\s]+host(?:\s|$)`)
+
+func (r *gl058) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerRunRe.MatchString(v) || !networkHostRe.MatchString(v) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL058",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "docker run --network host removes network isolation — the container shares the runner's network stack and can reach localhost services (metadata APIs, internal DBs) and bind any port; use a named network or the default bridge",
+			File:     file,
+			Line:     line.Line,
+			Col:      line.Column,
+		})
+	})
+	return findings
+}

--- a/rules/gl058_test.go
+++ b/rules/gl058_test.go
@@ -1,0 +1,98 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings058(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL058.Check(doc.Root, "test.yml")
+}
+
+func TestGL058_NetworkHost(t *testing.T) {
+	f := findings058(t, `
+test:
+  script:
+    - docker run --network host myimage ./integration-test.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL058" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+}
+
+func TestGL058_NetHostShortFlag(t *testing.T) {
+	f := findings058(t, `
+test:
+  script:
+    - docker run --net host myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --net host, got %d", len(f))
+	}
+}
+
+func TestGL058_EqualsForm(t *testing.T) {
+	f := findings058(t, `
+test:
+  script:
+    - docker run --network=host myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --network=host, got %d", len(f))
+	}
+}
+
+func TestGL058_NamedNetworkNotFlagged(t *testing.T) {
+	f := findings058(t, `
+test:
+  script:
+    - docker network create test-net
+    - docker run --network test-net myimage ./integration-test.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for named network, got %d", len(f))
+	}
+}
+
+func TestGL058_HostPrefixedNetworkNotFlagged(t *testing.T) {
+	f := findings058(t, `
+test:
+  script:
+    - docker run --network host-internal myimage
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for network named host-internal, got %d", len(f))
+	}
+}
+
+func TestGL058_NoDockerRun(t *testing.T) {
+	f := findings058(t, `
+test:
+  script:
+    - echo "use --network host for perf"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without docker run, got %d", len(f))
+	}
+}
+
+func TestGL058_CommentNotFlagged(t *testing.T) {
+	f := findings058(t, `
+test:
+  script:
+    - "# docker run --network host is discouraged"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -60,6 +60,7 @@ var owaspCategories = map[string][]string{
 	"GL055": {"CICD-SEC-5"},
 	"GL056": {"CICD-SEC-7"},
 	"GL057": {"CICD-SEC-7"},
+	"GL058": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl058-docker-run-network-host.yml
+++ b/testdata/fixtures/gl058-docker-run-network-host.yml
@@ -1,0 +1,7 @@
+# docker run --network host removes network isolation from the runner host.
+test:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker run --network host myimage ./integration-test.sh


### PR DESCRIPTION
## Summary

New rule **GL058**: warns on `docker run --network host` (or `--net host`) in a CI script. Host networking removes all isolation — the container shares the runner's network stack, can reach localhost services (metadata APIs, internal DBs), bind any port, and sniff host traffic. Closes #219.

## Detection

Script lines invoking `docker run` (reuses `dockerRunRe`) with `--network host` / `--net host`, space- or `=`-separated. A network *named* `host-internal` etc. is not flagged (requires `host` followed by whitespace or end). Comment lines skipped.

## Mappings

- OWASP: CICD-SEC-7 (Insecure System Configuration)
- CWE: CWE-653 (Improper Isolation or Compartmentalization) — new entry added to `cweNames`

## Files

- `rules/gl058.go` + `rules/gl058_test.go` (7 cases: `--network host`, `--net host`, `=` form, named network skip, `host-internal` skip, no-docker-run skip, comment skip)
- Registered in `all.go`, `owasp.go`, `cwe.go` (+ CWE-653 name)
- `docs/rules/GL058.md`, `docs/rules.md`, README count 57→58 + table
- `testdata/fixtures/gl058-docker-run-network-host.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl058-docker-run-network-host.yml
```

Closes #219. Third in the #217–#222 docker-run hardening series.