### PR TITLE
feat: GL063 — chmod world-writable permissions (#224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ exclude_paths:
 
 ## Rules
 
-62 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+63 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -103,7 +103,7 @@ exclude_paths:
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
 | Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061 |
+| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -117,3 +117,4 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL058](rules/GL058.md) | `warn`  | `docker run --network host` removes network isolation from the runner host |
 | [GL060](rules/GL060.md) | `error`/`warn` | `docker run -v` mounts a sensitive host path (`/`, `/etc`, `/root`, `/proc`, `/sys`, …) breaking isolation |
 | [GL061](rules/GL061.md) | `warn`  | `docker run --pid host` shares the host PID namespace — container can see/signal all host processes |
+| [GL063](rules/GL063.md) | `warn`  | `chmod` grants world-writable permissions (`777`, `a+w`, `o+w`) — TOCTOU risk on shared runners |

--- a/docs/rules/GL063.md
+++ b/docs/rules/GL063.md
@@ -1,0 +1,44 @@
+# GL063 — `chmod 777` or world-writable permissions in CI script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-732 – Incorrect Permission Assignment for Critical Resource](https://cwe.mitre.org/data/definitions/732.html)
+
+## Risk
+
+Setting world-writable permissions (`chmod 777`, `chmod a+w`, `chmod o+w`) on files or directories in a CI script is a security smell. On shared runners where multiple jobs may run on the same host — or where artifacts are accessible to other pipelines — world-writable paths can be modified by other processes. For executables or scripts that are subsequently run in the same job, this creates a TOCTOU (time-of-check/time-of-use) race where a malicious write could replace the file between the `chmod` and the execution.
+
+The most common legitimate use — making a script executable — only requires `+x`, not `777`.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - chmod 777 deploy.sh
+    - ./deploy.sh
+```
+
+Flagged forms: octal modes whose "others" digit has the write bit (`777`, `666`, `707`, `1777`, …), and symbolic clauses granting write to others/all (`a+w`, `o+w`, `a+rwx`). `chmod -R 777` on a directory tree is especially concerning.
+
+## What is not flagged
+
+- `chmod +x` / `chmod 755` — execute permission without world-write
+- `chmod 644`, `chmod 600`, `chmod 700` — restrictive modes
+- `chmod u+w`, `chmod g+w` — user/group write (not others)
+
+## Safe alternative
+
+```yaml
+build:
+  script:
+    - chmod +x deploy.sh   # executable only
+    - ./deploy.sh
+```
+
+## Notes
+
+- Severity is `warn`.
+- Only the chmod **mode argument** is analysed, so an unrelated octal-looking number elsewhere on the line (e.g. `--port 7777`) does not trigger a false positive.
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL063`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -66,5 +66,6 @@ func All() []rule.Rule {
 		GL060,
 		GL061,
 		GL062,
+		GL063,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -64,6 +64,7 @@ var cweIDs = map[string]string{
 	"GL060": "CWE-552",
 	"GL061": "CWE-653",
 	"GL062": "CWE-532",
+	"GL063": "CWE-732",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -87,6 +88,7 @@ var cweNames = map[string]string{
 	"CWE-829":  "Inclusion of Functionality from Untrusted Control Sphere",
 	"CWE-653":  "Improper Isolation or Compartmentalization",
 	"CWE-552":  "Files or Directories Accessible to External Parties",
+	"CWE-732":  "Incorrect Permission Assignment for Critical Resource",
 	"CWE-1104": "Use of Unmaintained Third-Party Components",
 }
 

--- a/rules/gl063.go
+++ b/rules/gl063.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl063 struct{}
+
+var GL063 = &gl063{}
+
+func (r *gl063) ID() string { return "GL063" }
+
+var (
+	// chmodModeRe captures the mode argument of a chmod invocation: any
+	// leading flags (-R, -v, …) followed by the first non-flag token.
+	chmodModeRe = regexp.MustCompile(`\bchmod\s+((?:-[A-Za-z-]+\s+)*)(\S+)`)
+	octalModeRe = regexp.MustCompile(`^[0-7]{3,4}$`)
+	// symbolicWorldWriteRe matches a symbolic clause granting write to
+	// "others" or "all" (who part contains o or a, op is + or =, perms have w).
+	symbolicWorldWriteRe = regexp.MustCompile(`[ugoa]*[ao][ugoa]*[+=][rwxXst]*w`)
+)
+
+func (r *gl063) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		for _, m := range chmodModeRe.FindAllStringSubmatch(v, -1) {
+			if !worldWritableMode(m[2]) {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL063",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "chmod grants world-writable permissions — on shared runners other processes can modify the file, risking a TOCTOU race if it is later executed; use the minimal permission (e.g. chmod +x) instead",
+				File:     file,
+				Line:     line.Line,
+				Col:      line.Column,
+			})
+		}
+	})
+	return findings
+}
+
+// worldWritableMode reports whether a chmod mode token grants write to others.
+func worldWritableMode(mode string) bool {
+	if octalModeRe.MatchString(mode) {
+		last := mode[len(mode)-1] - '0'
+		return last&2 != 0
+	}
+	return symbolicWorldWriteRe.MatchString(mode)
+}

