### PR TITLE
feat: add GL067 analyzer-registry repoint rule (#268)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ exclude_paths:
 
 ## Rules
 
-66 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+67 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -66,6 +66,7 @@ User-controlled inputs and unversioned component references that allow malicious
 | [GL051](rules/GL051.md) | `warn`  | Unconstrained `spec:inputs` entry interpolated into `image:`, `script:`, or `environment:name:` — caller can supply arbitrary values |
 | [GL053](rules/GL053.md) | `warn`  | Missing or unrestricted `workflow:rules` — pipelines run for every event, including untrusted fork merge requests |
 | [GL065](rules/GL065.md) | `warn`  | `image:`/`services:` from a registry not in the opt-in `allowed_registries` allowlist |
+| [GL067](rules/GL067.md) | `warn`  | `SECURE_ANALYZERS_PREFIX` (or `*_ANALYZER_IMAGE`) repoints managed security scanners off `registry.gitlab.com` |
 
 ---
 
@@ -130,7 +131,7 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 
 | ASVS requirement | Rules |
 |---|---|
-| V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016, GL065 |
+| V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016, GL065, GL067 |
 | V14.2.2 — Components up to date and pinned | GL001, GL022, GL023, GL026, GL041 |
 | V14.2.3 — Dependencies verified for integrity | GL020 |
 | V14.3.1 — Pipeline config protected from modification | GL003, GL019 |

--- a/docs/rules/GL067.md
+++ b/docs/rules/GL067.md
@@ -1,0 +1,42 @@
+# GL067 — Managed-scan analyzer registry repointed off `registry.gitlab.com`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)  
+**CWE:** [CWE-829 – Inclusion of Functionality from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html)
+
+## Risk
+
+GitLab's managed security templates (SAST, Dependency Scanning, Container Scanning, etc.) pull their analyzer images using `SECURE_ANALYZERS_PREFIX`, which defaults to the official GitLab analyzer registry (`registry.gitlab.com/security-products`). If a pipeline overrides `SECURE_ANALYZERS_PREFIX` — or a per-analyzer image control such as `SAST_ANALYZER_IMAGE` / `CS_ANALYZER_IMAGE` — to point at an arbitrary registry, every "security scan" job silently runs an attacker-chosen image with access to the repository and the job's secrets. It is a scanner-substitution / poisoned-pipeline attack that still shows green "security scanning" jobs.
+
+## What glsec checks
+
+glsec flags a `variables:` entry (top-level, `default:`, or per-job) that sets one of the managed-scan analyzer controls to a registry host other than `registry.gitlab.com`:
+
+- `SECURE_ANALYZERS_PREFIX`
+- `SAST_ANALYZER_IMAGE`
+- `DS_ANALYZER_IMAGE`
+- `CS_ANALYZER_IMAGE`
+
+```yaml
+variables:
+  SECURE_ANALYZERS_PREFIX: registry.attacker.example/analyzers   # flagged
+```
+
+- **No-op when unset** — the default already resolves to `registry.gitlab.com`, so an absent variable is never flagged.
+- **Default host stays clean** — `registry.gitlab.com/security-products` (the resolved default) is not flagged.
+- **Variable-driven hosts are exempt** — `$CI_TEMPLATE_REGISTRY_HOST/security-products` and whole-value references (`$INTERNAL_PREFIX`) cannot be resolved statically and are treated as default-equivalent.
+
+## Safe alternative
+
+Do not override `SECURE_ANALYZERS_PREFIX`. If an internal mirror is genuinely required, make it a deliberate, reviewed choice: pin it to the trusted internal registry and pair it with the registry-allowlist rule ([GL065](GL065.md)).
+
+```yaml
+# Mirror the official analyzers into a trusted internal registry, then point at it explicitly:
+variables:
+  SECURE_ANALYZERS_PREFIX: registry.gitlab.com/security-products
+```
+
+## Notes
+
+- Severity is `warn` — legitimate internal-mirror setups exist, but repointing the scanner registry should always be a deliberate, reviewed decision.
+- Complements [GL065](GL065.md): GL065 enforces an allowlist over `image:`/`services:`, while GL067 specifically catches substitution of the managed *security-scanner* images.

--- a/rules/all.go
+++ b/rules/all.go
@@ -70,5 +70,6 @@ func All() []rule.Rule {
 		GL064,
 		GL065,
 		GL066,
+		GL067,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -35,6 +35,7 @@ var asvsRequirements = map[string][]string{
 	"GL041": {"ASVS-V14.2.2", "ASVS-V14.4.1"},
 	"GL065": {"ASVS-V14.2.1"},
 	"GL066": {"ASVS-V14.3.3"},
+	"GL067": {"ASVS-V14.2.1"},
 }
 
 // asvsRequirementNames maps an ASVS requirement ID to its short description.

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -68,6 +68,7 @@ var cweIDs = map[string]string{
 	"GL064": "CWE-829",
 	"GL065": "CWE-829",
 	"GL066": "CWE-798",
+	"GL067": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl067.go
+++ b/rules/gl067.go
@@ -1,0 +1,126 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl067 struct{}
+
+var GL067 = &gl067{}
+
+func (r *gl067) ID() string { return "GL067" }
+
+// officialAnalyzerRegistry is the host that GitLab's managed security templates
+// pull their analyzer images from by default (via SECURE_ANALYZERS_PREFIX, which
+// defaults to $CI_TEMPLATE_REGISTRY_HOST/security-products).
+const officialAnalyzerRegistry = "registry.gitlab.com"
+
+// analyzerImageVars are managed-scan controls that hold a full analyzer image
+// reference. Repointing any of them off the official registry substitutes the
+// scanner the same way SECURE_ANALYZERS_PREFIX does.
+var analyzerImageVars = map[string]bool{
+	"SAST_ANALYZER_IMAGE": true,
+	"DS_ANALYZER_IMAGE":   true,
+	"CS_ANALYZER_IMAGE":   true,
+}
+
+func (r *gl067) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, r.checkVariables(parser.FindKey(mapping, "variables"), file)...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, r.checkVariables(parser.FindKey(def, "variables"), file)...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range r.checkVariables(parser.FindKey(job, "variables"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func (r *gl067) checkVariables(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		isPrefix := key == "SECURE_ANALYZERS_PREFIX"
+		if !isPrefix && !analyzerImageVars[key] {
+			continue
+		}
+
+		scalar := analyzerScalar(node.Content[i+1])
+		if scalar == nil {
+			continue
+		}
+		host, off := analyzerOffOfficialRegistry(scalar.Value)
+		if !off {
+			continue
+		}
+
+		var msg string
+		if isPrefix {
+			msg = fmt.Sprintf("SECURE_ANALYZERS_PREFIX repoints managed-scan analyzers to registry %q instead of the default %s — every security-scan job would run an analyzer image from an unverified registry", host, officialAnalyzerRegistry)
+		} else {
+			msg = fmt.Sprintf("%s points the managed-scan analyzer image at registry %q instead of the default %s — the scan job would run an unverified analyzer image", key, host, officialAnalyzerRegistry)
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL067",
+			Severity: finding.Warn,
+			Message:  msg,
+			File:     file,
+			Line:     scalar.Line,
+			Col:      scalar.Column,
+		})
+	}
+	return findings
+}
+
+// analyzerScalar returns the scalar value node of a variable entry, unwrapping
+// the extended form ({value: ..., description: ...}).
+func analyzerScalar(val *yaml.Node) *yaml.Node {
+	switch val.Kind {
+	case yaml.ScalarNode:
+		return val
+	case yaml.MappingNode:
+		if v := parser.FindKey(val, "value"); v != nil && v.Kind == yaml.ScalarNode {
+			return v
+		}
+	}
+	return nil
+}
+
+// analyzerOffOfficialRegistry reports the registry host of an analyzer prefix or
+// image reference and whether it differs from the official GitLab registry. A
+// host built from a variable expansion ($CI_TEMPLATE_REGISTRY_HOST/...) is not
+// statically resolvable and is treated as default-equivalent.
+func analyzerOffOfficialRegistry(ref string) (host string, off bool) {
+	s := strings.TrimSpace(ref)
+	if s == "" {
+		return "", false
+	}
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	first := s
+	if i := strings.Index(s, "/"); i >= 0 {
+		first = s[:i]
+	}
+	if first == "" || strings.Contains(first, "$") {
+		return "", false
+	}
+	host = strings.ToLower(first)
+	return host, host != officialAnalyzerRegistry
+}

--- a/rules/gl067_test.go
+++ b/rules/gl067_test.go
@@ -1,0 +1,140 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings067(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL067.Check(doc.Root, "test.yml")
+}
+
+func TestGL067_OverridePrefix(t *testing.T) {
+	f := findings067(t, `
+variables:
+  SECURE_ANALYZERS_PREFIX: registry.attacker.example/analyzers
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for off-registry prefix, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL067_DefaultRegistryPrefix_NoFinding(t *testing.T) {
+	f := findings067(t, `
+variables:
+  SECURE_ANALYZERS_PREFIX: registry.gitlab.com/security-products
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when prefix stays on registry.gitlab.com, got %d", len(f))
+	}
+}
+
+func TestGL067_Unset_NoFinding(t *testing.T) {
+	f := findings067(t, `
+variables:
+  FOO: bar
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when SECURE_ANALYZERS_PREFIX is unset, got %d", len(f))
+	}
+}
+
+func TestGL067_TemplateRegistryHostVariable_NoFinding(t *testing.T) {
+	f := findings067(t, `
+variables:
+  SECURE_ANALYZERS_PREFIX: $CI_TEMPLATE_REGISTRY_HOST/security-products
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for variable-driven host, got %d", len(f))
+	}
+}
+
+func TestGL067_WholeVariableReference_NoFinding(t *testing.T) {
+	f := findings067(t, `
+variables:
+  SECURE_ANALYZERS_PREFIX: $INTERNAL_PREFIX
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for whole-variable reference, got %d", len(f))
+	}
+}
+
+func TestGL067_AnalyzerImageOverride(t *testing.T) {
+	f := findings067(t, `
+variables:
+  CS_ANALYZER_IMAGE: registry.attacker.example/container-scanning:7
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for off-registry analyzer image, got %d", len(f))
+	}
+}
+
+func TestGL067_AnalyzerImageOnOfficialRegistry_NoFinding(t *testing.T) {
+	f := findings067(t, `
+variables:
+  SAST_ANALYZER_IMAGE: registry.gitlab.com/security-products/semgrep:5
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for analyzer image on registry.gitlab.com, got %d", len(f))
+	}
+}
+
+func TestGL067_ExtendedForm(t *testing.T) {
+	f := findings067(t, `
+variables:
+  SECURE_ANALYZERS_PREFIX:
+    value: registry.attacker.example/analyzers
+    description: internal mirror
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for extended-form override, got %d", len(f))
+	}
+}
+
+func TestGL067_PerJobVariables(t *testing.T) {
+	f := findings067(t, `
+sast:
+  variables:
+    SECURE_ANALYZERS_PREFIX: registry.attacker.example/analyzers
+  script: [/analyzer run]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in job variables, got %d", len(f))
+	}
+	if f[0].Job != "sast" {
+		t.Errorf("expected job name 'sast', got %q", f[0].Job)
+	}
+}
+
+func TestGL067_DefaultVariables(t *testing.T) {
+	f := findings067(t, `
+default:
+  variables:
+    SECURE_ANALYZERS_PREFIX: registry.attacker.example/analyzers
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in default variables, got %d", len(f))
+	}
+}
+
+func TestGL067_HTTPSchemePrefix(t *testing.T) {
+	f := findings067(t, `
+variables:
+  SECURE_ANALYZERS_PREFIX: https://registry.attacker.example/analyzers
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for scheme-prefixed host, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -69,6 +69,7 @@ var owaspCategories = map[string][]string{
 	"GL064": {"CICD-SEC-3"},
 	"GL065": {"CICD-SEC-4"},
 	"GL066": {"CICD-SEC-6"},
+	"GL067": {"CICD-SEC-4"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl067-secure-analyzers-prefix.yml
+++ b/testdata/fixtures/gl067-secure-analyzers-prefix.yml
@@ -1,0 +1,19 @@
+stages:
+  - test
+
+variables:
+  SECURE_ANALYZERS_PREFIX: registry.attacker.example/analyzers
+
+sast:
+  stage: test
+  variables:
+    CS_ANALYZER_IMAGE: registry.attacker.example/container-scanning:7
+  script:
+    - /analyzer run
+
+dependency_scanning:
+  stage: test
+  variables:
+    SECURE_ANALYZERS_PREFIX: registry.gitlab.com/security-products
+  script:
+    - /analyzer run


### PR DESCRIPTION
Closes #268.

## What changed

New rule **GL067 — managed-scan analyzer registry repointed off `registry.gitlab.com`** (`warn`, CICD-SEC-4 / CWE-829).

GitLab's managed security templates (SAST, Dependency Scanning, Container Scanning, …) pull their analyzer images via `SECURE_ANALYZERS_PREFIX`, which defaults to `registry.gitlab.com/security-products`. Overriding it (or a per-analyzer `*_ANALYZER_IMAGE` control) to another registry silently runs an attacker-chosen image in every "security scan" job while the jobs still show green — a scanner-substitution / poisoned-pipeline attack.

GL067 flags a `variables:` entry (top-level, `default:`, or per-job) that sets one of these to a registry host other than `registry.gitlab.com`:

- `SECURE_ANALYZERS_PREFIX`
- `SAST_ANALYZER_IMAGE`
- `DS_ANALYZER_IMAGE`
- `CS_ANALYZER_IMAGE`

## Why

A pipeline can pass every managed security scan while running entirely attacker-controlled analyzer images with full access to the repo and the job's secrets. The override is invisible in the job output, so it needs static detection.

## Behaviour / edge cases

- **No-op when unset** — the default already resolves to `registry.gitlab.com`.
- **Default host stays clean** — `registry.gitlab.com/security-products` is not flagged.
- **Variable-driven hosts exempt** — `$CI_TEMPLATE_REGISTRY_HOST/security-products` and whole-value refs (`$INTERNAL_PREFIX`) are unresolvable and treated as default-equivalent.
- Handles the extended `{value:, description:}` variable form and `https://`-prefixed values.
- `warn` severity — legitimate internal mirrors exist, but repointing the scanner registry should be a deliberate, reviewed choice. Complements GL065 (registry allowlist).

## How to test

- `go test ./...` — new unit tests in `rules/gl067_test.go` cover override, default-registry, unset, variable-driven host, per-analyzer image, extended form, per-job/`default:`, and scheme-prefixed cases.
- Fixture `testdata/fixtures/gl067-secure-analyzers-prefix.yml` triggers the rule and validates against the gitlab-ci schema.
- `golangci-lint run` — clean.

Registered in `all.go`; OWASP/CWE/ASVS maps, README rule table + count, and `docs/rules.md` updated; rule doc at `docs/rules/GL067.md`.
