### PR TITLE
Add GL065: flag container images from non-allowlisted registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ exclude_paths:
 
 ## Rules
 
-64 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+65 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -138,6 +138,7 @@ func main() {
 	}
 
 	rules.GL016.SetTrustedHosts(cfg.TrustedHosts)
+	rules.GL065.SetAllowedRegistries(cfg.AllowedRegistries)
 
 	// --gitlab-version flag overrides the config file value.
 	gitlabVersionStr := cfg.GitLabVersion

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -64,6 +64,7 @@ User-controlled inputs and unversioned component references that allow malicious
 | [GL044](rules/GL044.md) | `warn`  | MR-triggered job checks out `$CI_MERGE_REQUEST_SOURCE_BRANCH_SHA` — executes attacker-controlled code with `$CI_JOB_TOKEN` access |
 | [GL051](rules/GL051.md) | `warn`  | Unconstrained `spec:inputs` entry interpolated into `image:`, `script:`, or `environment:name:` — caller can supply arbitrary values |
 | [GL053](rules/GL053.md) | `warn`  | Missing or unrestricted `workflow:rules` — pipelines run for every event, including untrusted fork merge requests |
+| [GL065](rules/GL065.md) | `warn`  | `image:`/`services:` from a registry not in the opt-in `allowed_registries` allowlist |
 
 ---
 
@@ -128,7 +129,7 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 
 | ASVS requirement | Rules |
 |---|---|
-| V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016 |
+| V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016, GL065 |
 | V14.2.2 — Components up to date and pinned | GL001, GL022, GL023, GL026, GL041 |
 | V14.2.3 — Dependencies verified for integrity | GL020 |
 | V14.3.1 — Pipeline config protected from modification | GL003, GL019 |

