### PR TITLE
Add GL066: hardcoded registry credentials in DOCKER_AUTH_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ exclude_paths:
 
 ## Rules
 
-65 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+66 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062 |
+| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,6 +14,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL027](rules/GL027.md) | `warn`  | Secret-like variable defined without `masked: true` |
 | [GL004](rules/GL004.md) | `warn`  | `CI_JOB_TOKEN` forwarded to a non-GitLab host |
 | [GL006](rules/GL006.md) | `error` | Hardcoded secret in `variables:` block |
+| [GL066](rules/GL066.md) | `error` | Inline registry credentials in `DOCKER_AUTH_CONFIG` instead of a masked CI/CD variable |
 | [GL036](rules/GL036.md) | `warn`  | Connection string with embedded credentials (`scheme://user:pass@host`) in `variables:` block |
 | [GL010](rules/GL010.md) | `warn`  | `trigger: forward: pipeline_variables: true` leaks secrets to downstream pipeline (GitLab ≥ 14.9) |
 | [GL037](rules/GL037.md) | `warn`  | `trigger:` job without `inherit: variables: false` — top-level secrets implicitly forwarded to downstream |
@@ -134,6 +135,6 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 | V14.2.3 — Dependencies verified for integrity | GL020 |
 | V14.3.1 — Pipeline config protected from modification | GL003, GL019 |
 | V14.3.2 — Security tools run and failures block the build | GL008, GL039 |
-| V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038 |
+| V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038, GL066 |
 | V14.3.4 — Build environment isolated | GL007, GL015, GL025 |
 | V14.4.1 — Third-party CI/CD service dependence minimised | GL041 |

