### PR TITLE
feat: glsec list subcommand to show all rules (#203)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ glsec --only GL001,GL003 .gitlab-ci.yml
 # skip specific rules
 glsec --skip GL008,GL022 .gitlab-ci.yml
 
+# list all rules (ID, severity, OWASP, description); --format json / --owasp also supported
+glsec list
+glsec list --owasp CICD-SEC-4
+
+# explain a specific rule
+glsec explain GL001
+
 # baseline existing findings so only new violations are reported
 glsec --generate-ignore .gitlab-ci.yml
 glsec .gitlab-ci.yml  # now exits 0; new violations will be caught

--- a/cmd/glsec/list.go
+++ b/cmd/glsec/list.go
@@ -67,9 +67,9 @@ func runList(args []string) {
 
 func printRuleTable(infos []ruleInfo) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tSEVERITY\tOWASP\tDESCRIPTION")
+	_, _ = fmt.Fprintln(w, "ID\tSEVERITY\tOWASP\tDESCRIPTION")
 	for _, info := range infos {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 			info.ID, info.Severity, strings.Join(info.OWASP, ", "), info.Description)
 	}
 	_ = w.Flush()

--- a/cmd/glsec/list.go
+++ b/cmd/glsec/list.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	glsecdocs "github.com/glsec/glsec/docs"
+	"github.com/glsec/glsec/rules"
+)
+
+type ruleInfo struct {
+	ID          string   `json:"id"`
+	Severity    string   `json:"severity"`
+	OWASP       []string `json:"owasp"`
+	Description string   `json:"description"`
+}
+
+func runList(args []string) {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+	format := fs.String("format", "text", "output format: text or json")
+	owaspFilter := fs.String("owasp", "", "filter by OWASP category (e.g. CICD-SEC-4)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: glsec list [--format text|json] [--owasp CICD-SEC-N]")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+
+	wantOWASP := strings.ToUpper(strings.TrimSpace(*owaspFilter))
+
+	var infos []ruleInfo
+	for _, r := range rules.All() {
+		id := r.ID()
+		cats := rules.OWASPCategories(id)
+		if wantOWASP != "" && !containsFold(cats, wantOWASP) {
+			continue
+		}
+		info := ruleInfo{ID: id, OWASP: cats}
+		if raw, err := glsecdocs.FS.ReadFile("rules/" + id + ".md"); err == nil {
+			doc := parseExplainDoc(raw)
+			info.Severity = normalizeSeverity(doc.severity)
+			info.Description = strings.ReplaceAll(doc.title, "`", "")
+		}
+		infos = append(infos, info)
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].ID < infos[j].ID })
+
+	switch *format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(infos); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(2)
+		}
+	case "text":
+		printRuleTable(infos)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown format %q — use text or json\n", *format)
+		os.Exit(2)
+	}
+}
+
+func printRuleTable(infos []ruleInfo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSEVERITY\tOWASP\tDESCRIPTION")
+	for _, info := range infos {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			info.ID, info.Severity, strings.Join(info.OWASP, ", "), info.Description)
+	}
+	_ = w.Flush()
+	fmt.Printf("\n%d rules total\n", len(infos))
+}
+
+// normalizeSeverity reduces a doc severity line to a compact table value.
+func normalizeSeverity(s string) string {
+	low := strings.ToLower(s)
+	hasErr := strings.Contains(low, "error")
+	hasWarn := strings.Contains(low, "warn")
+	switch {
+	case hasErr && hasWarn:
+		return "error/warn"
+	case hasErr:
+		return "error"
+	case hasWarn:
+		return "warn"
+	case strings.Contains(low, "info"):
+		return "info"
+	default:
+		return "varies"
+	}
+}
+
+func containsFold(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.EqualFold(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/glsec/list_test.go
+++ b/cmd/glsec/list_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestNormalizeSeverity(t *testing.T) {
+	cases := map[string]string{
+		"`error`":                       "error",
+		"`warn`":                        "warn",
+		"`info`":                        "info",
+		"`error` for X; `warn` for Y":   "error/warn",
+		"varies by context (see below)": "varies",
+		"":                              "varies",
+	}
+	for in, want := range cases {
+		if got := normalizeSeverity(in); got != want {
+			t.Errorf("normalizeSeverity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestContainsFold(t *testing.T) {
+	cats := []string{"CICD-SEC-4", "CICD-SEC-8"}
+	if !containsFold(cats, "cicd-sec-4") {
+		t.Error("expected case-insensitive match for cicd-sec-4")
+	}
+	if containsFold(cats, "CICD-SEC-1") {
+		t.Error("did not expect a match for CICD-SEC-1")
+	}
+	if containsFold(nil, "CICD-SEC-4") {
+		t.Error("empty list should not match")
+	}
+}

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -29,6 +29,10 @@ var (
 )
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "list" {
+		runList(os.Args[2:])
+		return
+	}
 	if len(os.Args) >= 2 && os.Args[1] == "explain" {
 		if len(os.Args) < 3 {
 			fmt.Fprintln(os.Stderr, "usage: glsec explain <RULE-ID>")
@@ -81,6 +85,7 @@ func main() {
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: glsec [flags] [file]")
 		fmt.Fprintln(os.Stderr, "       glsec explain <RULE-ID>")
+		fmt.Fprintln(os.Stderr, "       glsec list [--format text|json] [--owasp CICD-SEC-N]")
 		fmt.Fprintln(os.Stderr, "       If no file is given, glsec looks for .gitlab-ci.yml in the current directory.")
 		flag.PrintDefaults()
 	}


### PR DESCRIPTION
## Summary

Adds a `glsec list` subcommand that prints all rules with ID, severity, OWASP category, and a short description — no need to open the docs. Closes #203.

```
$ glsec list
ID     SEVERITY    OWASP        DESCRIPTION
GL001  error       CICD-SEC-3   Mutable image tag
GL002  warn        CICD-SEC-4   Variable injection
GL005  error/warn  CICD-SEC-6   Sensitive artifacts
...
63 rules total
```

## Flags

- `--format text|json` — machine-readable JSON output
- `--owasp CICD-SEC-N` — filter to one OWASP category (case-insensitive)

## Implementation

- Dispatched in `main()` like the existing `explain` subcommand.
- Metadata comes from the same source as `explain`: OWASP from `rules.OWASPCategories` (authoritative), severity + description parsed from the embedded `docs/rules/GLxxx.md` headers via the shared `parseExplainDoc`.
- `normalizeSeverity` collapses the doc severity line to a compact token (`error`, `warn`, `error/warn`, `info`, or `varies` for context-dependent rules like GL016).
- Backticks are stripped from descriptions for clean terminal/JSON output.
- Table rendering uses `text/tabwriter` for alignment.

## Files

- `cmd/glsec/list.go` — subcommand
- `cmd/glsec/list_test.go` — `normalizeSeverity` (incl. the `varies` fallback) and `containsFold` tests
- `cmd/glsec/main.go` — dispatch + usage line
- `README.md` — usage examples (also surfaced `glsec explain`, which was undocumented there)

## Test

```sh
go test ./...
glsec list
glsec list --owasp CICD-SEC-4   # 8 rules
glsec list --format json
```

Closes #203.