### PR TITLE
feat: add pre-commit hook manifest (#272)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,23 @@
+- id: glsec
+  name: glsec (GitLab CI security scan)
+  description: Scan .gitlab-ci.yml for CI/CD security issues (builds glsec from source)
+  entry: glsec
+  language: golang
+  files: '(^|/)\.gitlab-ci\.yml$'
+  pass_filenames: true
+
+- id: glsec-system
+  name: glsec (GitLab CI security scan, system binary)
+  description: Scan .gitlab-ci.yml using a glsec binary already on PATH
+  entry: glsec
+  language: system
+  files: '(^|/)\.gitlab-ci\.yml$'
+  pass_filenames: true
+
+- id: glsec-docker
+  name: glsec (GitLab CI security scan, Docker)
+  description: Scan .gitlab-ci.yml using the published glsec Docker image
+  entry: ghcr.io/glsec/glsec
+  language: docker_image
+  files: '(^|/)\.gitlab-ci\.yml$'
+  pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -187,6 +187,39 @@ ShellCheck's own inline directives (`# shellcheck disable=SC2086`) are also resp
 
 ---
 
+## Pre-commit hook
+
+glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` issues are caught before they're pushed. Add this to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/glsec/glsec
+    rev: v1.4.0
+    hooks:
+      - id: glsec
+```
+
+Then `pre-commit install` once; the hook runs on every commit that touches a matching file. Run it across the whole tree at any time with `pre-commit run glsec --all-files`.
+
+Three hook variants are provided — pick the one that fits how you install glsec:
+
+| Hook id | `language` | Use when |
+|---------|------------|----------|
+| `glsec` | `golang` | Default — pre-commit builds glsec from source at the pinned `rev` (needs a Go toolchain; no separate install). |
+| `glsec-system` | `system` | You already have a `glsec` binary on `PATH` (fastest; version is whatever is installed). |
+| `glsec-docker` | `docker_image` | You'd rather not install anything but Docker — runs `ghcr.io/glsec/glsec` (pin the image version in your own config if reproducibility matters). |
+
+By default the hook only matches files named `.gitlab-ci.yml`. To also scan custom CI-config names/paths (see `--recursive --name`), override `files:`:
+
+```yaml
+      - id: glsec
+        files: '(^|/)[^/]*\.gitlab-ci\.yml$'   # also matches *.gitlab-ci.yml
+```
+
+The hook exits non-zero (failing the commit) on `error` findings or parse errors, matching glsec's normal [exit codes](#exit-codes).
+
+---
+
 ## CI integration
 
 > **Runnable examples for every pattern below:** [gitlab.com/glsec-io/examples](https://gitlab.com/glsec-io/examples) — [Catalog component](https://gitlab.com/glsec-io/examples/component) · [Catalog + Code Quality](https://gitlab.com/glsec-io/examples/component-code-quality) · [Docker image](https://gitlab.com/glsec-io/examples/docker) · [Binary download](https://gitlab.com/glsec-io/examples/binary)


### PR DESCRIPTION
Closes #272.

## What changed

Adds a root `.pre-commit-hooks.yaml` so glsec can be used directly with [pre-commit](https://pre-commit.com/), shifting `.gitlab-ci.yml` findings left to commit time. No scanner code changed — manifest + README docs only.

Consumers add:

```yaml
repos:
  - repo: https://github.com/glsec/glsec
    rev: v1.4.0
    hooks:
      - id: glsec
```

## Hook variants (answers the issue's `language` open question)

Rather than pick one, the manifest ships three so users match it to how they install glsec:

| Hook id | `language` | Use when |
|---------|------------|----------|
| `glsec` | `golang` | Default — pre-commit builds from source at the pinned `rev` (Go toolchain, no separate install). |
| `glsec-system` | `system` | A `glsec` binary is already on `PATH`. |
| `glsec-docker` | `docker_image` | Only Docker available — runs `ghcr.io/glsec/glsec`. |

All three use `files: '(^|/)\.gitlab-ci\.yml$'` and `pass_filenames: true`, so only changed CI files are scanned. The hook fails the commit on `error` findings / parse errors (glsec's normal exit codes).

## `files:` default and #270

Default matches exactly `.gitlab-ci.yml` (least surprising). README documents overriding `files:` to `(^|/)[^/]*\.gitlab-ci\.yml$` for custom names, aligning with the `--recursive --name` work in #270.

## How tested

Installed pre-commit 4.6.0 and ran `pre-commit try-repo` against this branch:

- **`glsec` (golang):** built from source, scanned a bad pipeline, reported GL001 + GL053, exited 1 (commit fails). ✅
- **`glsec-system`:** with `glsec` on PATH, passed a clean pinned pipeline (exit 0) and correctly ignored a non-matching `README.txt` via the `files:` filter. ✅
- Manifest passes pre-commit's schema validation on load.

`glsec-docker` not run here (would require pulling the image) but is a standard `docker_image` hook; the published image's entrypoint is `glsec`, so file args pass straight through.
