### PR TITLE
feat: GL062 — printenv/env dumps all variables to job log (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ exclude_paths:
 
 ## Rules
 
-61 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+62 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059 |
+| Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026, GL046 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -28,6 +28,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL040](rules/GL040.md) | `warn`  | Script uses plain `ftp://` — credentials and content transmitted unencrypted |
 | [GL052](rules/GL052.md) | `warn`  | User-controlled variable in `environment:name:` — attacker can craft a branch name that resolves to a protected environment and access its secrets |
 | [GL059](rules/GL059.md) | `warn`  | `docker build --build-arg` with a secret-keyword name bakes the value into image layer metadata (visible via `docker history`) |
+| [GL062](rules/GL062.md) | `warn`  | `printenv` or bare `env` dumps every variable (including secrets) to the job log |
 
 ---
 

--- a/docs/rules/GL062.md
+++ b/docs/rules/GL062.md
@@ -1,0 +1,46 @@
+# GL062 — `printenv` or bare `env` dumps all variables to the job log
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
+**CWE:** [CWE-532 – Insertion of Sensitive Information into Log File](https://cwe.mitre.org/data/definitions/532.html)
+
+## Risk
+
+Running `printenv` or bare `env` in a CI script dumps every environment variable to the job log — including all CI/CD secrets, tokens, and masked variables. GitLab masks known secret variable values in logs, but masking is not guaranteed for all formats (short values, values with special characters, values that appear mid-line). Any third party with read access to the job log can potentially extract credentials.
+
+[GL021](GL021.md) already flags `echo`/`printf` of individual secret variables. This rule covers the broader pattern of dumping the entire environment.
+
+## Trigger example
+
+```yaml
+debug:
+  script:
+    - printenv   # dumps all variables to the log
+    - env
+```
+
+`/usr/bin/env`, and forms with shell separators (`printenv && ...`, `cd /tmp; env`), are also detected.
+
+## What is not flagged
+
+- `printenv VAR_NAME` — printing a specific variable (same risk class as `echo`, covered by GL021)
+- `env VAR=value command` — setting a variable for a subprocess
+- `env python script.py` — using `env` as a command runner
+
+## Safe alternative
+
+Print only the specific variables needed for debugging:
+
+```yaml
+debug:
+  script:
+    - echo "CI_COMMIT_REF=$CI_COMMIT_REF_NAME"
+    - echo "DEPLOY_ENV=$DEPLOY_ENV"
+```
+
+## Notes
+
+- Severity is `warn`.
+- Related: [GL021](GL021.md) (individual secret printed via echo/printf), [GL033](GL033.md) (`CI_DEBUG_TRACE` exposes all variables).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL062`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -65,5 +65,6 @@ func All() []rule.Rule {
 		GL059,
 		GL060,
 		GL061,
+		GL062,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -63,6 +63,7 @@ var cweIDs = map[string]string{
 	"GL059": "CWE-532",
 	"GL060": "CWE-552",
 	"GL061": "CWE-653",
+	"GL062": "CWE-532",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl062.go
+++ b/rules/gl062.go
@@ -1,0 +1,45 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl062 struct{}
+
+var GL062 = &gl062{}
+
+func (r *gl062) ID() string { return "GL062" }
+
+// envFullDumpRe matches a standalone `printenv` or `env` command (optionally
+// path-prefixed) with no arguments — i.e. one that dumps the entire
+// environment. The command must sit at a shell command boundary and be
+// followed immediately by end-of-line or a shell separator, so
+// `printenv VAR` and `env VAR=v cmd` are not matched.
+var envFullDumpRe = regexp.MustCompile(`(?:^|[;&|(])\s*(?:/usr/bin/|/bin/)?(?:printenv|env)\s*(?:$|[;&|#)])`)
+
+func (r *gl062) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !envFullDumpRe.MatchString(v) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL062",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "printenv/env with no arguments dumps every environment variable to the job log, including CI/CD secrets and tokens that may not be reliably masked — print only the specific variables you need",
+			File:     file,
+			Line:     line.Line,
+			Col:      line.Column,
+		})
+	})
+	return findings
+}

--- a/rules/gl062_test.go
+++ b/rules/gl062_test.go
@@ -1,0 +1,130 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings062(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL062.Check(doc.Root, "test.yml")
+}
+
+func TestGL062_Printenv(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - printenv
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL062" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+}
+
+func TestGL062_BareEnv(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for bare env, got %d", len(f))
+	}
+}
+
+func TestGL062_UsrBinEnv(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - /usr/bin/env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for /usr/bin/env, got %d", len(f))
+	}
+}
+
+func TestGL062_PrintenvWithVarNotFlagged(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - printenv DEPLOY_ENV
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for printenv VAR, got %d", len(f))
+	}
+}
+
+func TestGL062_EnvSetVarNotFlagged(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - env FOO=bar ./run.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for env VAR=v cmd, got %d", len(f))
+	}
+}
+
+func TestGL062_EnvRunCommandNotFlagged(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - env python script.py
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for env <command>, got %d", len(f))
+	}
+}
+
+func TestGL062_PrintenvWithSeparator(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - printenv && echo done
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 'printenv &&', got %d", len(f))
+	}
+}
+
+func TestGL062_EnvAfterSemicolon(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - cd /tmp; env
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for '; env', got %d", len(f))
+	}
+}
+
+func TestGL062_CommentNotFlagged(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - "# printenv would leak everything"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}
+
+func TestGL062_EnvironmentWordNotFlagged(t *testing.T) {
+	f := findings062(t, `
+debug:
+  script:
+    - environment_setup.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for word containing env, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -64,6 +64,7 @@ var owaspCategories = map[string][]string{
 	"GL059": {"CICD-SEC-6"},
 	"GL060": {"CICD-SEC-7"},
 	"GL061": {"CICD-SEC-7"},
+	"GL062": {"CICD-SEC-6"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl062-env-dump.yml
+++ b/testdata/fixtures/gl062-env-dump.yml
@@ -1,0 +1,6 @@
+# printenv / bare env dump every variable, including secrets, to the job log.
+debug:
+  image: alpine:3.20
+  script:
+    - printenv
+    - env


### PR DESCRIPTION
## Summary

New rule **GL062**: warns on `printenv` or bare `env` in a CI script, which dump every environment variable — including secrets and tokens that may not be reliably masked — to the job log. Closes #223.

## Detection

A standalone `printenv` / `env` (optionally `/usr/bin/`-prefixed) with **no arguments**, at a shell command boundary (line start or after `;` `&` `|` `(`) and followed by end-of-line or a separator.

Not flagged:
- `printenv VAR_NAME` (specific variable — GL021's domain)
- `env VAR=value command` (setting a var for a subprocess)
- `env python script.py` (command runner)

Handles separators (`printenv && ...`, `cd /tmp; env`) and avoids matching words like `environment_setup.sh`. Comment lines skipped.

## Mappings

- OWASP: CICD-SEC-6 (Insufficient Credential Hygiene)
- CWE: CWE-532 (Insertion of Sensitive Information into Log File)

## Files

- `rules/gl062.go` + `rules/gl062_test.go` (10 cases incl. all the not-flagged forms, separators, and the `environment` word guard)
- Registered in `all.go`, `owasp.go`, `cwe.go`
- `docs/rules/GL062.md`, `docs/rules.md`, README count 61→62 + table
- `testdata/fixtures/gl062-env-dump.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl062-env-dump.yml   # printenv + env both flagged
```

Closes #223.