### PR TITLE
feat: GL059 — docker build --build-arg with secret-like value (#220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ exclude_paths:
 
 ## Rules
 
-58 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+59 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052 |
+| Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026, GL046 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,6 +27,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |
 | [GL040](rules/GL040.md) | `warn`  | Script uses plain `ftp://` — credentials and content transmitted unencrypted |
 | [GL052](rules/GL052.md) | `warn`  | User-controlled variable in `environment:name:` — attacker can craft a branch name that resolves to a protected environment and access its secrets |
+| [GL059](rules/GL059.md) | `warn`  | `docker build --build-arg` with a secret-keyword name bakes the value into image layer metadata (visible via `docker history`) |
 
 ---
 

--- a/docs/rules/GL059.md
+++ b/docs/rules/GL059.md
@@ -1,0 +1,41 @@
+# GL059 — `docker build --build-arg` with a secret-like value
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
+**CWE:** [CWE-532 – Insertion of Sensitive Information into Log File](https://cwe.mitre.org/data/definitions/532.html)
+
+## Risk
+
+Passing secrets via `docker build --build-arg` bakes them into the image's layer metadata. Even if the final image doesn't expose the value at runtime, `docker history --no-trunc` reveals all build arguments in plaintext. Any party with read access to the image — the registry, a CI artifact store, a colleague pulling the image — can extract the secret.
+
+This is a common pattern developers use to inject API keys, tokens, or passwords into the build process without realising the value persists in the image.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t myapp .
+```
+
+Flagged when the build-arg name contains a secret keyword (`TOKEN`, `SECRET`, `PASSWORD`, `PASS`, `KEY`, `CREDENTIAL`, `AUTH`) as an underscore- or boundary-delimited token. Generic args like `--build-arg VERSION=1.0` or `--build-arg BYPASS_CACHE=true` are not flagged.
+
+## Safe alternative
+
+Use Docker BuildKit secret mounts — the secret is available during build but never written to any layer:
+
+```yaml
+build:
+  script:
+    - echo "$NPM_TOKEN" > /tmp/npm_token
+    - docker build --secret id=npm_token,src=/tmp/npm_token -t myapp .
+    # In Dockerfile: RUN --mount=type=secret,id=npm_token npm install
+```
+
+## Notes
+
+- Severity is `warn` — the value may already be non-sensitive, but a secret-keyword build-arg name is a strong signal.
+- Detection is name-based and value-agnostic: both `--build-arg API_KEY=$API_KEY` and `--build-arg API_KEY=literal` are flagged.
+- Related: [GL006](GL006.md) (hardcoded secrets in `variables:`), [GL021](GL021.md) (secret printed to log).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL059`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -62,5 +62,6 @@ func All() []rule.Rule {
 		GL056,
 		GL057,
 		GL058,
+		GL059,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -60,6 +60,7 @@ var cweIDs = map[string]string{
 	"GL056": "CWE-250",
 	"GL057": "CWE-250",
 	"GL058": "CWE-653",
+	"GL059": "CWE-532",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl059.go
+++ b/rules/gl059.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl059 struct{}
+
+var GL059 = &gl059{}
+
+func (r *gl059) ID() string { return "GL059" }
+
+var (
+	dockerBuildRe = regexp.MustCompile(`\bdocker\s+(?:buildx\s+)?build\b`)
+	buildArgRe    = regexp.MustCompile(`--build-arg[=\s]+([A-Za-z_][A-Za-z0-9_]*)`)
+	// secretArgNameRe matches a secret keyword as an underscore- or
+	// boundary-delimited token, so NPM_TOKEN / API_KEY / DB_PASSWORD match but
+	// BYPASS_CACHE / VERSION / MONKEY do not.
+	secretArgNameRe = regexp.MustCompile(`(^|_)(TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIAL|AUTH)(_|$)`)
+)
+
+func (r *gl059) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerBuildRe.MatchString(v) {
+			return
+		}
+		for _, m := range buildArgRe.FindAllStringSubmatch(v, -1) {
+			name := m[1]
+			if !secretArgNameRe.MatchString(strings.ToUpper(name)) {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL059",
+				Severity: finding.Warn,
+				Job:      job,
+				Message: fmt.Sprintf(
+					"docker build --build-arg %s embeds a secret into image layer metadata (visible via `docker history --no-trunc`) — use BuildKit secret mounts (--secret id=...) instead",
+					name,
+				),
+				File: file, Line: line.Line, Col: line.Column,
+			})
+		}
+	})
+	return findings
+}

