### PR TITLE
feat: GL060 — docker run mounting sensitive host paths (#221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-59 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+60 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -103,7 +103,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -114,3 +114,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL056](rules/GL056.md) | `warn`  | `docker run --privileged` in a script grants the container full host kernel access |
 | [GL057](rules/GL057.md) | `error`/`warn` | `docker run --cap-add` with dangerous Linux capabilities (`ALL`, `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `NET_ADMIN`) |
 | [GL058](rules/GL058.md) | `warn`  | `docker run --network host` removes network isolation from the runner host |
+| [GL060](rules/GL060.md) | `error`/`warn` | `docker run -v` mounts a sensitive host path (`/`, `/etc`, `/root`, `/proc`, `/sys`, …) breaking isolation |

--- a/docs/rules/GL060.md
+++ b/docs/rules/GL060.md
@@ -1,0 +1,46 @@
+# GL060 — `docker run` mounting sensitive host paths
+
+**Severity:** `error` for `/`, `/etc`, `/root`, `/proc`, `/sys`; `warn` for `/var/run`, `/dev`, `/boot`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-552 – Files or Directories Accessible to External Parties](https://cwe.mitre.org/data/definitions/552.html)
+
+## Risk
+
+Mounting sensitive host filesystem paths into a container via `docker run -v` breaks container isolation. A compromised job or malicious dependency can read or write host files outside the container boundary.
+
+Particularly dangerous source paths:
+
+- `/` — full root filesystem access
+- `/etc` — read/write system config (`/etc/passwd`, `/etc/shadow`, `/etc/sudoers`)
+- `/root` — root home directory including SSH keys
+- `/proc` — host process information and kernel interfaces
+- `/sys` — kernel and hardware control interfaces
+- `/var/run` — runtime sockets (the Docker socket specifically is covered by [GL055](GL055.md))
+
+## Trigger example
+
+```yaml
+test:
+  script:
+    - docker run -v /:/host -it myimage chroot /host
+```
+
+Both `-v` and `--volume` are detected. **The source side of the bind mount is what matters** — `-v /etc:/anything` is flagged regardless of the destination inside the container. Subpaths count too (`-v /root/.ssh:/keys`).
+
+## Safe alternative
+
+Mount only the specific project directory or a named Docker volume:
+
+```yaml
+test:
+  script:
+    - docker run -v $CI_PROJECT_DIR:/app myimage ./test.sh
+```
+
+## Notes
+
+- `error` for `/`, `/etc`, `/root`, `/proc`, `/sys`; `warn` for `/var/run`, `/dev`, `/boot`.
+- Named volumes (`-v cache:/cache`), relative paths, and non-sensitive absolute paths (`/tmp/build`) are not flagged.
+- Related: [GL055](GL055.md) (Docker socket mount), [GL056](GL056.md) (`--privileged`).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL060`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -63,5 +63,6 @@ func All() []rule.Rule {
 		GL057,
 		GL058,
 		GL059,
+		GL060,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -61,6 +61,7 @@ var cweIDs = map[string]string{
 	"GL057": "CWE-250",
 	"GL058": "CWE-653",
 	"GL059": "CWE-532",
+	"GL060": "CWE-552",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -83,6 +84,7 @@ var cweNames = map[string]string{
 	"CWE-625":  "Permissive Regular Expression",
 	"CWE-829":  "Inclusion of Functionality from Untrusted Control Sphere",
 	"CWE-653":  "Improper Isolation or Compartmentalization",
+	"CWE-552":  "Files or Directories Accessible to External Parties",
 	"CWE-1104": "Use of Unmaintained Third-Party Components",
 }
 

--- a/rules/gl060.go
+++ b/rules/gl060.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl060 struct{}
+
+var GL060 = &gl060{}
+
+func (r *gl060) ID() string { return "GL060" }
+
+// volumeFlagRe captures the volume spec passed to -v / --volume.
+var volumeFlagRe = regexp.MustCompile(`(?:^|\s)(?:--volume|-v)[=\s]+(\S+)`)
+
+// errorMountPaths are host source paths whose exposure is critical.
+var errorMountPaths = []string{"/etc", "/root", "/proc", "/sys"}
+
+// warnMountPaths are host source paths that are sensitive but lower-impact.
+var warnMountPaths = []string{"/var/run", "/dev", "/boot"}
+
+func (r *gl060) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerRunRe.MatchString(v) {
+			return
+		}
+		for _, m := range volumeFlagRe.FindAllStringSubmatch(v, -1) {
+			src := volumeSource(m[1])
+			sev, ok := hostMountSeverity(src)
+			if !ok {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL060",
+				Severity: sev,
+				Job:      job,
+				Message: fmt.Sprintf(
+					"docker run mounts sensitive host path %q — breaks container isolation; the job can read/write host files outside the container. Mount only $CI_PROJECT_DIR or a named volume",
+					src,
+				),
+				File: file, Line: line.Line, Col: line.Column,
+			})
+		}
+	})
+	return findings
+}
+
+// volumeSource returns the host (source) side of a bind-mount spec SRC:DST[:opts].
+func volumeSource(spec string) string {
+	if i := strings.Index(spec, ":"); i >= 0 {
+		return spec[:i]
+	}
+	return spec
+}
+
+func hostMountSeverity(src string) (finding.Severity, bool) {
+	if src == "/" {
+		return finding.Error, true
+	}
+	if !strings.HasPrefix(src, "/") {
+		return "", false // named volume or relative path
+	}
+	src = strings.TrimSuffix(src, "/")
+	for _, p := range errorMountPaths {
+		if src == p || strings.HasPrefix(src, p+"/") {
+			return finding.Error, true
+		}
+	}
+	for _, p := range warnMountPaths {
+		if src == p || strings.HasPrefix(src, p+"/") {
+			return finding.Warn, true
+		}
+	}
+	return "", false
+}