--- a/docs/rules/GL065.md
+++ b/docs/rules/GL065.md
@@ -1,0 +1,45 @@
+# GL065 — Container image from a non-allowlisted registry
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)  
+**CWE:** [CWE-829 – Inclusion of Functionality from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html)
+
+## Risk
+
+A pipeline can pull an `image:` or `services:` entry from any registry. An image from an untrusted or unexpected registry runs with full access to the job's secrets and build context, so a compromised or malicious image is a direct path to pipeline execution. Teams that mandate a curated internal registry (or a small set of trusted public ones) have no way to enforce that from `.gitlab-ci.yml` alone.
+
+## How glsec checks
+
+This rule is **opt-in and config-driven**: it does nothing until you set `allowed_registries:` in `.glsec.yml`. Once set, glsec flags any `image:` / `services:` reference whose registry is not on the list.
+
+```yaml
+# .glsec.yml
+allowed_registries:
+  - registry.example.com   # bare host — any image from this registry is allowed
+  - ghcr.io/myorg          # host + namespace — only this namespace is allowed
+```
+
+- **No-op when unset** — without `allowed_registries`, nothing is flagged (so the default behaviour does not complain about every `docker.io` image).
+- **Registry host** is the part before the first `/` when it contains a `.` or `:port` (or is `localhost`). Bare images like `node:20` and Docker Hub namespaces like `myorg/app` resolve to `docker.io` implicitly.
+- **Bare-host entries** (`registry.example.com`) match by host; **namespace entries** (`ghcr.io/myorg`) match as a host/namespace prefix, so `ghcr.io/myorg/app` is allowed but `ghcr.io/other/app` is not.
+- **Variable hosts are exempt** — `image: $MY_IMAGE` or `image: $REGISTRY/app` cannot be resolved statically and are not flagged (a resolvable host with a variable path, e.g. `docker.io/$IMAGE`, is still checked).
+
+## Trigger example
+
+```yaml
+# .glsec.yml has allowed_registries: [registry.example.com]
+build:
+  image: docker.io/library/node:20   # flagged — docker.io is not on the allowlist
+```
+
+## Safe alternative
+
+```yaml
+build:
+  image: registry.example.com/node:20
+```
+
+## Notes
+
+- Mirrors the config-driven model used by [GL016](GL016.md) (`trusted-hosts`).
+- To allow Docker Hub explicitly, add `docker.io` to the list.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,10 @@ type Config struct {
 	GitLabVersion string `yaml:"gitlab-version"`
 	// TrustedHosts is a list of hostnames or CIDRs whose HTTP URLs are never flagged.
 	TrustedHosts []string `yaml:"trusted-hosts"`
+	// AllowedRegistries is an opt-in allowlist of container registry hosts (or
+	// host/namespace prefixes). When non-empty, GL065 flags any image/service
+	// from a registry not on the list. Empty disables the check.
+	AllowedRegistries []string `yaml:"allowed_registries"`
 	// ShellCheck holds optional ShellCheck integration settings.
 	ShellCheck ShellCheckConfig `yaml:"shellcheck"`
 	// Strict makes warn findings count as errors for exit-code purposes.
@@ -146,16 +150,17 @@ func parse(data []byte, path string) (*Config, error) {
 }
 
 var allowedTopLevelKeys = map[string]bool{
-	"rules":          true,
-	"min-severity":   true,
-	"gitlab-version": true,
-	"trusted-hosts":  true,
-	"strict":         true,
-	"no-exit-codes":  true,
-	"exclude_paths":  true,
-	"owasp":          true,
-	"owasp_exclude":  true,
-	"shellcheck":     true,
+	"rules":              true,
+	"min-severity":       true,
+	"gitlab-version":     true,
+	"trusted-hosts":      true,
+	"allowed_registries": true,
+	"strict":             true,
+	"no-exit-codes":      true,
+	"exclude_paths":      true,
+	"owasp":              true,
+	"owasp_exclude":      true,
+	"shellcheck":         true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {

--- a/rules/all.go
+++ b/rules/all.go
@@ -68,5 +68,6 @@ func All() []rule.Rule {
 		GL062,
 		GL063,
 		GL064,
+		GL065,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -33,6 +33,7 @@ var asvsRequirements = map[string][]string{
 	"GL038": {"ASVS-V14.3.3"},
 	"GL039": {"ASVS-V14.3.2"},
 	"GL041": {"ASVS-V14.2.2", "ASVS-V14.4.1"},
+	"GL065": {"ASVS-V14.2.1"},
 }
 
 // asvsRequirementNames maps an ASVS requirement ID to its short description.

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -66,6 +66,7 @@ var cweIDs = map[string]string{
 	"GL062": "CWE-532",
 	"GL063": "CWE-732",
 	"GL064": "CWE-829",
+	"GL065": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl065.go
+++ b/rules/gl065.go
@@ -1,0 +1,142 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl065 struct {
+	allowedRegistries []string
+}
+
+var GL065 = &gl065{}
+
+func (r *gl065) ID() string { return "GL065" }
+
+// SetAllowedRegistries configures the opt-in registry allowlist. When empty,
+// the rule is a no-op and flags nothing (avoids flagging every docker.io image
+// by default).
+func (r *gl065) SetAllowedRegistries(registries []string) {
+	r.allowedRegistries = registries
+}
+
+func (r *gl065) Check(doc *yaml.Node, file string) []finding.Finding {
+	if len(r.allowedRegistries) == 0 {
+		return nil
+	}
+
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, r.checkImage(parser.FindKey(mapping, "image"), file)...)
+	findings = append(findings, r.checkServices(parser.FindKey(mapping, "services"), file)...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, r.checkImage(parser.FindKey(def, "image"), file)...)
+		findings = append(findings, r.checkServices(parser.FindKey(def, "services"), file)...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range r.checkImage(parser.FindKey(job, "image"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+		for _, f := range r.checkServices(parser.FindKey(job, "services"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func (r *gl065) checkImage(node *yaml.Node, file string) []finding.Finding {
+	if node == nil {
+		return nil
+	}
+	ref, line, col := imageRef(node)
+	return r.checkRegistry(ref, line, col, file)
+}
+
+func (r *gl065) checkServices(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		ref, line, col := imageRef(item)
+		findings = append(findings, r.checkRegistry(ref, line, col, file)...)
+	}
+	return findings
+}
+
+func (r *gl065) checkRegistry(ref string, line, col int, file string) []finding.Finding {
+	if ref == "" {
+		return nil
+	}
+	// The registry host of $REGISTRY/app or a fully variable ref ($MY_IMAGE) is
+	// not statically resolvable, so it cannot be checked against the allowlist.
+	if registryHostUnresolvable(ref) {
+		return nil
+	}
+	host, normalized := normalizeRegistry(ref)
+	if registryAllowed(host, normalized, r.allowedRegistries) {
+		return nil
+	}
+	return []finding.Finding{{
+		RuleID:   "GL065",
+		Severity: finding.Warn,
+		Message:  fmt.Sprintf("image %q is from registry %q, which is not in the allowed_registries allowlist", ref, host),
+		File:     file, Line: line, Col: col,
+	}}
+}
+
+// registryHostUnresolvable reports whether the registry-host portion of an
+// image reference contains a variable expansion.
+func registryHostUnresolvable(ref string) bool {
+	first := ref
+	if i := strings.Index(ref, "/"); i >= 0 {
+		first = ref[:i]
+	}
+	return strings.Contains(first, "$")
+}
+
+// normalizeRegistry returns the registry host and the reference normalized to
+// carry an explicit, lowercased host. The first path segment is the registry
+// only when it contains a "." or ":port" (or is "localhost"); bare images
+// (node:20) and Docker Hub namespaces (myorg/app) resolve to docker.io.
+func normalizeRegistry(ref string) (host, normalized string) {
+	if i := strings.Index(ref, "/"); i >= 0 {
+		first := ref[:i]
+		if first == "localhost" || strings.ContainsAny(first, ".:") {
+			host = strings.ToLower(first)
+			return host, host + ref[i:]
+		}
+	}
+	return "docker.io", "docker.io/" + ref
+}
+
+// registryAllowed reports whether the image matches any allowlist entry. A bare
+// entry (registry.example.com) matches by host; an entry that contains a path
+// (ghcr.io/myorg) matches as a host/namespace prefix of the normalized ref.
+func registryAllowed(host, normalized string, allow []string) bool {
+	normLower := strings.ToLower(normalized)
+	for _, entry := range allow {
+		e := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(entry), "/"))
+		if e == "" {
+			continue
+		}
+		if strings.Contains(e, "/") {
+			if normLower == e || strings.HasPrefix(normLower, e+"/") {
+				return true
+			}
+		} else if host == e {
+			return true
+		}
+	}
+	return false
+}

--- a/rules/gl065_test.go
+++ b/rules/gl065_test.go
@@ -1,0 +1,188 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings065(t *testing.T, yaml string, allowed []string) []finding.Finding {
+	t.Helper()
+	r := &gl065{allowedRegistries: allowed}
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return r.Check(doc.Root, "test.yml")
+}
+
+func TestGL065_NoOpWhenUnset(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: docker.io/library/node:20
+`, nil)
+	if len(f) != 0 {
+		t.Errorf("expected no findings when allowlist is empty, got %d", len(f))
+	}
+}
+
+func TestGL065_DisallowedExplicitRegistry(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: docker.io/library/node:20
+`, []string{"registry.example.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for docker.io image, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL065_AllowedExplicitRegistry(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: registry.example.com/node:20
+`, []string{"registry.example.com"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for allowlisted registry, got %d", len(f))
+	}
+}
+
+func TestGL065_BareImageResolvesToDockerHub(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: node:20
+`, []string{"registry.example.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for bare image (docker.io), got %d", len(f))
+	}
+}
+
+func TestGL065_DockerHubAllowed(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: node:20
+`, []string{"docker.io"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding when docker.io is allowlisted, got %d", len(f))
+	}
+}
+
+func TestGL065_NamespacePrefixAllowed(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: ghcr.io/myorg/app:1.0.0
+`, []string{"ghcr.io/myorg"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for image under allowed namespace, got %d", len(f))
+	}
+}
+
+func TestGL065_NamespacePrefixOtherFlagged(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: ghcr.io/other/app:1.0.0
+`, []string{"ghcr.io/myorg"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for image outside allowed namespace, got %d", len(f))
+	}
+}
+
+func TestGL065_NamespacePrefixIsNotSubstring(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: ghcr.io/myorg-evil/app:1.0.0
+`, []string{"ghcr.io/myorg"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding — myorg-evil is not under myorg, got %d", len(f))
+	}
+}
+
+func TestGL065_DockerHubNamespacePrefix(t *testing.T) {
+	clean := findings065(t, `
+build:
+  image: myorg/app:1.0.0
+`, []string{"docker.io/myorg"})
+	if len(clean) != 0 {
+		t.Errorf("expected no finding for docker.io/myorg namespace, got %d", len(clean))
+	}
+	flagged := findings065(t, `
+build:
+  image: other/app:1.0.0
+`, []string{"docker.io/myorg"})
+	if len(flagged) != 1 {
+		t.Fatalf("expected 1 finding for other docker.io namespace, got %d", len(flagged))
+	}
+}
+
+func TestGL065_Services(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: registry.example.com/node:20
+  services:
+    - docker.io/library/postgres:16
+    - name: registry.example.com/redis:7
+`, []string{"registry.example.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for disallowed service, got %d", len(f))
+	}
+}
+
+func TestGL065_VariableHostExempt(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: $REGISTRY/node:20
+deploy:
+  image: $MY_IMAGE
+`, []string{"registry.example.com"})
+	if len(f) != 0 {
+		t.Errorf("expected no findings for variable registry hosts, got %d", len(f))
+	}
+}
+
+func TestGL065_ResolvableHostWithVariablePath(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: docker.io/$IMAGE_NAME:latest
+`, []string{"registry.example.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding — host docker.io is resolvable, got %d", len(f))
+	}
+}
+
+func TestGL065_RegistryWithPort(t *testing.T) {
+	clean := findings065(t, `
+build:
+  image: registry.example.com:5000/app:1.0
+`, []string{"registry.example.com:5000"})
+	if len(clean) != 0 {
+		t.Errorf("expected no finding when host:port is allowlisted, got %d", len(clean))
+	}
+}
+
+func TestGL065_DefaultImage(t *testing.T) {
+	f := findings065(t, `
+default:
+  image: quay.io/org/tool:1.0
+build:
+  script: [make]
+`, []string{"registry.example.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for default: image, got %d", len(f))
+	}
+}
+
+func TestGL065_JobNameAttached(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: docker.io/library/node:20
+`, []string{"registry.example.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Job != "build" {
+		t.Errorf("expected job name 'build', got %q", f[0].Job)
+	}
+}

--- a/rules/main_test.go
+++ b/rules/main_test.go
@@ -1,0 +1,15 @@
+package rules
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain configures the global GL065 singleton with an allowlist so its
+// fixture fires in TestRuleConsistency. GL065 is config-gated (a no-op without
+// an allowlist), and the consistency check exercises the global singleton.
+// Unit tests use their own local gl065 instances and are unaffected.
+func TestMain(m *testing.M) {
+	GL065.SetAllowedRegistries([]string{"registry.example.com", "ghcr.io/myorg"})
+	os.Exit(m.Run())
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -67,6 +67,7 @@ var owaspCategories = map[string][]string{
 	"GL062": {"CICD-SEC-6"},
 	"GL063": {"CICD-SEC-7"},
 	"GL064": {"CICD-SEC-3"},
+	"GL065": {"CICD-SEC-4"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl065-disallowed-registry.yml
+++ b/testdata/fixtures/gl065-disallowed-registry.yml
@@ -1,0 +1,17 @@
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  image: docker.io/library/node:20.11.0
+  services:
+    - name: docker.io/library/postgres:16.2
+  script:
+    - npm ci
+
+deploy:
+  stage: deploy
+  image: registry.example.com/deployer:1.2.3
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
Closes #265.

## What changed

Adds **GL065**, an opt-in, config-driven rule that flags `image:` / `services:` references whose registry is not on a configured allowlist. Mirrors the `trusted-hosts` config model used by GL016.

```yaml
# .glsec.yml
allowed_registries:
  - registry.example.com   # bare host — any image from this registry is allowed
  - ghcr.io/myorg          # host + namespace — only this namespace is allowed
```

- **No-op when unset** — without `allowed_registries`, the rule flags nothing (so it does not complain about every `docker.io` image by default).
- **Registry host** is the first path segment when it contains a `.` or `:port` (or is `localhost`); bare images (`node:20`) and Docker Hub namespaces (`myorg/app`) resolve to `docker.io`.
- **Bare-host entries** match by host; **namespace entries** (`ghcr.io/myorg`) match as a host/namespace prefix, so `ghcr.io/myorg/app` is allowed while `ghcr.io/other/app` and `ghcr.io/myorg-evil/app` are flagged.
- **Variable hosts are exempt** — `$MY_IMAGE` and `$REGISTRY/app` are not statically resolvable and are skipped; a resolvable host with a variable path (`docker.io/$IMAGE`) is still checked.
- Severity `warn`; OWASP CICD-SEC-4; CWE-829; ASVS V14.2.1.

## Why

A job can pull an image from any registry, and that image runs with full access to the job's secrets and build context. Teams that mandate a curated internal registry had no way to enforce it from `.gitlab-ci.yml`. This is candidate #1 from the peer-tool gap analysis (plumber's "Container Images Must Come From Authorized Sources").

## Files

- `rules/gl065.go` + `rules/gl065_test.go` — the rule and its tests.
- `internal/config/config.go` — new `allowed_registries` key.
- `cmd/glsec/main.go` — wires `SetAllowedRegistries`.
- `rules/all.go`, `owasp.go`, `cwe.go`, `asvs.go` — registration and mappings.
- `rules/main_test.go` — a `TestMain` that configures the global GL065 singleton so its fixture fires in the rule-consistency test (the rule is otherwise a no-op without config). Unit tests use local instances.
- `docs/rules/GL065.md`, `docs/rules.md`, `README.md` — docs, overview table, ASVS row, rule count (64 → 65).
- `testdata/fixtures/gl065-disallowed-registry.yml` — fixture.

## How to test

- `go test ./...` — full suite incl. rule-consistency and README-table tests.
- `golangci-lint run ./...` — clean.
- `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl065-disallowed-registry.yml` — schema-valid.
- End-to-end:
  ```
  printf 'allowed_registries:\n  - registry.example.com\n' > /tmp/.glsec.yml
  glsec --config /tmp/.glsec.yml testdata/fixtures/gl065-disallowed-registry.yml
  ```
  flags the `docker.io` image + service, leaves `registry.example.com/deployer` clean, and emits nothing when `allowed_registries` is unset.