### PR TITLE
feat: map rules to OWASP ASVS V14 (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ glsec --format json .gitlab-ci.yml
 # SARIF output for GitHub Code Scanning / GitLab SAST
 glsec --format sarif .gitlab-ci.yml > gl.sarif
 
+# JSON/SARIF carry OWASP CICD-SEC, CWE, and OWASP ASVS V14 mappings per finding
+
 # Code Climate output for GitLab Code Quality (inline MR findings, works on all tiers)
 glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -279,9 +279,9 @@ func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCoun
 func writeOutput(w *os.File, format output.Format, findings []finding.Finding, jobCount int, colorEnabled bool) error {
 	switch format {
 	case output.FormatSARIF:
-		return output.WriteSARIF(w, findings, rules.CWEID, rules.CWEName, rules.OWASPCategories, rules.OWASPCategoryName)
+		return output.WriteSARIF(w, findings, rules.CWEID, rules.CWEName, rules.OWASPCategories, rules.OWASPCategoryName, rules.ASVSRequirements, rules.ASVSRequirementName)
 	case output.FormatJSON:
-		return output.WriteJSON(w, findings, rules.OWASPCategories)
+		return output.WriteJSON(w, findings, rules.OWASPCategories, rules.ASVSRequirements)
 	default:
 		return output.Write(w, format, findings, jobCount, colorEnabled)
 	}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -119,3 +119,20 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL060](rules/GL060.md) | `error`/`warn` | `docker run -v` mounts a sensitive host path (`/`, `/etc`, `/root`, `/proc`, `/sys`, …) breaking isolation |
 | [GL061](rules/GL061.md) | `warn`  | `docker run --pid host` shares the host PID namespace — container can see/signal all host processes |
 | [GL063](rules/GL063.md) | `warn`  | `chmod` grants world-writable permissions (`777`, `a+w`, `o+w`) — TOCTOU risk on shared runners |
+
+---
+
+## OWASP ASVS v4.0.3 — V14 (Build and Deploy) mapping
+
+A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) v4.0.3 Chapter V14 requirements, surfaced in JSON output (`asvs` field) and SARIF (an `OWASP ASVS` taxonomy) for compliance evidence.
+
+| ASVS requirement | Rules |
+|---|---|
+| V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016 |
+| V14.2.2 — Components up to date and pinned | GL001, GL022, GL023, GL026, GL041 |
+| V14.2.3 — Dependencies verified for integrity | GL020 |
+| V14.3.1 — Pipeline config protected from modification | GL003, GL019 |
+| V14.3.2 — Security tools run and failures block the build | GL008, GL039 |
+| V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038 |
+| V14.3.4 — Build environment isolated | GL007, GL015, GL025 |
+| V14.4.1 — Third-party CI/CD service dependence minimised | GL041 |

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -33,9 +33,9 @@ func ParseFormat(s string) (Format, bool) {
 func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int, colorEnabled bool) error {
 	switch format {
 	case FormatJSON:
-		return writeJSON(w, findings, nil)
+		return writeJSON(w, findings, nil, nil)
 	case FormatSARIF:
-		return writeSARIF(w, findings, nil, nil, nil, nil)
+		return writeSARIF(w, findings, nil, nil, nil, nil, nil, nil)
 	case FormatCodeClimate:
 		return writeCodeClimate(w, findings)
 	default:
@@ -84,19 +84,20 @@ type jsonFinding struct {
 	Line     int      `json:"line"`
 	Message  string   `json:"message"`
 	OWASP    []string `json:"owasp,omitempty"`
+	ASVS     []string `json:"asvs,omitempty"`
 }
 
 type jsonOutput struct {
 	Findings []jsonFinding `json:"findings"`
 }
 
-// WriteJSON writes findings as JSON. owasp, if non-nil, is called per finding
-// to populate the "owasp" field with category IDs.
-func WriteJSON(w io.Writer, findings []finding.Finding, owasp func(string) []string) error {
-	return writeJSON(w, findings, owasp)
+// WriteJSON writes findings as JSON. owasp and asvs, if non-nil, are called
+// per finding to populate the "owasp" and "asvs" fields.
+func WriteJSON(w io.Writer, findings []finding.Finding, owasp, asvs func(string) []string) error {
+	return writeJSON(w, findings, owasp, asvs)
 }
 
-func writeJSON(w io.Writer, findings []finding.Finding, owasp func(string) []string) error {
+func writeJSON(w io.Writer, findings []finding.Finding, owasp, asvs func(string) []string) error {
 	out := jsonOutput{Findings: make([]jsonFinding, 0, len(findings))}
 	for _, f := range findings {
 		jf := jsonFinding{
@@ -109,6 +110,9 @@ func writeJSON(w io.Writer, findings []finding.Finding, owasp func(string) []str
 		}
 		if owasp != nil {
 			jf.OWASP = owasp(f.RuleID)
+		}
+		if asvs != nil {
+			jf.ASVS = asvs(f.RuleID)
 		}
 		out.Findings = append(out.Findings, jf)
 	}
@@ -125,9 +129,9 @@ type sarifLog struct {
 }
 
 type sarifRun struct {
-	Tool       sarifTool        `json:"tool"`
-	Taxonomies []sarifTaxonomy  `json:"taxonomies,omitempty"`
-	Results    []sarifResult    `json:"results"`
+	Tool       sarifTool       `json:"tool"`
+	Taxonomies []sarifTaxonomy `json:"taxonomies,omitempty"`
+	Results    []sarifResult   `json:"results"`
 }
 
 type sarifTool struct {
@@ -135,14 +139,14 @@ type sarifTool struct {
 }
 
 type sarifDriver struct {
-	Name           string       `json:"name"`
-	InformationURI string       `json:"informationUri"`
-	Rules          []sarifRule  `json:"rules,omitempty"`
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri"`
+	Rules          []sarifRule `json:"rules,omitempty"`
 }
 
 type sarifRule struct {
-	ID            string                  `json:"id"`
-	Relationships []sarifRelationship     `json:"relationships,omitempty"`
+	ID            string              `json:"id"`
+	Relationships []sarifRelationship `json:"relationships,omitempty"`
 }
 
 type sarifRelationship struct {
@@ -151,8 +155,8 @@ type sarifRelationship struct {
 }
 
 type sarifRelationshipTarget struct {
-	ID            string                    `json:"id"`
-	ToolComponent sarifToolComponentRef     `json:"toolComponent"`
+	ID            string                `json:"id"`
+	ToolComponent sarifToolComponentRef `json:"toolComponent"`
 }
 
 type sarifToolComponentRef struct {
@@ -160,10 +164,10 @@ type sarifToolComponentRef struct {
 }
 
 type sarifTaxonomy struct {
-	Name             string      `json:"name"`
-	Version          string      `json:"version"`
-	Organization     string      `json:"organization"`
-	Taxa             []sarifTaxon `json:"taxa"`
+	Name         string       `json:"name"`
+	Version      string       `json:"version"`
+	Organization string       `json:"organization"`
+	Taxa         []sarifTaxon `json:"taxa"`
 }
 
 type sarifTaxon struct {
@@ -219,13 +223,15 @@ func severityToSARIFLevel(s finding.Severity) string {
 func WriteSARIF(w io.Writer, findings []finding.Finding,
 	cweID func(string) string, cweName func(string) string,
 	owasp func(string) []string, owaspName func(string) string,
+	asvs func(string) []string, asvsName func(string) string,
 ) error {
-	return writeSARIF(w, findings, cweID, cweName, owasp, owaspName)
+	return writeSARIF(w, findings, cweID, cweName, owasp, owaspName, asvs, asvsName)
 }
 
 func writeSARIF(w io.Writer, findings []finding.Finding,
 	cweID func(string) string, cweName func(string) string,
 	owasp func(string) []string, owaspName func(string) string,
+	asvs func(string) []string, asvsName func(string) string,
 ) error {
 	results := make([]sarifResult, 0, len(findings))
 	for _, f := range findings {
@@ -253,6 +259,7 @@ func writeSARIF(w io.Writer, findings []finding.Finding,
 	seenRules := map[string]bool{}
 	seenCWEs := map[string]bool{}
 	seenOWASP := map[string]bool{}
+	seenASVS := map[string]bool{}
 
 	for _, f := range findings {
 		if seenRules[f.RuleID] {
@@ -279,6 +286,16 @@ func writeSARIF(w io.Writer, findings []finding.Finding,
 					Kinds:  []string{"superset"},
 				})
 				seenOWASP[cat] = true
+			}
+		}
+
+		if asvs != nil {
+			for _, req := range asvs(f.RuleID) {
+				rels = append(rels, sarifRelationship{
+					Target: sarifRelationshipTarget{ID: req, ToolComponent: sarifToolComponentRef{Name: "OWASP ASVS"}},
+					Kinds:  []string{"superset"},
+				})
+				seenASVS[req] = true
 			}
 		}
 
@@ -309,6 +326,16 @@ func writeSARIF(w io.Writer, findings []finding.Finding,
 		})
 	}
 
+	if len(seenASVS) > 0 && asvsName != nil {
+		taxa := make([]sarifTaxon, 0, len(seenASVS))
+		for req := range seenASVS {
+			taxa = append(taxa, sarifTaxon{ID: req, Name: asvsName(req)})
+		}
+		run.Taxonomies = append(run.Taxonomies, sarifTaxonomy{
+			Name: "OWASP ASVS", Version: "4.0.3", Organization: "OWASP", Taxa: taxa,
+		})
+	}
+
 	log := sarifLog{
 		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
 		Version: "2.1.0",
@@ -323,13 +350,13 @@ func writeSARIF(w io.Writer, findings []finding.Finding,
 // (artifacts:reports:codequality). Spec:
 // https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md
 type codeClimateIssue struct {
-	Type        string               `json:"type"`
-	CheckName   string               `json:"check_name"`
-	Description string               `json:"description"`
-	Categories  []string             `json:"categories"`
-	Severity    string               `json:"severity"`
-	Fingerprint string               `json:"fingerprint"`
-	Location    codeClimateLocation  `json:"location"`
+	Type        string              `json:"type"`
+	CheckName   string              `json:"check_name"`
+	Description string              `json:"description"`
+	Categories  []string            `json:"categories"`
+	Severity    string              `json:"severity"`
+	Fingerprint string              `json:"fingerprint"`
+	Location    codeClimateLocation `json:"location"`
 }
 
 type codeClimateLocation struct {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -186,7 +186,7 @@ func TestWriteSARIF_WithCWE(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := WriteSARIF(&buf, testFindings, cweID, cweName, nil, nil); err != nil {
+	if err := WriteSARIF(&buf, testFindings, cweID, cweName, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -217,7 +217,7 @@ func TestWriteSARIF_WithCWE(t *testing.T) {
 
 func TestWriteSARIF_NoCWE(t *testing.T) {
 	var buf bytes.Buffer
-	if err := WriteSARIF(&buf, testFindings, nil, nil, nil, nil); err != nil {
+	if err := WriteSARIF(&buf, testFindings, nil, nil, nil, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -240,7 +240,7 @@ func TestWriteJSON_WithOWASP(t *testing.T) {
 		return []string{"CICD-SEC-6"}
 	}
 	var buf bytes.Buffer
-	if err := WriteJSON(&buf, testFindings, owasp); err != nil {
+	if err := WriteJSON(&buf, testFindings, owasp, nil); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -373,7 +373,7 @@ func TestWriteSARIF_WithOWASP(t *testing.T) {
 		return ""
 	}
 	var buf bytes.Buffer
-	if err := WriteSARIF(&buf, testFindings, nil, nil, owasp, owaspName); err != nil {
+	if err := WriteSARIF(&buf, testFindings, nil, nil, owasp, owaspName, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -399,5 +399,62 @@ func TestWriteSARIF_WithOWASP(t *testing.T) {
 	}
 	if len(run.Taxonomies[0].Taxa) != 1 || run.Taxonomies[0].Taxa[0].ID != "CICD-SEC-3" {
 		t.Errorf("unexpected taxa: %+v", run.Taxonomies[0].Taxa)
+	}
+}
+
+func TestWriteJSON_WithASVS(t *testing.T) {
+	asvs := func(id string) []string {
+		if id == "GL001" {
+			return []string{"ASVS-V14.2.2"}
+		}
+		return nil
+	}
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, testFindings, nil, asvs); err != nil {
+		t.Fatal(err)
+	}
+	var out jsonOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(out.Findings[0].ASVS) != 1 || out.Findings[0].ASVS[0] != "ASVS-V14.2.2" {
+		t.Errorf("expected ASVS-V14.2.2 for GL001, got %v", out.Findings[0].ASVS)
+	}
+	if len(out.Findings[1].ASVS) != 0 {
+		t.Errorf("expected no ASVS for GL002, got %v", out.Findings[1].ASVS)
+	}
+}
+
+func TestWriteSARIF_WithASVS(t *testing.T) {
+	asvs := func(id string) []string {
+		if id == "GL001" {
+			return []string{"ASVS-V14.2.2"}
+		}
+		return nil
+	}
+	asvsName := func(id string) string {
+		if id == "ASVS-V14.2.2" {
+			return "Verify that all components are up to date and pinned to a specific version"
+		}
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := WriteSARIF(&buf, testFindings, nil, nil, nil, nil, asvs, asvsName); err != nil {
+		t.Fatal(err)
+	}
+	var log sarifLog
+	if err := json.Unmarshal(buf.Bytes(), &log); err != nil {
+		t.Fatalf("invalid SARIF JSON: %v", err)
+	}
+	run := log.Runs[0]
+	rule := run.Tool.Driver.Rules[0]
+	if rule.ID != "GL001" || len(rule.Relationships) != 1 || rule.Relationships[0].Target.ID != "ASVS-V14.2.2" {
+		t.Errorf("unexpected ASVS relationship: %+v", rule.Relationships)
+	}
+	if rule.Relationships[0].Target.ToolComponent.Name != "OWASP ASVS" {
+		t.Errorf("unexpected tool component: %q", rule.Relationships[0].Target.ToolComponent.Name)
+	}
+	if len(run.Taxonomies) != 1 || run.Taxonomies[0].Name != "OWASP ASVS" || run.Taxonomies[0].Version != "4.0.3" {
+		t.Fatalf("expected OWASP ASVS 4.0.3 taxonomy, got %+v", run.Taxonomies)
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -1,0 +1,56 @@
+package rules
+
+// ASVSVersion is the OWASP ASVS release the V14 (Build and Deploy) mappings
+// below are pinned to. Bump only after reviewing the mapping against the new
+// release.
+const ASVSVersion = "4.0.3"
+
+// asvsRequirements maps a rule ID to the OWASP ASVS v4.0.3 V14 requirement(s)
+// it provides evidence for.
+var asvsRequirements = map[string][]string{
+	"GL001": {"ASVS-V14.2.2"},
+	"GL003": {"ASVS-V14.2.1", "ASVS-V14.3.1"},
+	"GL006": {"ASVS-V14.3.3"},
+	"GL007": {"ASVS-V14.3.4"},
+	"GL008": {"ASVS-V14.3.2"},
+	"GL011": {"ASVS-V14.2.1"},
+	"GL014": {"ASVS-V14.3.3"},
+	"GL015": {"ASVS-V14.3.4"},
+	"GL016": {"ASVS-V14.2.1"},
+	"GL018": {"ASVS-V14.3.3"},
+	"GL019": {"ASVS-V14.3.1"},
+	"GL020": {"ASVS-V14.2.3"},
+	"GL021": {"ASVS-V14.3.3"},
+	"GL022": {"ASVS-V14.2.2"},
+	"GL023": {"ASVS-V14.2.2"},
+	"GL025": {"ASVS-V14.3.4"},
+	"GL026": {"ASVS-V14.2.2"},
+	"GL027": {"ASVS-V14.3.3"},
+	"GL032": {"ASVS-V14.3.3"},
+	"GL033": {"ASVS-V14.3.3"},
+	"GL035": {"ASVS-V14.3.3"},
+	"GL036": {"ASVS-V14.3.3"},
+	"GL038": {"ASVS-V14.3.3"},
+	"GL039": {"ASVS-V14.3.2"},
+	"GL041": {"ASVS-V14.2.2", "ASVS-V14.4.1"},
+}
+
+// asvsRequirementNames maps an ASVS requirement ID to its short description.
+var asvsRequirementNames = map[string]string{
+	"ASVS-V14.2.1": "Verify that all components come from trusted, continually maintained sources",
+	"ASVS-V14.2.2": "Verify that all components are up to date and pinned to a specific version",
+	"ASVS-V14.2.3": "Verify that third-party dependencies are verified for integrity",
+	"ASVS-V14.3.1": "Verify that build pipeline configuration is protected from unauthorized modification",
+	"ASVS-V14.3.2": "Verify that security tooling runs in the pipeline and failures block the build",
+	"ASVS-V14.3.3": "Verify that secrets are not present in source code or pipeline logs",
+	"ASVS-V14.3.4": "Verify that the build environment is isolated",
+	"ASVS-V14.4.1": "Verify that dependence on third-party CI/CD services is minimised",
+}
+
+// ASVSRequirements returns the ASVS V14 requirement IDs mapped to rule id, or
+// nil if the rule has no ASVS mapping.
+func ASVSRequirements(id string) []string { return asvsRequirements[id] }
+
+// ASVSRequirementName returns the human-readable description for an ASVS
+// requirement ID.
+func ASVSRequirementName(reqID string) string { return asvsRequirementNames[reqID] }


### PR DESCRIPTION
## Summary

Maps a subset of glsec rules to OWASP ASVS **v4.0.3** Chapter V14 (Build and Deploy) requirements, surfaced in JSON (`asvs` field) and SARIF (an `OWASP ASVS` taxonomy) for compliance evidence. Closes #156.

Only ASVS V14 was pursued; SLSA (#155) and SSDF (#158) were closed as not-planned (weak fit / coarse granularity vs. the existing OWASP CICD-SEC + CWE taxonomies).

## What's included

- `rules/asvs.go` — rule → ASVS requirement mapping (per the issue's draft table), `ASVSRequirements` / `ASVSRequirementName` lookups, and a pinned `ASVSVersion = "4.0.3"` constant.
- JSON output: optional `"asvs"` field per finding (omitted when empty).
- SARIF output: `OWASP ASVS` taxonomy + per-rule `superset` relationships, version `4.0.3` (mirrors the existing CWE/OWASP taxonomy wiring).
- `docs/rules.md`: *OWASP ASVS v4.0.3 — V14 mapping* cross-reference table.
- `README.md`: note that JSON/SARIF carry the ASVS mapping.

## API change

`WriteJSON` gains an `asvs` param; `WriteSARIF` gains `asvs` + `asvsName`. Internal `Write` dispatcher and all existing test call sites updated. New tests: `TestWriteJSON_WithASVS`, `TestWriteSARIF_WithASVS`.

## Scope notes

- The scheduled version-check workflow (compare pinned `ASVSVersion` against the latest OWASP/ASVS release) is tracked separately in #159 — the constant is in place for it to consume.
- Per-rule doc ASVS lines were left out to avoid 25 files of hand-maintained duplication; the single `docs/rules.md` cross-reference table + machine-readable JSON/SARIF cover the mapping. Can add per-doc lines later if wanted.

## Test

```sh
go test ./...
golangci-lint run ./...   # clean (verified locally)
glsec --format json --only GL001 ci.yml   # finding carries "asvs": ["ASVS-V14.2.2"]
```

Closes #156.