### PR TITLE
fix: print clean-run summary only on a TTY (#273)

### DIFF
--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -160,6 +160,7 @@ func main() {
 	}
 
 	colorEnabled := color.IsEnabled(*noColorFlag, os.Stdout)
+	stdoutIsTTY := color.IsTerminal(os.Stdout)
 	useCache := !*noCacheFlag && !*generateIgnoreFlag
 
 	scanOpts := scanOptions{
@@ -198,7 +199,7 @@ func main() {
 		return // exit 0
 	}
 
-	if err := writeOutput(os.Stdout, format, allFindings, totalJobCount, colorEnabled); err != nil {
+	if err := writeOutput(os.Stdout, format, allFindings, totalJobCount, colorEnabled, stdoutIsTTY); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(2)
 	}
@@ -276,14 +277,14 @@ func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCoun
 }
 
 // writeOutput renders findings in the requested format.
-func writeOutput(w *os.File, format output.Format, findings []finding.Finding, jobCount int, colorEnabled bool) error {
+func writeOutput(w *os.File, format output.Format, findings []finding.Finding, jobCount int, colorEnabled, isTTY bool) error {
 	switch format {
 	case output.FormatSARIF:
 		return output.WriteSARIF(w, findings, rules.CWEID, rules.CWEName, rules.OWASPCategories, rules.OWASPCategoryName, rules.ASVSRequirements, rules.ASVSRequirementName)
 	case output.FormatJSON:
 		return output.WriteJSON(w, findings, rules.OWASPCategories, rules.ASVSRequirements)
 	default:
-		return output.Write(w, format, findings, jobCount, colorEnabled)
+		return output.Write(w, format, findings, jobCount, colorEnabled, isTTY)
 	}
 }
 

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -25,6 +25,12 @@ func IsEnabled(noColor bool, w io.Writer) bool {
 	if forceColor("FORCE_COLOR") || forceColor("CLICOLOR_FORCE") {
 		return true
 	}
+	return IsTerminal(w)
+}
+
+// IsTerminal reports whether w is a character device (an interactive
+// terminal), ignoring any color env overrides.
+func IsTerminal(w io.Writer) bool {
 	f, ok := w.(*os.File)
 	if !ok {
 		return false

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -32,7 +32,10 @@ func ParseFormat(s string) (Format, bool) {
 	}
 }
 
-func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int, colorEnabled bool) error {
+// Write renders findings in the given format. isTTY reports whether w is an
+// interactive terminal; the text format uses it to decide whether to print the
+// clean-run summary line (suppressed when piped, e.g. in CI).
+func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int, colorEnabled, isTTY bool) error {
 	switch format {
 	case FormatJSON:
 		return writeJSON(w, findings, nil, nil)
@@ -41,20 +44,23 @@ func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int,
 	case FormatCodeClimate:
 		return writeCodeClimate(w, findings)
 	case FormatTable:
-		return writeTable(w, findings, jobCount)
+		return writeTable(w, findings, jobCount, isTTY)
 	default:
-		return writeText(w, findings, jobCount, colorEnabled)
+		return writeText(w, findings, jobCount, colorEnabled, isTTY)
 	}
 }
 
 // writeTable renders findings as an aligned column table, similar to
 // osv-scanner's table output. Columns are tab-separated and padded with
 // text/tabwriter. On a clean run it falls back to the same summary line as the
-// text format.
-func writeTable(w io.Writer, findings []finding.Finding, jobCount int) error {
+// text format, which is only emitted on an interactive terminal (issue #273).
+func writeTable(w io.Writer, findings []finding.Finding, jobCount int, isTTY bool) error {
 	if len(findings) == 0 {
-		_, err := fmt.Fprintf(w, "Scanned %d jobs, 0 issues found.\n", jobCount)
-		return err
+		if isTTY {
+			_, err := fmt.Fprintf(w, "Scanned %d jobs, 0 issues found.\n", jobCount)
+			return err
+		}
+		return nil
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -75,7 +81,7 @@ func writeTable(w io.Writer, findings []finding.Finding, jobCount int) error {
 	return tw.Flush()
 }
 
-func writeText(w io.Writer, findings []finding.Finding, jobCount int, col bool) error {
+func writeText(w io.Writer, findings []finding.Finding, jobCount int, col, isTTY bool) error {
 	for _, f := range findings {
 		sev := strings.ToUpper(string(f.Severity))
 		switch f.Severity {
@@ -101,7 +107,10 @@ func writeText(w io.Writer, findings []finding.Finding, jobCount int, col bool) 
 			return err
 		}
 	}
-	if len(findings) == 0 {
+	// The clean-run summary is a human-facing nicety: only emit it on an
+	// interactive terminal. When piped (e.g. a CI runner), keep stdout empty so
+	// the line cannot be duplicated by the executor's trace handling (issue #273).
+	if len(findings) == 0 && isTTY {
 		_, err := fmt.Fprintf(w, "Scanned %d jobs, 0 issues found.\n", jobCount)
 		return err
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -22,7 +22,7 @@ var testFindingsWithJob = []finding.Finding{
 
 func TestWriteText(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, testFindings, 5, false); err != nil {
+	if err := Write(&buf, FormatText, testFindings, 5, false, false); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -39,7 +39,7 @@ func TestWriteText(t *testing.T) {
 
 func TestWriteText_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, nil, 7, false); err != nil {
+	if err := Write(&buf, FormatText, nil, 7, false, true); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -48,9 +48,19 @@ func TestWriteText_Empty(t *testing.T) {
 	}
 }
 
+func TestWriteText_EmptyNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatText, nil, 7, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("expected no summary line when not a TTY, got %q", got)
+	}
+}
+
 func TestWriteJSON(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, testFindings, 0, false); err != nil {
+	if err := Write(&buf, FormatJSON, testFindings, 0, false, false); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -68,7 +78,7 @@ func TestWriteJSON(t *testing.T) {
 
 func TestWriteJSON_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, nil, 0, false); err != nil {
+	if err := Write(&buf, FormatJSON, nil, 0, false, false); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -82,7 +92,7 @@ func TestWriteJSON_Empty(t *testing.T) {
 
 func TestWriteSARIF(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatSARIF, testFindings, 0, false); err != nil {
+	if err := Write(&buf, FormatSARIF, testFindings, 0, false, false); err != nil {
 		t.Fatal(err)
 	}
 	var log sarifLog
@@ -113,7 +123,7 @@ func TestWriteSARIF(t *testing.T) {
 
 func TestWriteText_WithJob(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatText, testFindingsWithJob, 3, false); err != nil {
+	if err := Write(&buf, FormatText, testFindingsWithJob, 3, false, false); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -133,7 +143,7 @@ func TestWriteText_WithJob(t *testing.T) {
 
 func TestWriteJSON_WithJob(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatJSON, testFindingsWithJob, 0, false); err != nil {
+	if err := Write(&buf, FormatJSON, testFindingsWithJob, 0, false, false); err != nil {
 		t.Fatal(err)
 	}
 	var out jsonOutput
@@ -153,7 +163,7 @@ func TestWriteJSON_WithJob(t *testing.T) {
 
 func TestWriteTable(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatTable, testFindingsWithJob, 3, false); err != nil {
+	if err := Write(&buf, FormatTable, testFindingsWithJob, 3, false, false); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -171,7 +181,7 @@ func TestWriteTable(t *testing.T) {
 
 func TestWriteTable_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatTable, nil, 9, false); err != nil {
+	if err := Write(&buf, FormatTable, nil, 9, false, true); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -180,6 +190,16 @@ func TestWriteTable_Empty(t *testing.T) {
 	}
 	if strings.Contains(got, "SEVERITY") {
 		t.Errorf("did not expect a table header on a clean run, got %q", got)
+	}
+}
+
+func TestWriteTable_EmptyNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatTable, nil, 9, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("expected no summary line when not a TTY, got %q", got)
 	}
 }
 
@@ -290,7 +310,7 @@ func TestWriteJSON_WithOWASP(t *testing.T) {
 
 func TestWriteCodeClimate(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatCodeClimate, testFindings, 0, false); err != nil {
+	if err := Write(&buf, FormatCodeClimate, testFindings, 0, false, false); err != nil {
 		t.Fatal(err)
 	}
 	var issues []codeClimateIssue
@@ -331,7 +351,7 @@ func TestWriteCodeClimate(t *testing.T) {
 
 func TestWriteCodeClimate_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := Write(&buf, FormatCodeClimate, nil, 0, false); err != nil {
+	if err := Write(&buf, FormatCodeClimate, nil, 0, false, false); err != nil {
 		t.Fatal(err)
 	}
 	var issues []codeClimateIssue


### PR DESCRIPTION
## What changed

The clean-run summary line (`Scanned N jobs, 0 issues found.`) is now printed **only when stdout is an interactive terminal**. When stdout is piped — as it always is inside a CI runner — the line is suppressed and stdout stays empty on a clean run.

## Why

Issue #273 reports the summary appearing twice under the GitLab CI shell executor:

```
$ glsec
Scanned 22 jobs, 0 issues found.
Scanned 22 jobs, 0 issues found.
```

The issue hypothesised that glsec detects CI env vars and emits the line through a second code path. That is not the case — glsec has no CI detection, and the line is written exactly once to stdout (`internal/output/output.go`). Locally it prints once; the duplication is an artifact of how the shell executor's trace captures the child process's stdout.

Rather than chase the executor quirk, this treats the summary for what it is: a human-facing convenience. It belongs on an interactive terminal, not in machine-captured output. Suppressing it when piped makes the doubling impossible and keeps stdout clean for clean runs (consistent with the isatty behaviour of tools like `git status`).

## How it works

- `color.IsTerminal(w)` is factored out of `color.IsEnabled` to expose a plain char-device check (independent of `NO_COLOR`/`FORCE_COLOR` overrides).
- `output.Write` / `writeText` take an `isTTY` argument; the summary is gated on `len(findings) == 0 && isTTY`.
- `main` computes `color.IsTerminal(os.Stdout)` and threads it through.

Findings output and all other formats (json, sarif, codeclimate) are unchanged.

## How to test

```
# Clean pipeline, piped (CI-like) → no output
glsec clean.yml | cat
# Clean pipeline, interactive terminal → summary shown
glsec clean.yml
```

- `go test ./...` — added `TestWriteText_EmptyNonTTY` (no summary when piped) and updated `TestWriteText_Empty` (summary when TTY).
- `golangci-lint run ./...` clean.

Closes #273