### PR TITLE
feat: --only and --skip CLI flags for rule selection (#201)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ glsec --no-exit-codes .gitlab-ci.yml
 # exclude a file or directory from scanning
 glsec --exclude vendor/ .gitlab-ci.yml
 
+# run only specific rules (comma-separated or repeated)
+glsec --only GL001,GL003 .gitlab-ci.yml
+
+# skip specific rules
+glsec --skip GL008,GL022 .gitlab-ci.yml
+
 # baseline existing findings so only new violations are reported
 glsec --generate-ignore .gitlab-ci.yml
 glsec .gitlab-ci.yml  # now exits 0; new violations will be caught

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -69,6 +69,15 @@ func main() {
 		excludeArgs = append(excludeArgs, s)
 		return nil
 	})
+	var onlyArgs, skipArgs []string
+	flag.Func("only", "run only these rule IDs (comma-separated, may be repeated)", func(s string) error {
+		onlyArgs = append(onlyArgs, splitRuleIDs(s)...)
+		return nil
+	})
+	flag.Func("skip", "skip these rule IDs (comma-separated, may be repeated)", func(s string) error {
+		skipArgs = append(skipArgs, splitRuleIDs(s)...)
+		return nil
+	})
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: glsec [flags] [file]")
 		fmt.Fprintln(os.Stderr, "       glsec explain <RULE-ID>")
@@ -116,6 +125,15 @@ func main() {
 		cfg.NoExitCodes = true
 	}
 	cfg.ExcludePaths = append(cfg.ExcludePaths, excludeArgs...)
+
+	if len(onlyArgs) > 0 {
+		cfg.Only = ruleIDSet(onlyArgs)
+		warnUnknownRuleIDs("--only", cfg.Only)
+	}
+	if len(skipArgs) > 0 {
+		cfg.Skip = ruleIDSet(skipArgs)
+		warnUnknownRuleIDs("--skip", cfg.Skip)
+	}
 
 	rules.GL016.SetTrustedHosts(cfg.TrustedHosts)
 
