### PR TITLE
chore: bump README version pins to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,13 +227,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.3.0
+    name: ghcr.io/glsec/glsec:1.4.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.3.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.4.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -241,7 +241,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.3.0"
+  GLSEC_VERSION: "1.4.0"
 
 glsec:
   stage: test
@@ -263,7 +263,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.3.0
+    name: ghcr.io/glsec/glsec:1.4.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -282,7 +282,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.3.0
+    name: ghcr.io/glsec/glsec:1.4.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
Prep for the v1.4.0 release: update the install/usage examples in the README from `1.3.0` to `1.4.0` (Docker image tags and `GLSEC_VERSION`).

Docs-only; no code changes.