--- a/rules/gl059_test.go
+++ b/rules/gl059_test.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings059(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL059.Check(doc.Root, "test.yml")
+}
+
+func TestGL059_TokenBuildArg(t *testing.T) {
+	f := findings059(t, `
+build:
+  script:
+    - docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t myapp .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL059" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+}
+
+func TestGL059_LiteralPassword(t *testing.T) {
+	f := findings059(t, `
+build:
+  script:
+    - docker build --build-arg PASSWORD=hunter2 .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for PASSWORD literal, got %d", len(f))
+	}
+}
+
+func TestGL059_BuildxAndEqualsForm(t *testing.T) {
+	f := findings059(t, `
+build:
+  script:
+    - docker buildx build --build-arg=API_KEY=$API_KEY -t myapp .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for buildx + =form, got %d", len(f))
+	}
+}
+
+func TestGL059_MultipleArgs(t *testing.T) {
+	f := findings059(t, `
+build:
+  script:
+    - docker build --build-arg VERSION=1.0 --build-arg AUTH_TOKEN=$AUTH_TOKEN -t myapp .
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding (only AUTH_TOKEN, not VERSION), got %d", len(f))
+	}
+}
+
+func TestGL059_GenericArgNotFlagged(t *testing.T) {
+	f := findings059(t, `
+build:
+  script:
+    - docker build --build-arg VERSION=1.0 --build-arg BYPASS_CACHE=true -t myapp .
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for VERSION/BYPASS_CACHE, got %d", len(f))
+	}
+}
+
+func TestGL059_SecretMountNotFlagged(t *testing.T) {
+	f := findings059(t, `
+build:
+  script:
+    - docker build --secret id=npm_token,src=/tmp/npm_token -t myapp .
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for --secret mount, got %d", len(f))
+	}
+}
+
+func TestGL059_CommentNotFlagged(t *testing.T) {
+	f := findings059(t, `
+build:
+  script:
+    - "# docker build --build-arg API_KEY=$API_KEY is unsafe"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -61,6 +61,7 @@ var owaspCategories = map[string][]string{
 	"GL056": {"CICD-SEC-7"},
 	"GL057": {"CICD-SEC-7"},
 	"GL058": {"CICD-SEC-7"},
+	"GL059": {"CICD-SEC-6"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl059-docker-build-arg-secret.yml
+++ b/testdata/fixtures/gl059-docker-build-arg-secret.yml
@@ -1,0 +1,7 @@
+# docker build --build-arg with a secret-like name bakes the value into image layers.
+build:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t myapp .


### PR DESCRIPTION
## Summary

New rule **GL059**: warns when `docker build --build-arg` uses a secret-keyword arg name. Build args are baked into image layer metadata and recoverable via `docker history --no-trunc` by anyone with image read access. Closes #220.

## Detection

Script lines invoking `docker build` / `docker buildx build` with `--build-arg NAME=...` where `NAME` contains a secret keyword (`TOKEN`, `SECRET`, `PASSWORD`, `PASS`, `KEY`, `CREDENTIAL`, `AUTH`) as an underscore/boundary-delimited token. Name-based and value-agnostic.

False-positive guard: the keyword must be a delimited token, so `NPM_TOKEN`/`API_KEY`/`DB_PASSWORD` match while `VERSION`, `BYPASS_CACHE`, `MONKEY` do not. `--secret` mounts (the safe alternative) are not flagged.

## Mappings

- OWASP: CICD-SEC-6 (Insufficient Credential Hygiene)
- CWE: CWE-532 (Insertion of Sensitive Information into Log File)

## Files

- `rules/gl059.go` + `rules/gl059_test.go` (7 cases: token arg, literal password, buildx + `=` form, multiple args, generic-arg skip, `--secret` skip, comment skip)
- Registered in `all.go`, `owasp.go`, `cwe.go`
- `docs/rules/GL059.md`, `docs/rules.md`, README count 58→59 + table
- `testdata/fixtures/gl059-docker-build-arg-secret.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl059-docker-build-arg-secret.yml
```

Closes #220. Fourth in the #217–#222 docker hardening series.