--- a/rules/gl063_test.go
+++ b/rules/gl063_test.go
@@ -1,0 +1,156 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings063(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL063.Check(doc.Root, "test.yml")
+}
+
+func TestGL063_Chmod777(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod 777 deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL063" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+}
+
+func TestGL063_Recursive777(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod -R 777 /app
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for chmod -R 777, got %d", len(f))
+	}
+}
+
+func TestGL063_Octal666(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod 666 data.txt
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 666, got %d", len(f))
+	}
+}
+
+func TestGL063_Octal1777Sticky(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod 1777 /scratch
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 1777, got %d", len(f))
+	}
+}
+
+func TestGL063_SymbolicAllWrite(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod a+w secret.key
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for a+w, got %d", len(f))
+	}
+}
+
+func TestGL063_SymbolicOthersWrite(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod o+w deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for o+w, got %d", len(f))
+	}
+}
+
+func TestGL063_SymbolicARWX(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod a+rwx /workspace
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for a+rwx, got %d", len(f))
+	}
+}
+
+func TestGL063_ExecuteOnlyNotFlagged(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod +x deploy.sh
+    - chmod 755 build.sh
+    - chmod u+x run.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for +x/755/u+x, got %d", len(f))
+	}
+}
+
+func TestGL063_RestrictiveOctalNotFlagged(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod 644 config.yml
+    - chmod 600 id_rsa
+    - chmod 700 bin
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for 644/600/700, got %d", len(f))
+	}
+}
+
+func TestGL063_GroupWriteNotFlagged(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod g+w shared
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for g+w (group, not others), got %d", len(f))
+	}
+}
+
+func TestGL063_UnrelatedOctalOnLineNotFlagged(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - chmod +x app && ./app --port 7777
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings (7777 is not the chmod mode), got %d", len(f))
+	}
+}
+
+func TestGL063_CommentNotFlagged(t *testing.T) {
+	f := findings063(t, `
+build:
+  script:
+    - "# chmod 777 would be bad"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -65,6 +65,7 @@ var owaspCategories = map[string][]string{
 	"GL060": {"CICD-SEC-7"},
 	"GL061": {"CICD-SEC-7"},
 	"GL062": {"CICD-SEC-6"},
+	"GL063": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl063-chmod-world-writable.yml
+++ b/testdata/fixtures/gl063-chmod-world-writable.yml
@@ -1,0 +1,6 @@
+# chmod 777 makes the file world-writable, risking a TOCTOU race before execution.
+build:
+  image: alpine:3.20
+  script:
+    - chmod 777 deploy.sh
+    - ./deploy.sh


### PR DESCRIPTION
## Summary

New rule **GL063**: warns when a CI script sets world-writable permissions via `chmod`. On shared runners, world-writable files can be modified by other processes — a TOCTOU risk if the file is later executed. Closes #224.

## Detection

Parses the chmod **mode argument** (after any flags like `-R`):
- Octal modes whose others digit has the write bit: `777`, `666`, `707`, `1777`, …
- Symbolic clauses granting write to others/all: `a+w`, `o+w`, `a+rwx`

Not flagged: `+x`, `755`, `644`, `600`, `700`, `u+w`, `g+w` (user/group, not others).

Because only the mode argument is analysed, an unrelated octal number elsewhere on the line (`chmod +x app && ./app --port 7777`) does not false-positive.

## Mappings

- OWASP: CICD-SEC-7 (Insecure System Configuration)
- CWE: CWE-732 (Incorrect Permission Assignment for Critical Resource) — new entry added to `cweNames`

## Files

- `rules/gl063.go` + `rules/gl063_test.go` (12 cases: 777, -R 777, 666, 1777, a+w, o+w, a+rwx, +x/755/u+x skip, 644/600/700 skip, g+w skip, unrelated-octal skip, comment skip)
- Registered in `all.go`, `owasp.go`, `cwe.go` (+ CWE-732 name)
- `docs/rules/GL063.md`, `docs/rules.md`, README count 62→63 + table
- `testdata/fixtures/gl063-chmod-world-writable.yml` (schema-validated)

## Test

```sh
go test ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
/tmp/glsec --no-exit-codes testdata/fixtures/gl063-chmod-world-writable.yml
```

Closes #224.