--- a/docs/rules/GL066.md
+++ b/docs/rules/GL066.md
@@ -1,0 +1,41 @@
+# GL066 — Hardcoded registry credentials in `DOCKER_AUTH_CONFIG`
+
+**Severity:** `error`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)  
+**CWE:** [CWE-798 – Use of Hard-coded Credentials](https://cwe.mitre.org/data/definitions/798.html)
+
+## Risk
+
+GitLab authenticates to private container registries via the `DOCKER_AUTH_CONFIG` variable, a JSON document holding base64-encoded registry credentials. When it is hardcoded in `.gitlab-ci.yml` instead of stored as a masked/protected CI/CD variable, the credentials are committed to the repository in a plaintext-recoverable form — the `auth` field is just base64, not encryption, so anyone with read access to the repo (or its history) can decode `user:password`.
+
+## What glsec checks
+
+glsec flags any `DOCKER_AUTH_CONFIG` entry in a `variables:` block (top-level, `default:`, or per-job) whose value is an inline credential document — i.e. it contains an `"auths"` / `"auth"` JSON key.
+
+```yaml
+variables:
+  DOCKER_AUTH_CONFIG: '{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}'   # flagged
+```
+
+A whole-value variable reference is the safe form and is **not** flagged:
+
+```yaml
+variables:
+  DOCKER_AUTH_CONFIG: $REGISTRY_AUTH   # not flagged
+```
+
+## Safe alternative
+
+Define `DOCKER_AUTH_CONFIG` as a **masked, protected** CI/CD variable in *Settings → CI/CD → Variables*, and reference it (or simply let the runner pick it up) rather than committing the JSON:
+
+```yaml
+# Settings → CI/CD → Variables: DOCKER_AUTH_CONFIG = {"auths":{...}}  (masked, protected)
+build:
+  image: registry.example.com/builder:1.0.0
+  script:
+    - docker build -t registry.example.com/app:1.0.0 .
+```
+
+## Why this matters
+
+Unlike a masked CI/CD variable — which GitLab keeps out of the repository, redacts in job logs, and can restrict to protected branches — a committed `DOCKER_AUTH_CONFIG` lives in git history forever. Rotating the credential requires a force-rewrite of history, and any fork or clone made before rotation retains the working secret. [GL006](GL006.md) catches generic hardcoded secrets but does not recognise this structured registry-auth form.

--- a/rules/all.go
+++ b/rules/all.go
@@ -69,5 +69,6 @@ func All() []rule.Rule {
 		GL063,
 		GL064,
 		GL065,
+		GL066,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -34,6 +34,7 @@ var asvsRequirements = map[string][]string{
 	"GL039": {"ASVS-V14.3.2"},
 	"GL041": {"ASVS-V14.2.2", "ASVS-V14.4.1"},
 	"GL065": {"ASVS-V14.2.1"},
+	"GL066": {"ASVS-V14.3.3"},
 }
 
 // asvsRequirementNames maps an ASVS requirement ID to its short description.

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -67,6 +67,7 @@ var cweIDs = map[string]string{
 	"GL063": "CWE-732",
 	"GL064": "CWE-829",
 	"GL065": "CWE-829",
+	"GL066": "CWE-798",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl066.go
+++ b/rules/gl066.go
@@ -1,0 +1,86 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl066 struct{}
+
+var GL066 = &gl066{}
+
+func (r *gl066) ID() string { return "GL066" }
+
+// dockerAuthKeyRe matches the JSON "auths"/"auth" key of an inline Docker
+// registry credential document.
+var dockerAuthKeyRe = regexp.MustCompile(`"auths?"\s*:`)
+
+func (r *gl066) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, checkDockerAuthConfig(parser.FindKey(mapping, "variables"), file)...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, checkDockerAuthConfig(parser.FindKey(def, "variables"), file)...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range checkDockerAuthConfig(parser.FindKey(job, "variables"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func checkDockerAuthConfig(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value != "DOCKER_AUTH_CONFIG" {
+			continue
+		}
+
+		val := node.Content[i+1]
+		var scalar *yaml.Node
+		switch val.Kind {
+		case yaml.ScalarNode:
+			scalar = val
+		case yaml.MappingNode:
+			// Extended form: {value: ..., description: ...}
+			if v := parser.FindKey(val, "value"); v != nil && v.Kind == yaml.ScalarNode {
+				scalar = v
+			}
+		}
+		if scalar == nil {
+			continue
+		}
+
+		v := strings.TrimSpace(scalar.Value)
+		// A whole-value variable reference ($REGISTRY_AUTH) is the safe form.
+		if v == "" || strings.HasPrefix(v, "$") {
+			continue
+		}
+		if !dockerAuthKeyRe.MatchString(v) {
+			continue
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL066",
+			Severity: finding.Error,
+			Message:  "DOCKER_AUTH_CONFIG contains inline registry credentials (\"auth\" is base64, not encryption) — store it as a masked, protected CI/CD variable (Settings → CI/CD → Variables) instead",
+			File:     file,
+			Line:     scalar.Line,
+			Col:      scalar.Column,
+		})
+	}
+	return findings
+}

--- a/rules/gl066_test.go
+++ b/rules/gl066_test.go
@@ -1,0 +1,119 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings066(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL066.Check(doc.Root, "test.yml")
+}
+
+func TestGL066_InlineCredentials(t *testing.T) {
+	f := findings066(t, `
+variables:
+  DOCKER_AUTH_CONFIG: '{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for inline DOCKER_AUTH_CONFIG, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL066_VariableReference_NoFinding(t *testing.T) {
+	f := findings066(t, `
+variables:
+  DOCKER_AUTH_CONFIG: $REGISTRY_AUTH
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for variable reference, got %d", len(f))
+	}
+}
+
+func TestGL066_BracedVariableReference_NoFinding(t *testing.T) {
+	f := findings066(t, `
+variables:
+  DOCKER_AUTH_CONFIG: ${REGISTRY_AUTH}
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for braced variable reference, got %d", len(f))
+	}
+}
+
+func TestGL066_ExtendedForm(t *testing.T) {
+	f := findings066(t, `
+variables:
+  DOCKER_AUTH_CONFIG:
+    value: '{"auths":{"reg.example.com":{"auth":"dXNlcjpwYXNz"}}}'
+    description: registry auth
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for extended-form inline creds, got %d", len(f))
+	}
+}
+
+func TestGL066_PerJobVariables(t *testing.T) {
+	f := findings066(t, `
+build:
+  variables:
+    DOCKER_AUTH_CONFIG: '{"auths":{"r.example.com":{"auth":"dXNlcjpwYXNz"}}}'
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in job variables, got %d", len(f))
+	}
+	if f[0].Job != "build" {
+		t.Errorf("expected job name 'build', got %q", f[0].Job)
+	}
+}
+
+func TestGL066_DefaultVariables(t *testing.T) {
+	f := findings066(t, `
+default:
+  image: node:20
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when DOCKER_AUTH_CONFIG absent, got %d", len(f))
+	}
+}
+
+func TestGL066_OtherVariableIgnored(t *testing.T) {
+	f := findings066(t, `
+variables:
+  SOME_CONFIG: '{"auths":{"reg":{"auth":"x"}}}'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for non-DOCKER_AUTH_CONFIG variable, got %d", len(f))
+	}
+}
+
+func TestGL066_AuthKeyOnly(t *testing.T) {
+	f := findings066(t, `
+variables:
+  DOCKER_AUTH_CONFIG: '{"auth":"dXNlcjpwYXNz"}'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for bare auth key, got %d", len(f))
+	}
+}
+
+func TestGL066_NonCredentialValue_NoFinding(t *testing.T) {
+	f := findings066(t, `
+variables:
+  DOCKER_AUTH_CONFIG: ""
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for empty value, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -68,6 +68,7 @@ var owaspCategories = map[string][]string{
 	"GL063": {"CICD-SEC-7"},
 	"GL064": {"CICD-SEC-3"},
 	"GL065": {"CICD-SEC-4"},
+	"GL066": {"CICD-SEC-6"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl066-docker-auth-config.yml
+++ b/testdata/fixtures/gl066-docker-auth-config.yml
@@ -1,0 +1,19 @@
+stages:
+  - build
+
+variables:
+  DOCKER_AUTH_CONFIG: '{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}'
+
+build:
+  stage: build
+  image: registry.example.com/builder:1.0.0
+  script:
+    - docker build -t registry.example.com/app:1.0.0 .
+
+deploy:
+  stage: build
+  variables:
+    DOCKER_AUTH_CONFIG: $REGISTRY_AUTH
+  image: registry.example.com/deployer:1.0.0
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
Closes #267.

## What changed

Adds **GL066** (`error`), which flags a `DOCKER_AUTH_CONFIG` entry in any `variables:` block (top-level, `default:`, or per-job) whose value is an inline credential document — i.e. it contains an `"auths"` / `"auth"` JSON key.

```yaml
variables:
  DOCKER_AUTH_CONFIG: '{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}'   # flagged
```

A whole-value variable reference is the safe form and is not flagged:

```yaml
variables:
  DOCKER_AUTH_CONFIG: $REGISTRY_AUTH   # not flagged
```

## Why

GitLab authenticates to private registries via `DOCKER_AUTH_CONFIG`, whose `auth` field is base64 (not encryption). Committed inline, the credentials are recoverable by anyone with repo (or history) access. GL006 catches generic hardcoded secrets but does not recognise this structured registry-auth form. This is candidate #3 from the peer-tool gap analysis (zizmor's hardcoded-container-credentials).

## Detection details

- Matches only the `DOCKER_AUTH_CONFIG` variable name; other variables with similar JSON are ignored.
- Handles both the plain scalar and extended (`{value:, description:}`) variable forms.
- Skips whole-value variable references (`$VAR`, `${VAR}`) and empty values.
- Severity `error`; OWASP CICD-SEC-6; CWE-798; ASVS V14.3.3.

## Files

- `rules/gl066.go` + `rules/gl066_test.go` — rule and tests.
- `rules/all.go`, `owasp.go`, `cwe.go`, `asvs.go` — registration and mappings.
- `docs/rules/GL066.md`, `docs/rules.md`, `README.md` — docs, overview + ASVS rows, rule count (65 → 66).
- `testdata/fixtures/gl066-docker-auth-config.yml` — fixture (inline creds flagged, `$REGISTRY_AUTH` clean).

## How to test

- `go test ./...` — full suite incl. rule-consistency and README-table tests.
- `golangci-lint run ./...` — clean.
- `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl066-docker-auth-config.yml` — schema-valid.
- `go run ./cmd/glsec testdata/fixtures/gl066-docker-auth-config.yml` — one GL066 error on the inline document, nothing on the `$REGISTRY_AUTH` job.