### PR TITLE
fix: align README rule table with owasp.go and enforce via test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ coverage.html
 .idea/
 .vscode/
 *.swp
+
+# Playwright MCP artifacts
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ exclude_paths:
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL002, GL004, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062 |
-| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL015, GL022, GL023, GL026, GL046, GL064 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL041, GL044, GL051, GL053 |
-| Supply Chain Integrity | CICD-SEC-9 | GL011, GL020, GL025, GL045 |
+| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062 |
+| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053 |
+| Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
-| Insecure Configuration | CICD-SEC-7 | GL005, GL007, GL016, GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |
+| Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/rules/consistency_test.go
+++ b/rules/consistency_test.go
@@ -220,3 +220,75 @@ func checkRulesOverviewLink(t *testing.T, id, overview string) {
 		t.Errorf("%s has no proper link in docs/rules.md (expected %q)", id, link)
 	}
 }
+
+// TestReadmeRuleTable verifies the README "Rules" category table stays in sync
+// with the registered rules and their owasp.go category mappings — a table
+// that is otherwise hand-maintained and prone to drift.
+func TestReadmeRuleTable(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "README.md"))
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	readme := string(data)
+
+	// Rule count: "N rules across ..." must equal the registered rule count.
+	countPat := regexp.MustCompile(`(?m)^(\d+) rules across`)
+	cm := countPat.FindStringSubmatch(readme)
+	if cm == nil {
+		t.Fatal("could not find 'N rules across' line in README")
+	}
+	want := len(All())
+	if cm[1] != fmt.Sprint(want) {
+		t.Errorf("README says %s rules, but %d are registered", cm[1], want)
+	}
+
+	// Category table rows: "| name | CICD-SEC-... | GL..., ... |".
+	rowPat := regexp.MustCompile(`(?m)^\|[^|]+\|([^|]*CICD-SEC[^|]*)\|([^|]+)\|\s*$`)
+	catPat := regexp.MustCompile(`CICD-SEC-\d+`)
+	idPat := regexp.MustCompile(`GL\d{3}`)
+
+	rows := rowPat.FindAllStringSubmatch(readme, -1)
+	if len(rows) == 0 {
+		t.Fatal("no category rows found in README rule table")
+	}
+
+	seen := map[string]int{}
+	for _, row := range rows {
+		rowCats := map[string]bool{}
+		for _, c := range catPat.FindAllString(row[1], -1) {
+			rowCats[c] = true
+		}
+		for _, id := range idPat.FindAllString(row[2], -1) {
+			seen[id]++
+			cats := OWASPCategories(id)
+			matched := false
+			for _, c := range cats {
+				if rowCats[c] {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				t.Errorf("README lists %s under categories %v, but owasp.go maps it to %v", id, keysOf(rowCats), cats)
+			}
+		}
+	}
+
+	for _, r := range All() {
+		switch seen[r.ID()] {
+		case 0:
+			t.Errorf("%s is registered but missing from the README rule table", r.ID())
+		case 1:
+		default:
+			t.Errorf("%s appears %d times in the README rule table (want 1)", r.ID(), seen[r.ID()])
+		}
+	}
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Pre-release consistency audit. Found and fixed drift between the hand-maintained README rule-category table and the source-of-truth `owasp.go` mappings, and added a test so it can't drift again.

## Audit results

Checked cross-file consistency beyond what `TestRuleConsistency` already covers:

| Check | Result |
|---|---|
| all.go / docs / fixtures / owasp.go / cwe.go / rules.md / README count | ✅ all 64 |
| Orphan doc files / fixtures (no registered rule) | ✅ none |
| ASVS: mapped rule IDs all registered; every requirement has a name; no unused names | ✅ clean |
| rules.md ASVS table vs `asvs.go` | ✅ matches |
| **README category table vs owasp.go** | ❌ **7 rules misfiled** → fixed |

### The drift

These rules were listed under a README category whose OWASP label didn't match their `owasp.go` mapping (`rules.md`, which *is* test-enforced, had them correct):

- GL002, GL007, GL015, GL025 (CICD-SEC-4) — scattered into the SEC-6/3/7/9 rows
- GL011, GL016 (CICD-SEC-3) — in the SEC-9 / SEC-7 rows
- GL005 (CICD-SEC-6) — in the SEC-7 row

The README table was regenerated from `owasp.go` so every rule sits under the row matching its category; each rule now appears exactly once.

## New check

`TestReadmeRuleTable` enforces, going forward:
1. The "N rules across …" count equals `len(All())`.
2. Every registered rule appears exactly once in the README category table.
3. Each rule's table row OWASP set intersects its `owasp.go` categories.

This is the README analogue of the existing `checkRulesOverviewSection` (which covers `docs/rules.md`).

## Also

- Removed stray Playwright verification artifacts from the repo root and added `.playwright-mcp/` to `.gitignore`.

## Test

```sh
go test ./...            # passes, incl. new TestReadmeRuleTable
golangci-lint run ./...  # clean
```