### PR TITLE
docs: pin README examples to glsec 1.3.0 / component v1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.2
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.3
 
 stages:
   - test
@@ -197,7 +197,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.2
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.3
 
 stages:
   - test
@@ -224,13 +224,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.2.0
+    name: ghcr.io/glsec/glsec:1.3.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.2.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.3.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -238,7 +238,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.2.0"
+  GLSEC_VERSION: "1.3.0"
 
 glsec:
   stage: test
@@ -260,7 +260,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.2.0
+    name: ghcr.io/glsec/glsec:1.3.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -279,7 +279,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.2.0
+    name: ghcr.io/glsec/glsec:1.3.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
## Summary

Post-release doc bump for **v1.3.0**. Updates the version pins in the README CI integration examples:

- Docker image examples: `ghcr.io/glsec/glsec:1.2.0` → `:1.3.0` (plain, SAST, Code Quality)
- Binary example: `GLSEC_VERSION: "1.2.0"` → `"1.3.0"`
- Catalog component examples: `@v1.0.2` → `@v1.0.3`
- Prose pin reference `1.2.0` → `1.3.0`

## Context

v1.3.0 is released (image + binaries live on GHCR/Releases), and the GitLab CI Catalog component `glsec-io/glsec` v1.0.3 (which defaults to glsec 1.3.0) is published. All four example repos at gitlab.com/glsec-io/examples are bumped and green.

## Test

`go test ./...` passes (including `TestReadmeRuleTable` / `TestRuleConsistency`).