@@ -185,7 +203,7 @@ func main() {
 		for i, d := range allDocs {
 			filePaths[i] = d.File
 		}
-		cacheKey, err = cache.Key(resolvedVersion(), gitlabVersionStr, filePaths, *configFlag, suppress.IgnoreFile, cfg.ExcludePaths)
+		cacheKey, err = cache.Key(resolvedVersion(), gitlabVersionStr, filePaths, *configFlag, suppress.IgnoreFile, cfg.ExcludePaths, onlyArgs, skipArgs)
 		if err == nil {
 			if entry, ok := cache.Load(cacheKey); ok {
 				writeAndExit(os.Stdout, format, entry.Findings, entry.JobCount, cfg, colorEnabled)
@@ -251,6 +269,41 @@ func resolvedVersion() string {
 		return info.Main.Version
 	}
 	return "dev"
+}
+
+// splitRuleIDs splits a comma-separated rule list, trims and upper-cases each
+// entry, and drops empties.
+func splitRuleIDs(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if id := strings.ToUpper(strings.TrimSpace(part)); id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// ruleIDSet builds a set from a list of rule IDs.
+func ruleIDSet(ids []string) map[string]bool {
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set
+}
+
+// warnUnknownRuleIDs prints a stderr warning for any ID in set that is not a
+// known rule, so typos (e.g. --only GL01) do not silently match nothing.
+func warnUnknownRuleIDs(flagName string, set map[string]bool) {
+	known := make(map[string]bool, len(rules.All()))
+	for _, r := range rules.All() {
+		known[r.ID()] = true
+	}
+	for id := range set {
+		if !known[id] {
+			fmt.Fprintf(os.Stderr, "warning: %s: unknown rule ID %q\n", flagName, id)
+		}
+	}
 }
 
 // matchesExclude returns true if file matches any of the given patterns.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -37,7 +37,7 @@ func Dir() string {
 // Key computes a deterministic hex key from all inputs that affect scan results.
 // filePaths must include the main pipeline file and all discovered child pipeline files.
 // configPath and ignorePath are read from disk if they exist.
-func Key(version, gitlabVersion string, filePaths []string, configPath, ignorePath string, excludePatterns []string) (string, error) {
+func Key(version, gitlabVersion string, filePaths []string, configPath, ignorePath string, excludePatterns, only, skip []string) (string, error) {
 	h := sha256.New()
 
 	_, _ = fmt.Fprintf(h, "version:%s\n", version)
@@ -49,6 +49,9 @@ func Key(version, gitlabVersion string, filePaths []string, configPath, ignorePa
 	for _, p := range sorted {
 		_, _ = fmt.Fprintf(h, "exclude:%s\n", p)
 	}
+
+	hashSorted(h, "only", only)
+	hashSorted(h, "skip", skip)
 
 	sortedFiles := make([]string, len(filePaths))
 	copy(sortedFiles, filePaths)
@@ -69,6 +72,17 @@ func Key(version, gitlabVersion string, filePaths []string, configPath, ignorePa
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// hashSorted writes a sorted, labelled list into the cache key so order does
+// not affect the result.
+func hashSorted(h io.Writer, label string, items []string) {
+	sorted := make([]string, len(items))
+	copy(sorted, items)
+	sort.Strings(sorted)
+	for _, s := range sorted {
+		_, _ = fmt.Fprintf(h, "%s:%s\n", label, s)
+	}
 }
 
 func hashFile(h io.Writer, path string) error {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -65,11 +65,11 @@ func TestKey_Deterministic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	k1, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil)
+	k1, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	k2, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil)
+	k2, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestKey_DiffersOnContentChange(t *testing.T) {
 	if err := os.WriteFile(f, []byte("stages: [build]"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	k1, err := Key("v1.0.0", "", []string{f}, "", "", nil)
+	k1, err := Key("v1.0.0", "", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestKey_DiffersOnContentChange(t *testing.T) {
 	if err := os.WriteFile(f, []byte("stages: [deploy]"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	k2, err := Key("v1.0.0", "", []string{f}, "", "", nil)
+	k2, err := Key("v1.0.0", "", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,9 +104,24 @@ func TestKey_DiffersOnContentChange(t *testing.T) {
 }
 
 func TestKey_DiffersOnVersion(t *testing.T) {
-	k1, _ := Key("v1.0.0", "", nil, "", "", nil)
-	k2, _ := Key("v1.0.1", "", nil, "", "", nil)
+	k1, _ := Key("v1.0.0", "", nil, "", "", nil, nil, nil)
+	k2, _ := Key("v1.0.1", "", nil, "", "", nil, nil, nil)
 	if k1 == k2 {
 		t.Error("key should differ on version change")
+	}
+}
+
+func TestKey_DiffersOnOnlySkip(t *testing.T) {
+	base, _ := Key("v1.0.0", "", nil, "", "", nil, nil, nil)
+	only, _ := Key("v1.0.0", "", nil, "", "", nil, []string{"GL001"}, nil)
+	skip, _ := Key("v1.0.0", "", nil, "", "", nil, nil, []string{"GL001"})
+	if base == only {
+		t.Error("key should differ when --only is set")
+	}
+	if base == skip {
+		t.Error("key should differ when --skip is set")
+	}
+	if only == skip {
+		t.Error("--only and --skip with the same ID should produce different keys")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,12 @@ type Config struct {
 	// OWASPExclude is a denylist of OWASP CICD-SEC category IDs. Rules
 	// belonging to any listed category are skipped.
 	OWASPExclude []string `yaml:"owasp_exclude"`
+	// Only, when non-empty, restricts execution to these rule IDs. Set from
+	// the --only CLI flag; takes precedence over per-rule config.
+	Only map[string]bool `yaml:"-"`
+	// Skip lists rule IDs to exclude. Set from the --skip CLI flag; takes
+	// precedence over per-rule config.
+	Skip map[string]bool `yaml:"-"`
 }
 
 // Default returns a Config with no overrides.
@@ -205,8 +211,16 @@ var validOWASPCategories = map[string]bool{
 
 func validOWASPCategory(s string) bool { return validOWASPCategories[s] }
 
-// RuleEnabled returns false if the rule is set to "off" in the config.
+// RuleEnabled returns false if the rule is disabled. The --only and --skip
+// CLI selections take precedence over per-rule config: a non-empty Only set
+// restricts execution to its members, and any rule in Skip is disabled.
 func (c *Config) RuleEnabled(id string) bool {
+	if len(c.Only) > 0 && !c.Only[id] {
+		return false
+	}
+	if c.Skip[id] {
+		return false
+	}
 	rc, ok := c.Rules[id]
 	return !ok || rc.Severity != "off"
 }


### PR DESCRIPTION
## Summary

Adds `--only` and `--skip` CLI flags for ad-hoc rule selection without touching the config file. Closes #201.

```bash
glsec --only GL001,GL003 .gitlab-ci.yml      # run only these
glsec --skip GL008,GL022 .gitlab-ci.yml      # exclude these
glsec --only GL001 --only GL003 .gitlab-ci.yml   # repeatable
```

Both flags accept comma-separated lists and may be repeated. IDs are upper-cased, so `--only gl001` works. CLI selection takes precedence over per-rule config.

## Implementation

- `config.Config` gains `Only` / `Skip` sets (`yaml:"-"`, CLI-only).
- `config.RuleEnabled` checks them first: a non-empty `Only` restricts to its members; any rule in `Skip` is disabled — both before the config `off` check.
- `cmd/glsec`: `--only`/`--skip` flags (via `flag.Func`, comma-split + repeatable), populated into the config after load. Unknown rule IDs print a stderr warning so typos like `--only GL01` don't silently match nothing.

## Cache correctness

The result cache previously keyed on version/files/config/exclude but **not** rule selection — so a cached full run would be returned for a later `--skip` invocation, ignoring the filter. `cache.Key` now hashes the `only`/`skip` lists (sorted), so each selection caches independently. Added `TestKey_DiffersOnOnlySkip`.

## Files

- `internal/config/config.go` — `Only`/`Skip` fields + `RuleEnabled` logic
- `cmd/glsec/main.go` — flags, `splitRuleIDs`/`ruleIDSet`/`warnUnknownRuleIDs` helpers
- `internal/cache/cache.go` — `Key` takes + hashes `only`/`skip`
- `internal/cache/cache_test.go` — signature update + new differentiation test
- `README.md` — usage examples

## Test

```sh
go test ./...
glsec --only GL054 fixture.yml   # only GL054
glsec --skip GL056 fixture.yml   # GL056 gone, rest remain
glsec --only GL999 fixture.yml   # warning: --only: unknown rule ID "GL999"
```

Closes #201.