### PR TITLE
feat: match non-default CI filenames in --recursive (#270)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ glsec pipelines/*.yml
 # recursively scan a tree for all .gitlab-ci.yml files
 glsec --recursive .
 
+# also pick up CI configs with non-default names/paths during a recursive scan
+glsec --recursive --name '*.gitlab-ci.yml' --name 'ci/pipeline.yml' .
+
 # aligned table view, easier to scan when there are many findings
 glsec --format table .gitlab-ci.yml
 
@@ -115,6 +118,10 @@ exclude_paths:
   - legacy/.gitlab-ci.yml
   - infra/old-pipelines/**
   - vendor/
+
+recursive_patterns:    # extra CI-config names/paths for --recursive (default: .gitlab-ci.yml)
+  - '*.gitlab-ci.yml'   # no "/" → matched against the basename
+  - ci/pipeline.yml     # contains "/" → matched against the path relative to each scanned dir
 ```
 
 ## Rules

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -70,6 +70,11 @@ func main() {
 	clearCacheFlag := flag.Bool("clear-cache", false, "remove all cached results and exit")
 	noColorFlag := flag.Bool("no-color", false, "disable colored output")
 	recursiveFlag := flag.Bool("recursive", false, "recursively scan the given directories for .gitlab-ci.yml files")
+	var nameArgs []string
+	flag.Func("name", "additional filename/path glob to treat as a CI config during --recursive walks (may be repeated)", func(s string) error {
+		nameArgs = append(nameArgs, s)
+		return nil
+	})
 	var excludeArgs []string
 	flag.Func("exclude", "exclude a file or glob pattern from scanning (may be repeated)", func(s string) error {
 		excludeArgs = append(excludeArgs, s)
@@ -154,7 +159,12 @@ func main() {
 		fmt.Fprintf(os.Stderr, "warning: gitlab-version %s is below the minimum supported version %s\n", gitlabVersion, gitlabver.Minimum)
 	}
 
-	targets, err := resolveTargets(flag.Args(), *recursiveFlag)
+	recursivePatterns := append(append([]string{}, cfg.RecursivePatterns...), nameArgs...)
+	if len(recursivePatterns) > 0 && !*recursiveFlag {
+		fmt.Fprintln(os.Stderr, "warning: --name / recursive_patterns only apply with --recursive; ignoring")
+	}
+
+	targets, err := resolveTargets(flag.Args(), *recursiveFlag, recursivePatterns)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(2)
@@ -355,23 +365,33 @@ func warnUnknownRuleIDs(flagName string, set map[string]bool) {
 // to scan. Without --recursive: each argument is used as a literal file if it
 // exists, otherwise expanded as a glob; with no arguments it falls back to
 // .gitlab-ci.yml in the current directory. With --recursive: each argument (or
-// "." if none) is walked for files named .gitlab-ci.yml.
-func resolveTargets(args []string, recursive bool) ([]string, error) {
+// "." if none) is walked for files named .gitlab-ci.yml plus any extra
+// patterns.
+func resolveTargets(args []string, recursive bool, patterns []string) ([]string, error) {
 	if recursive {
+		for _, p := range patterns {
+			if _, err := filepath.Match(p, ""); err != nil {
+				return nil, fmt.Errorf("invalid --name pattern %q: %w", p, err)
+			}
+		}
 		dirs := args
 		if len(dirs) == 0 {
 			dirs = []string{"."}
 		}
 		var out []string
 		for _, d := range dirs {
-			files, err := walkForCIFiles(d)
+			files, err := walkForCIFiles(d, patterns)
 			if err != nil {
 				return nil, err
 			}
 			out = append(out, files...)
 		}
 		if len(out) == 0 {
-			return nil, fmt.Errorf("no .gitlab-ci.yml files found under %s", strings.Join(dirs, ", "))
+			what := ".gitlab-ci.yml files"
+			if len(patterns) > 0 {
+				what = "matching CI config files"
+			}
+			return nil, fmt.Errorf("no %s found under %s", what, strings.Join(dirs, ", "))
 		}
 		return dedupeStrings(out), nil
 	}
@@ -399,9 +419,11 @@ func resolveTargets(args []string, recursive bool) ([]string, error) {
 	return dedupeStrings(out), nil
 }
 
-// walkForCIFiles returns all files named .gitlab-ci.yml under dir, skipping
-// .git directories.
-func walkForCIFiles(dir string) ([]string, error) {
+// walkForCIFiles returns all CI config files under dir, skipping .git
+// directories. A file matches if its basename is .gitlab-ci.yml or if it
+// matches one of the extra patterns: a pattern without "/" is matched against
+// the basename, one with "/" against the path relative to dir.
+func walkForCIFiles(dir string, patterns []string) ([]string, error) {
 	var out []string
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -413,12 +435,34 @@ func walkForCIFiles(dir string) ([]string, error) {
 			}
 			return nil
 		}
-		if d.Name() == ".gitlab-ci.yml" {
+		if matchesCIFile(dir, path, d.Name(), patterns) {
 			out = append(out, path)
 		}
 		return nil
 	})
 	return out, err
+}
+
+// matchesCIFile reports whether a walked file should be treated as a CI config.
+func matchesCIFile(dir, path, base string, patterns []string) bool {
+	if base == ".gitlab-ci.yml" {
+		return true
+	}
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		rel = path
+	}
+	rel = filepath.ToSlash(rel)
+	for _, p := range patterns {
+		target := base
+		if strings.Contains(p, "/") {
+			target = rel
+		}
+		if ok, _ := filepath.Match(filepath.ToSlash(p), target); ok {
+			return true
+		}
+	}
+	return false
 }
 
 func dedupeStrings(in []string) []string {

--- a/cmd/glsec/targets_test.go
+++ b/cmd/glsec/targets_test.go
@@ -23,7 +23,7 @@ func TestResolveTargets_ExplicitFiles(t *testing.T) {
 	writeFile(t, a)
 	writeFile(t, b)
 
-	got, err := resolveTargets([]string{a, b}, false)
+	got, err := resolveTargets([]string{a, b}, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestResolveTargets_Glob(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "two.yml"))
 	writeFile(t, filepath.Join(dir, "skip.txt"))
 
-	got, err := resolveTargets([]string{filepath.Join(dir, "*.yml")}, false)
+	got, err := resolveTargets([]string{filepath.Join(dir, "*.yml")}, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestResolveTargets_Glob(t *testing.T) {
 }
 
 func TestResolveTargets_NoMatchErrors(t *testing.T) {
-	if _, err := resolveTargets([]string{"/no/such/path-xyz.yml"}, false); err == nil {
+	if _, err := resolveTargets([]string{"/no/such/path-xyz.yml"}, false, nil); err == nil {
 		t.Error("expected error for non-existent file with no glob match")
 	}
 }
@@ -60,7 +60,7 @@ func TestResolveTargets_Recursive(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "nested", "other.yml"))    // not named .gitlab-ci.yml
 	writeFile(t, filepath.Join(dir, ".git", ".gitlab-ci.yml")) // inside .git — skipped
 
-	got, err := resolveTargets([]string{dir}, true)
+	got, err := resolveTargets([]string{dir}, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,8 +72,60 @@ func TestResolveTargets_Recursive(t *testing.T) {
 func TestResolveTargets_RecursiveNoneFound(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "pipeline.yml"))
-	if _, err := resolveTargets([]string{dir}, true); err == nil {
+	if _, err := resolveTargets([]string{dir}, true, nil); err == nil {
 		t.Error("expected error when no .gitlab-ci.yml files are found recursively")
+	}
+}
+
+func TestResolveTargets_RecursiveBasenamePattern(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".gitlab-ci.yml"))
+	writeFile(t, filepath.Join(dir, "svc", "build.gitlab-ci.yml"))
+	writeFile(t, filepath.Join(dir, "svc", "other.yml"))
+
+	got, err := resolveTargets([]string{dir}, true, []string{"*.gitlab-ci.yml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// .gitlab-ci.yml (default) + build.gitlab-ci.yml (pattern); other.yml excluded.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 matches, got %v", got)
+	}
+}
+
+func TestResolveTargets_RecursiveRelativePathPattern(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "repo", "ci", "pipeline.yml"))
+	writeFile(t, filepath.Join(dir, "repo", "ci", "other.yml"))
+
+	got, err := resolveTargets([]string{dir}, true, []string{"repo/ci/pipeline.yml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 path-pattern match, got %v", got)
+	}
+}
+
+func TestResolveTargets_RecursiveNoDoubleCount(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".gitlab-ci.yml"))
+
+	// .gitlab-ci.yml matches the default and the pattern — must appear once.
+	got, err := resolveTargets([]string{dir}, true, []string{"*.yml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 deduped match, got %v", got)
+	}
+}
+
+func TestResolveTargets_RecursiveBadPattern(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".gitlab-ci.yml"))
+	if _, err := resolveTargets([]string{dir}, true, []string{"["}); err == nil {
+		t.Error("expected error for malformed glob pattern")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,11 @@ type Config struct {
 	// ExcludePaths is a list of file globs to skip entirely.
 	// Supports filepath.Match patterns and directory suffixes (/ or /**).
 	ExcludePaths []string `yaml:"exclude_paths"`
+	// RecursivePatterns lists additional filename/path globs that --recursive
+	// treats as CI config files (alongside the built-in .gitlab-ci.yml). A
+	// pattern without a "/" matches the basename; one with a "/" matches the
+	// path relative to the scanned directory (e.g. ci/pipeline.yml).
+	RecursivePatterns []string `yaml:"recursive_patterns"`
 	// OWASP is an allowlist of OWASP CICD-SEC category IDs. When non-empty,
 	// only rules belonging to one of these categories are run.
 	OWASP []string `yaml:"owasp"`


### PR DESCRIPTION
Closes #270.

## What changed

`--recursive` previously discovered only files named exactly `.gitlab-ci.yml`. Repos that point their CI config to a custom path (GitLab project setting — e.g. `ci/pipeline.yml`, `build.gitlab-ci.yml`) were silently skipped during multi-repo folder scans.

This adds an opt-in matcher to broaden filename matching during recursive walks, via **both**:

- `--name <glob>` — repeatable CLI flag
- `recursive_patterns:` — list key in `.glsec.yml`

CLI values are appended to config values. The built-in `.gitlab-ci.yml` match is always kept, so **default behaviour is unchanged**.

## Matching semantics (resolves the issue's open questions)

- A pattern **without** `/` is matched against the **basename** (e.g. `*.gitlab-ci.yml`).
- A pattern **with** `/` is matched against the **path relative to each scanned directory** (e.g. `ci/pipeline.yml`), so non-default *paths* work too.
- `.git` directories are still skipped; results are still deduped (a file matching both the default and a pattern is listed once).
- Patterns are strictly user-supplied — no built-in alternates beyond `.gitlab-ci.yml`.
- Malformed globs produce a clear `invalid --name pattern` error.
- `--name` / `recursive_patterns` only apply with `--recursive`; using them without it prints a warning and is ignored.

## Examples

```sh
glsec --recursive --name '*.gitlab-ci.yml' --name 'ci/pipeline.yml' .
```

```yaml
# .glsec.yml
recursive_patterns:
  - '*.gitlab-ci.yml'   # basename glob
  - ci/pipeline.yml     # relative-path glob
```

## Scope

Target resolution only (`resolveTargets` / `walkForCIFiles` in `cmd/glsec/main.go`, plus the config field). No rule logic touched.

## How to test

- `go test ./...` — new tests in `cmd/glsec/targets_test.go` cover basename patterns, relative-path patterns, dedupe (no double-count), and the bad-pattern error; existing recursive tests updated for the new signature.
- `golangci-lint run` — clean.
