### PR TITLE
feat: add table output format (#274)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ glsec pipelines/*.yml
 # recursively scan a tree for all .gitlab-ci.yml files
 glsec --recursive .
 
+# aligned table view, easier to scan when there are many findings
+glsec --format table .gitlab-ci.yml
+
 # JSON output for machine consumption
 glsec --format json .gitlab-ci.yml
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -59,7 +59,7 @@ func main() {
 		return
 	}
 
-	formatFlag := flag.String("format", "text", "output format: text, json, sarif, codeclimate")
+	formatFlag := flag.String("format", "text", "output format: text, table, json, sarif, codeclimate")
 	configFlag := flag.String("config", config.DefaultFile, "path to .glsec.yml config file")
 	versionFlag := flag.Bool("version", false, "print version and exit")
 	gitlabVersionFlag := flag.String("gitlab-version", "", "target GitLab version, e.g. 16.0 (skips rules not available in that version)")
@@ -109,7 +109,7 @@ func main() {
 
 	format, ok := output.ParseFormat(*formatFlag)
 	if !ok {
-		fmt.Fprintf(os.Stderr, "unknown format %q — use text, json, sarif, or codeclimate\n", *formatFlag)
+		fmt.Fprintf(os.Stderr, "unknown format %q — use text, table, json, sarif, or codeclimate\n", *formatFlag)
 		os.Exit(2)
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/glsec/glsec/internal/color"
 	"github.com/glsec/glsec/internal/finding"
@@ -19,11 +20,12 @@ const (
 	FormatJSON        Format = "json"
 	FormatSARIF       Format = "sarif"
 	FormatCodeClimate Format = "codeclimate"
+	FormatTable       Format = "table"
 )
 
 func ParseFormat(s string) (Format, bool) {
 	switch Format(s) {
-	case FormatText, FormatJSON, FormatSARIF, FormatCodeClimate:
+	case FormatText, FormatJSON, FormatSARIF, FormatCodeClimate, FormatTable:
 		return Format(s), true
 	default:
 		return "", false
@@ -38,9 +40,39 @@ func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int,
 		return writeSARIF(w, findings, nil, nil, nil, nil, nil, nil)
 	case FormatCodeClimate:
 		return writeCodeClimate(w, findings)
+	case FormatTable:
+		return writeTable(w, findings, jobCount)
 	default:
 		return writeText(w, findings, jobCount, colorEnabled)
 	}
+}
+
+// writeTable renders findings as an aligned column table, similar to
+// osv-scanner's table output. Columns are tab-separated and padded with
+// text/tabwriter. On a clean run it falls back to the same summary line as the
+// text format.
+func writeTable(w io.Writer, findings []finding.Finding, jobCount int) error {
+	if len(findings) == 0 {
+		_, err := fmt.Fprintf(w, "Scanned %d jobs, 0 issues found.\n", jobCount)
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "SEVERITY\tRULE\tJOB\tFILE\tLINE\tMESSAGE"); err != nil {
+		return err
+	}
+	for _, f := range findings {
+		job := f.Job
+		if job == "" {
+			job = "-"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
+			strings.ToUpper(string(f.Severity)), f.RuleID, job, f.File, f.Line, f.Message,
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
 }
 
 func writeText(w io.Writer, findings []finding.Finding, jobCount int, col bool) error {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -151,6 +151,38 @@ func TestWriteJSON_WithJob(t *testing.T) {
 	}
 }
 
+func TestWriteTable(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatTable, testFindingsWithJob, 3, false); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{"SEVERITY", "RULE", "JOB", "FILE", "LINE", "MESSAGE", "GL024", "phpmd", ".gitlab-ci.yml"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("table output missing %q:\n%s", want, got)
+		}
+	}
+	// A finding without a job renders a "-" placeholder, never an empty cell.
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if !strings.Contains(lines[len(lines)-1], "-") {
+		t.Errorf("expected job placeholder in no-job row, got: %q", lines[len(lines)-1])
+	}
+}
+
+func TestWriteTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatTable, nil, 9, false); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "9") || !strings.Contains(got, "0 issues found") {
+		t.Errorf("expected summary line on clean run, got %q", got)
+	}
+	if strings.Contains(got, "SEVERITY") {
+		t.Errorf("did not expect a table header on a clean run, got %q", got)
+	}
+}
+
 func TestParseFormat(t *testing.T) {
 	for _, tc := range []struct {
 		in   string
@@ -158,6 +190,7 @@ func TestParseFormat(t *testing.T) {
 		ok   bool
 	}{
 		{"text", FormatText, true},
+		{"table", FormatTable, true},
 		{"json", FormatJSON, true},
 		{"sarif", FormatSARIF, true},
 		{"codeclimate", FormatCodeClimate, true},


### PR DESCRIPTION
## What changed

Adds `table` as a new value for the `-format` flag:

```
-format string   output format: text, table, json, sarif, codeclimate (default "text")
```

Findings are rendered as an aligned column table (via `text/tabwriter`), easier to scan than the one-line-per-finding `text` format when there are many findings:

```
SEVERITY  RULE   JOB         FILE                         LINE  MESSAGE
WARN      GL017  deploy-job  testdata/fixtures/clean.yml  32    job "deploy-job" deploys or publishes but has no tags: …
WARN      GL019  deploy-job  testdata/fixtures/clean.yml  32    job "deploy-job" deploys or publishes but has no resource_group: …
WARN      GL053  -           testdata/fixtures/clean.yml  1     no top-level workflow:rules — …
```

## Design decisions

- **Opt-in only.** The table is selected explicitly with `-format table`; `text` remains the default and there is no isatty auto-switching. (The issue floated auto-switching on a TTY, but keeping format selection explicit avoids surprising behaviour changes for existing `text` users and keeps stdout deterministic.)
- **No-job placeholder.** Findings without a job (file-level rules) render `-` in the JOB column instead of an empty cell.
- **Clean run.** With zero findings the table format prints the same `Scanned N jobs, 0 issues found.` summary as `text`, rather than an empty header.
- **No ANSI color** in the table — escape codes break `tabwriter` column alignment.

## How to test

```
glsec --format table .gitlab-ci.yml         # aligned findings table
glsec --format table clean.yml              # → "Scanned N jobs, 0 issues found."
glsec --format xml .gitlab-ci.yml           # → error lists table among valid formats
```

- `go test ./...` — added `TestWriteTable`, `TestWriteTable_Empty`, and a `table` case in `TestParseFormat`.
- `golangci-lint run ./...` clean.

Closes #274