### PR TITLE
feat: GL033 also flags CI_DEBUG_SERVICES (#266)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,7 +21,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL018](rules/GL018.md) | `warn`  | Secret variable re-exported at pipeline level — available to all jobs including untrusted ones |
 | [GL021](rules/GL021.md) | `warn`  | Secret variable value printed to job log via `echo`/`printf` |
 | [GL032](rules/GL032.md) | `warn`  | SSH private key written to file via `echo` — key appears in job logs when debug tracing is active |
-| [GL033](rules/GL033.md) | `error` | `CI_DEBUG_TRACE: "true"` committed — shell tracing dumps all variable values including secrets to job logs |
+| [GL033](rules/GL033.md) | `error`/`warn` | `CI_DEBUG_TRACE`/`CI_DEBUG_SERVICES` committed — debug logging dumps variable values or service-container credentials to job logs |
 | [GL029](rules/GL029.md) | `warn`  | `docker login -p` exposes password in process table — use `--password-stdin` instead |
 | [GL035](rules/GL035.md) | `warn`  | `git` command uses URL with embedded credentials (`user:token@host`) — token appears in job logs |
 | [GL038](rules/GL038.md) | `error` | Hardcoded credential literal passed to CLI tool in script (`sqlcmd -P`, `mysql -p`, `PGPASSWORD=`, etc.) |

--- a/docs/rules/GL033.md
+++ b/docs/rules/GL033.md
@@ -1,17 +1,23 @@
-# GL033 — `CI_DEBUG_TRACE` enabled in committed pipeline YAML
+# GL033 — debug logging toggles enabled in committed pipeline YAML
 
-**Severity:** `error`  
+**Severity:** `error` (`CI_DEBUG_TRACE`) / `warn` (`CI_DEBUG_SERVICES`)  
 **OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
 
 ## What glsec checks
 
-glsec flags any `variables:` block — top-level or job-level — where `CI_DEBUG_TRACE` is set to `"true"`. When enabled, GitLab activates `set -x` shell tracing for the entire job, which prints every command with fully-expanded arguments to the job log, including the values of all CI variables — protected and masked alike. Committing this setting creates a persistent secret-dumping configuration accessible to anyone who can retry the pipeline.
+glsec flags any `variables:` block — top-level, `default:`, or job-level — that commits one of GitLab's debug logging toggles:
+
+- **`CI_DEBUG_TRACE: "true"`** (`error`) — activates `set -x` shell tracing for the entire job, printing every command with fully-expanded arguments to the job log, including the values of all CI variables, protected and masked alike.
+- **`CI_DEBUG_SERVICES`** set to a truthy value (`"true"`, `true`, `"1"`) (`warn`) — enables verbose logging of service containers, leaking their startup environment and any credentials passed to them (registry auth, database passwords) into the job log.
+
+Committing either creates a persistent secret-dumping configuration accessible to anyone who can retry the pipeline.
 
 ## Trigger example
 
 ```yaml
 variables:
-  CI_DEBUG_TRACE: "true"   # dumps all CI variable values to the job log
+  CI_DEBUG_TRACE: "true"      # dumps all CI variable values to the job log
+  CI_DEBUG_SERVICES: "true"   # dumps service-container logs incl. credentials
 ```
 
 Or at job level:
@@ -26,10 +32,10 @@ deploy:
 
 ## Safe alternative
 
-Remove `CI_DEBUG_TRACE` from the committed YAML. Use the GitLab UI **Run pipeline** dialog to pass it as a transient variable for a single run — it will not persist in the repository.
+Remove the toggle from the committed YAML. Use the GitLab UI **Run pipeline** dialog to pass it as a transient variable for a single run — it will not persist in the repository.
 
 ## References
 
-- [GitLab docs: Debug CI/CD pipelines with CI_DEBUG_TRACE](https://docs.gitlab.com/ee/ci/variables/#debug-logging)
+- [GitLab docs: Debug logging (`CI_DEBUG_TRACE`, `CI_DEBUG_SERVICES`)](https://docs.gitlab.com/ee/ci/variables/#debug-logging)
 - GL021: secret variable value printed to job log via `echo`/`printf`
 - GL027: secret-like variable missing `masked: true`

--- a/rules/gl033.go
+++ b/rules/gl033.go
@@ -16,52 +16,67 @@ func (r *gl033) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 	mapping := parser.Unwrap(doc)
 
-	if f := checkDebugTrace(parser.FindKey(mapping, "variables"), file, ""); f != nil {
-		findings = append(findings, *f)
-	}
+	findings = append(findings, checkDebugVars(parser.FindKey(mapping, "variables"), file, "")...)
 
 	if def := parser.FindKey(mapping, "default"); def != nil {
-		if f := checkDebugTrace(parser.FindKey(def, "variables"), file, ""); f != nil {
-			findings = append(findings, *f)
-		}
+		findings = append(findings, checkDebugVars(parser.FindKey(def, "variables"), file, "")...)
 	}
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		if f := checkDebugTrace(parser.FindKey(job, "variables"), file, name.Value); f != nil {
-			findings = append(findings, *f)
-		}
+		findings = append(findings, checkDebugVars(parser.FindKey(job, "variables"), file, name.Value)...)
 	})
 
 	return findings
 }
 
