### PR TITLE
feat: GL061 — docker run --pid host (#222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-60 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+61 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -103,7 +103,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -115,3 +115,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL057](rules/GL057.md) | `error`/`warn` | `docker run --cap-add` with dangerous Linux capabilities (`ALL`, `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `NET_ADMIN`) |
 | [GL058](rules/GL058.md) | `warn`  | `docker run --network host` removes network isolation from the runner host |
 | [GL060](rules/GL060.md) | `error`/`warn` | `docker run -v` mounts a sensitive host path (`/`, `/etc`, `/root`, `/proc`, `/sys`, …) breaking isolation |
+| [GL061](rules/GL061.md) | `warn`  | `docker run --pid host` shares the host PID namespace — container can see/signal all host processes |

--- a/docs/rules/GL061.md
+++ b/docs/rules/GL061.md
@@ -1,0 +1,36 @@
+# GL061 — `docker run --pid host` in CI script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-653 – Improper Isolation or Compartmentalization](https://cwe.mitre.org/data/definitions/653.html)
+
+## Risk
+
+`docker run --pid host` makes the container share the host's PID namespace. The container can see and interact with all processes running on the runner host — including processes from other CI jobs, the GitLab Runner agent itself, and any privileged system processes. Combined with `/proc` access this allows reading memory of other processes, injecting code, or killing critical services.
+
+## Trigger example
+
+```yaml
+test:
+  script:
+    - docker run --pid host myimage ./perf-test.sh
+```
+
+Both `--pid host` and `--pid=host` are detected.
+
+## Safe alternative
+
+Omit `--pid` (the default is an isolated PID namespace). If process visibility is genuinely needed for profiling or debugging, scope it to a specific container rather than the host:
+
+```yaml
+test:
+  script:
+    - docker run --pid container:abc123 myimage ./profile.sh
+```
+
+## Notes
+
+- Severity is `warn`.
+- Related: [GL056](GL056.md) (`--privileged`), [GL057](GL057.md) (`--cap-add SYS_PTRACE`).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL061`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -64,5 +64,6 @@ func All() []rule.Rule {
 		GL058,
 		GL059,
 		GL060,
+		GL061,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -62,6 +62,7 @@ var cweIDs = map[string]string{
 	"GL058": "CWE-653",
 	"GL059": "CWE-532",
 	"GL060": "CWE-552",
+	"GL061": "CWE-653",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl061.go
+++ b/rules/gl061.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl061 struct{}
+
+var GL061 = &gl061{}
+
+func (r *gl061) ID() string { return "GL061" }
+
+// pidHostRe matches --pid host / --pid=host.
+var pidHostRe = regexp.MustCompile(`--pid[=\s]+host(?:\s|$)`)
+
+func (r *gl061) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerRunRe.MatchString(v) || !pidHostRe.MatchString(v) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL061",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "docker run --pid host shares the host PID namespace — the container can see, signal, and read memory of all host processes (other jobs, the runner agent); omit --pid or scope it with --pid container:<id>",
+			File:     file,
+			Line:     line.Line,
+			Col:      line.Column,
+		})
+	})
+	return findings
+}

--- a/rules/gl061_test.go
+++ b/rules/gl061_test.go
@@ -1,0 +1,86 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings061(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL061.Check(doc.Root, "test.yml")
+}
+
+func TestGL061_PidHost(t *testing.T) {
+	f := findings061(t, `
+test:
+  script:
+    - docker run --pid host myimage ./perf-test.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL061" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+}
+
+func TestGL061_PidHostEqualsForm(t *testing.T) {
+	f := findings061(t, `
+test:
+  script:
+    - docker run --pid=host myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --pid=host, got %d", len(f))
+	}
+}
+
+func TestGL061_PidContainerNotFlagged(t *testing.T) {
+	f := findings061(t, `
+test:
+  script:
+    - docker run --pid container:abc123 myimage
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for --pid container:, got %d", len(f))
+	}
+}
+
+func TestGL061_NoPidFlag(t *testing.T) {
+	f := findings061(t, `
+test:
+  script:
+    - docker run myimage ./perf-test.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without --pid, got %d", len(f))
+	}
+}
+
+func TestGL061_NoDockerRun(t *testing.T) {
+	f := findings061(t, `
+test:
+  script:
+    - echo "use --pid host for profiling"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without docker run, got %d", len(f))
+	}
+}
+
+func TestGL061_CommentNotFlagged(t *testing.T) {
+	f := findings061(t, `
+test:
+  script:
+    - "# docker run --pid host is discouraged"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -63,6 +63,7 @@ var owaspCategories = map[string][]string{
 	"GL058": {"CICD-SEC-7"},
 	"GL059": {"CICD-SEC-6"},
 	"GL060": {"CICD-SEC-7"},
+	"GL061": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl061-docker-run-pid-host.yml
+++ b/testdata/fixtures/gl061-docker-run-pid-host.yml
@@ -1,0 +1,7 @@
+# docker run --pid host shares the host PID namespace with the container.
+test:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker run --pid host myimage ./perf-test.sh


### PR DESCRIPTION
## Summary

New rule **GL061**: warns on `docker run --pid host` (or `--pid=host`) in a CI script. Sharing the host PID namespace lets the container see, signal, and read memory of all host processes — other CI jobs, the runner agent, system services. Closes #222.

## Detection

Script lines invoking `docker run` (reuses `dockerRunRe`) with `--pid host` / `--pid=host`. `--pid container:<id>` is not flagged (scoped, safe alternative). Comment lines skipped.

## Mappings

- OWASP: CICD-SEC-7 (Insecure System Configuration)
- CWE: CWE-653 (Improper Isolation or Compartmentalization)

## Files

- `rules/gl061.go` + `rules/gl061_test.go` (6 cases: `--pid host`, `=` form, `container:` skip, no-pid skip, no-docker-run skip, comment skip)
- Registered in `all.go`, `owasp.go`, `cwe.go`
- `docs/rules/GL061.md`, `docs/rules.md`, README count 60→61 + table
- `testdata/fixtures/gl061-docker-run-pid-host.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl061-docker-run-pid-host.yml
```

Closes #222. **Completes the #217–#222 docker-run hardening series** (GL056 `--privileged`, GL057 `--cap-add`, GL058 `--network host`, GL059 `--build-arg`, GL060 host mounts, GL061 `--pid host`).