--- a/rules/gl060_test.go
+++ b/rules/gl060_test.go
@@ -1,0 +1,108 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings060(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL060.Check(doc.Root, "test.yml")
+}
+
+func TestGL060_RootMountIsError(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - docker run -v /:/host -it myimage chroot /host
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error || f[0].RuleID != "GL060" {
+		t.Errorf("expected error severity for / mount, got %+v", f[0])
+	}
+}
+
+func TestGL060_EtcMountIsError(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - docker run -v /etc:/etc myimage
+`)
+	if len(f) != 1 || f[0].Severity != finding.Error {
+		t.Fatalf("expected 1 error finding for /etc, got %+v", f)
+	}
+}
+
+func TestGL060_VolumeLongFlagAndSubpath(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - docker run --volume /root/.ssh:/keys myimage
+`)
+	if len(f) != 1 || f[0].Severity != finding.Error {
+		t.Fatalf("expected 1 error finding for /root subpath, got %+v", f)
+	}
+}
+
+func TestGL060_VarRunIsWarn(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - docker run -v /var/run:/var/run myimage
+`)
+	if len(f) != 1 || f[0].Severity != finding.Warn {
+		t.Fatalf("expected 1 warn finding for /var/run, got %+v", f)
+	}
+}
+
+func TestGL060_ProjectDirNotFlagged(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - docker run -v $CI_PROJECT_DIR:/app myimage ./test.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for project dir mount, got %d", len(f))
+	}
+}
+
+func TestGL060_NamedVolumeNotFlagged(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - docker run -v cache-vol:/cache myimage
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for named volume, got %d", len(f))
+	}
+}
+
+func TestGL060_NonSensitiveAbsolutePathNotFlagged(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - docker run -v /tmp/build:/build myimage
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for /tmp/build, got %d", len(f))
+	}
+}
+
+func TestGL060_CommentNotFlagged(t *testing.T) {
+	f := findings060(t, `
+test:
+  script:
+    - "# docker run -v /etc:/etc would be dangerous"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -62,6 +62,7 @@ var owaspCategories = map[string][]string{
 	"GL057": {"CICD-SEC-7"},
 	"GL058": {"CICD-SEC-7"},
 	"GL059": {"CICD-SEC-6"},
+	"GL060": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl060-docker-run-host-mount.yml
+++ b/testdata/fixtures/gl060-docker-run-host-mount.yml
@@ -1,0 +1,7 @@
+# docker run -v mounting a sensitive host path breaks container isolation.
+test:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker run -v /:/host -it myimage chroot /host


### PR DESCRIPTION
## Summary

New rule **GL060**: flags `docker run -v` / `--volume` bind-mounts of sensitive host paths, which break container isolation. Closes #221.

- **error**: `/`, `/etc`, `/root`, `/proc`, `/sys`
- **warn**: `/var/run`, `/dev`, `/boot`

## Detection

Script lines invoking `docker run` (reuses `dockerRunRe`) with `-v SRC:DST` / `--volume SRC:DST`. The **source** side is what's evaluated — `-v /etc:/anything` is flagged regardless of destination. Subpaths count (`/root/.ssh`). Named volumes, relative paths, and non-sensitive absolute paths (`/tmp/build`, `$CI_PROJECT_DIR`) are not flagged. Comment lines skipped.

## Mappings

- OWASP: CICD-SEC-7 (Insecure System Configuration)
- CWE: CWE-552 (Files or Directories Accessible to External Parties) — new entry added to `cweNames`

## Files

- `rules/gl060.go` + `rules/gl060_test.go` (8 cases: `/`→error, `/etc`→error, `/root/.ssh` subpath→error, `/var/run`→warn, project-dir skip, named-volume skip, `/tmp/build` skip, comment skip)
- Registered in `all.go`, `owasp.go`, `cwe.go` (+ CWE-552 name)
- `docs/rules/GL060.md`, `docs/rules.md`, README count 59→60 + table
- `testdata/fixtures/gl060-docker-run-host-mount.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl060-docker-run-host-mount.yml   # / mount → error
```

Closes #221. Fifth in the #217–#222 docker hardening series — only #222 (`--pid host`) remains.