-func checkDebugTrace(node *yaml.Node, file, job string) *finding.Finding {
+// checkDebugVars flags GitLab debug toggles committed in a variables: block.
+// CI_DEBUG_TRACE dumps every variable value to the log (error); CI_DEBUG_SERVICES
+// dumps service-container logs including their credentials (warn).
+func checkDebugVars(node *yaml.Node, file, job string) []finding.Finding {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
+	var findings []finding.Finding
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := node.Content[i]
-		val := node.Content[i+1]
-		if key.Value != "CI_DEBUG_TRACE" {
-			continue
-		}
-		scalar := resolveScalar(val)
+		scalar := resolveScalar(node.Content[i+1])
 		if scalar == nil {
 			continue
 		}
-		if scalar.Value != "true" {
-			continue
+		switch key.Value {
+		case "CI_DEBUG_TRACE":
+			if scalar.Value != "true" {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL033",
+				Severity: finding.Error,
+				Job:      job,
+				Message:  "CI_DEBUG_TRACE: \"true\" is committed — shell tracing dumps all variable values including secrets to the job log; remove it and use the GitLab UI run-pipeline dialog for transient debugging",
+				File:     file,
+				Line:     key.Line,
+				Col:      key.Column,
+			})
+		case "CI_DEBUG_SERVICES":
+			if !isDebugTruthy(scalar.Value) {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL033",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  "CI_DEBUG_SERVICES: \"true\" is committed — verbose service-container logging leaks their startup environment and credentials to the job log; remove it and use the GitLab UI run-pipeline dialog for transient debugging",
+				File:     file,
+				Line:     key.Line,
+				Col:      key.Column,
+			})
 		}
-		f := finding.Finding{
-			RuleID:   "GL033",
-			Severity: finding.Error,
-			Job:      job,
-			Message:  "CI_DEBUG_TRACE: \"true\" is committed — shell tracing dumps all variable values including secrets to the job log; remove it and use the GitLab UI run-pipeline dialog for transient debugging",
-			File:     file,
-			Line:     key.Line,
-			Col:      key.Column,
-		}
-		return &f
 	}
-	return nil
+	return findings
+}
+
+// isDebugTruthy reports whether v enables a GitLab debug toggle. GitLab treats
+// "true" and "1" as on for CI_DEBUG_SERVICES.
+func isDebugTruthy(v string) bool {
+	return v == "true" || v == "1"
 }

--- a/rules/gl033_test.go
+++ b/rules/gl033_test.go
@@ -1,8 +1,10 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/parser"
 )
 
@@ -50,6 +52,48 @@ deploy:
     - ./deploy.sh`,
 			wantHits: 2,
 		},
+		{
+			name: "top-level CI_DEBUG_SERVICES true",
+			yaml: `variables:
+  CI_DEBUG_SERVICES: "true"`,
+			wantHits: 1,
+		},
+		{
+			name: "CI_DEBUG_SERVICES unquoted true",
+			yaml: `variables:
+  CI_DEBUG_SERVICES: true`,
+			wantHits: 1,
+		},
+		{
+			name: "CI_DEBUG_SERVICES truthy 1",
+			yaml: `variables:
+  CI_DEBUG_SERVICES: "1"`,
+			wantHits: 1,
+		},
+		{
+			name: "CI_DEBUG_SERVICES false — safe",
+			yaml: `variables:
+  CI_DEBUG_SERVICES: "false"`,
+			wantHits: 0,
+		},
+		{
+			name: "job-level CI_DEBUG_SERVICES true",
+			yaml: `e2e:
+  variables:
+    CI_DEBUG_SERVICES: "true"
+  services:
+    - postgres:16
+  script:
+    - ./test.sh`,
+			wantHits: 1,
+		},
+		{
+			name: "both debug toggles in one block — two findings",
+			yaml: `variables:
+  CI_DEBUG_TRACE: "true"
+  CI_DEBUG_SERVICES: "true"`,
+			wantHits: 2,
+		},
 	}
 
 	for _, tt := range tests {
@@ -66,5 +110,25 @@ deploy:
 				}
 			}
 		})
+	}
+}
+
+func TestGL033Severity(t *testing.T) {
+	doc, err := parser.Parse([]byte(`variables:
+  CI_DEBUG_TRACE: "true"
+  CI_DEBUG_SERVICES: "true"`), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	want := map[string]finding.Severity{
+		"CI_DEBUG_TRACE":    finding.Error,
+		"CI_DEBUG_SERVICES": finding.Warn,
+	}
+	for _, f := range GL033.Check(doc.Root, "test.yml") {
+		for varName, sev := range want {
+			if strings.Contains(f.Message, varName) && f.Severity != sev {
+				t.Errorf("%s: got severity %q, want %q", varName, f.Severity, sev)
+			}
+		}
 	}
 }

--- a/testdata/fixtures/gl033-ci-debug-trace-enabled.yml
+++ b/testdata/fixtures/gl033-ci-debug-trace-enabled.yml
@@ -1,2 +1,3 @@
 variables:
   CI_DEBUG_TRACE: "true"
+  CI_DEBUG_SERVICES: "true"


### PR DESCRIPTION
## What changed

Extends **GL033** to flag `CI_DEBUG_SERVICES` in addition to the existing `CI_DEBUG_TRACE`, reusing the same `variables:` scopes (top-level, `default:`, job-level) and matching logic.

| Variable | Severity | Leaks |
|----------|----------|-------|
| `CI_DEBUG_TRACE` | `error` (unchanged) | every CI variable value via `set -x` |
| `CI_DEBUG_SERVICES` | `warn` (new) | service-container startup env + credentials |

## Why

`CI_DEBUG_SERVICES` is GitLab's second debug toggle. It enables verbose logging of service containers — including their startup environment and any credentials passed to them (registry auth, database passwords) — and dumps it into the job log the same way `CI_DEBUG_TRACE` does, but glsec ignored it. Implemented as an extension of GL033 (same rule ID) rather than a new rule, per the issue.

Severity is `warn` rather than `error`: narrower blast radius (service logs vs. *every* variable). The existing `CI_DEBUG_TRACE` finding is unchanged.

## Detection details

- Fires on `CI_DEBUG_SERVICES` set to a truthy value: `"true"`, unquoted `true`, or `"1"` (GitLab's accepted forms).
- `CI_DEBUG_TRACE` matching is untouched (still only `"true"`).
- Both can fire independently in the same block → two findings.

## How to test

```yaml
variables:
  CI_DEBUG_SERVICES: "true"
```
```
glsec --format table .gitlab-ci.yml   # → WARN GL033 on the CI_DEBUG_SERVICES line
```

- `go test ./...` — added cases for `"true"` / unquoted `true` / `"1"` / `"false"` / job-level / both-toggles, plus a `TestGL033Severity` asserting error-vs-warn. `TestRuleConsistency` still passes (fixture extended).
- `golangci-lint run ./...` clean.

Docs (`docs/rules/GL033.md`, `docs/rules.md`) and the fixture updated to cover both toggles.

## OWASP / CWE

Unchanged — CICD-SEC-6 (Insufficient Credential Hygiene), CWE-532 (Insertion of Sensitive Information into Log File).

Closes #266