### PR TITLE
feat: ship glsec as a Claude Code plugin (#280)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "glsec",
+  "owner": {
+    "name": "glsec",
+    "url": "https://github.com/glsec/glsec"
+  },
+  "plugins": [
+    {
+      "name": "glsec",
+      "source": "./",
+      "description": "Static security scanner for GitLab CI/CD pipelines"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "glsec",
+  "description": "Static security scanner for GitLab CI/CD pipelines",
+  "version": "1.5.0",
+  "author": {
+    "name": "glsec",
+    "url": "https://github.com/glsec/glsec"
+  },
+  "homepage": "https://github.com/glsec/glsec",
+  "repository": "https://github.com/glsec/glsec",
+  "license": "Apache-2.0",
+  "keywords": ["security", "gitlab-ci", "claude-code", "sast", "ci-cd"]
+}

--- a/README.md
+++ b/README.md
@@ -220,6 +220,24 @@ The hook exits non-zero (failing the commit) on `error` findings or parse errors
 
 ---
 
+## Claude Code plugin
+
+glsec ships as a [Claude Code](https://claude.com/claude-code) plugin so Claude can scan your GitLab CI config on demand and as you edit it. Install it from glsec's own marketplace:
+
+```
+/plugin marketplace add glsec/glsec
+/plugin install glsec@glsec
+```
+
+This adds:
+
+- **`/glsec:scan`** — a command that runs glsec over the project and has Claude explain and remediate each finding.
+- **An edit hook** — after Claude writes or edits a `.gitlab-ci.yml` (or a `.gitlab/*.yml`) file, glsec scans it automatically and surfaces any findings.
+
+No Go toolchain is required: the plugin bundles a small POSIX wrapper that resolves a `glsec` binary in order of preference — an existing one on your `PATH`, a cached download, or the prebuilt release asset (downloaded and **verified against `checksums.txt`**, then cached). Supported on **Linux and macOS** (amd64/arm64); the wrapper needs `curl` or `wget`, and the edit hook needs `jq`. On other platforms it prints an install hint instead.
+
+---
+
 ## CI integration
 
 > **Runnable examples for every pattern below:** [gitlab.com/glsec-io/examples](https://gitlab.com/glsec-io/examples) — [Catalog component](https://gitlab.com/glsec-io/examples/component) · [Catalog + Code Quality](https://gitlab.com/glsec-io/examples/component-code-quality) · [Docker image](https://gitlab.com/glsec-io/examples/docker) · [Binary download](https://gitlab.com/glsec-io/examples/binary)

--- a/bin/glsec
+++ b/bin/glsec
@@ -1,0 +1,118 @@
+#!/bin/sh
+# glsec Claude Code plugin wrapper.
+#
+# Resolves a real glsec binary WITHOUT requiring a Go toolchain, in order of
+# preference:
+#   1. an existing glsec already on PATH (Homebrew / go install / manual),
+#      skipping this wrapper itself to avoid self-recursion;
+#   2. a previously downloaded copy in the cache;
+#   3. the prebuilt release asset from GitHub Releases, verified against
+#      checksums.txt, extracted, cached, then exec'd.
+#
+# Supports linux + darwin only. VERSION is kept in lockstep with the release.
+set -eu
+
+VERSION="1.5.0"
+REPO="glsec/glsec"
+
+hint() {
+	cat >&2 <<EOF
+glsec: $1
+
+Install glsec one of these ways, then re-run:
+  - Go:        go install github.com/glsec/glsec/cmd/glsec@latest
+  - Binaries:  https://github.com/glsec/glsec/releases
+EOF
+	exit 1
+}
+
+# abspath prints the absolute path of its argument (dir resolved, basename kept).
+abspath() {
+	_d=$(dirname -- "$1")
+	_b=$(basename -- "$1")
+	_r=$(CDPATH= cd -- "$_d" 2>/dev/null && pwd -P) || return 1
+	printf '%s/%s\n' "$_r" "$_b"
+}
+
+self=$(abspath "$0" 2>/dev/null || printf '%s\n' "$0")
+
+# 1) An existing glsec elsewhere on PATH (not this wrapper). The lookup runs in
+# a subshell (so the local IFS change is contained) and prints the first match.
+found=$(
+	IFS=:
+	for d in $PATH; do
+		[ -n "$d" ] || d=.
+		cand="$d/glsec"
+		[ -x "$cand" ] || continue
+		[ "$(abspath "$cand" 2>/dev/null || true)" = "$self" ] && continue
+		printf '%s\n' "$cand"
+		break
+	done
+)
+if [ -n "$found" ]; then
+	exec "$found" "$@"
+fi
+
+# Map the platform to the release asset's os/arch tokens.
+os=$(uname -s)
+case "$os" in
+	Linux) os=linux ;;
+	Darwin) os=darwin ;;
+	*) hint "unsupported OS '$os' (this plugin supports linux and darwin only)" ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+	x86_64 | amd64) arch=amd64 ;;
+	aarch64 | arm64) arch=arm64 ;;
+	*) hint "unsupported architecture '$arch'" ;;
+esac
+
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/glsec"
+cached="$cache_dir/glsec-$VERSION-$os-$arch"
+
+# 2) Cached download from a previous run.
+if [ -x "$cached" ]; then
+	exec "$cached" "$@"
+fi
+
+# 3) Download, verify, cache.
+asset="glsec_${VERSION}_${os}_${arch}.tar.gz"
+base="https://github.com/$REPO/releases/download/v$VERSION"
+
+if command -v curl >/dev/null 2>&1; then
+	dl() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+	dl() { wget -qO "$2" "$1"; }
+else
+	hint "need curl or wget to download the glsec binary"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+	sha256() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+	sha256() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+	hint "need sha256sum or shasum to verify the download"
+fi
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/glsec.XXXXXX") || hint "could not create a temp directory"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+dl "$base/$asset" "$tmp/$asset" || hint "failed to download $asset from $base"
+dl "$base/checksums.txt" "$tmp/checksums.txt" || hint "failed to download checksums.txt from $base"
+
+want=$(awk -v f="$asset" '$2 == f {print $1}' "$tmp/checksums.txt")
+[ -n "$want" ] || hint "no checksum for $asset in checksums.txt"
+got=$(sha256 "$tmp/$asset")
+[ "$want" = "$got" ] || hint "checksum mismatch for $asset (expected $want, got $got)"
+
+tar -xzf "$tmp/$asset" -C "$tmp" || hint "failed to extract $asset"
+[ -f "$tmp/glsec" ] || hint "glsec binary not found inside $asset"
+
+mkdir -p "$cache_dir"
+chmod +x "$tmp/glsec"
+# Move into place atomically where possible; fall back to copy across devices.
+mv "$tmp/glsec" "$cached" 2>/dev/null || cp "$tmp/glsec" "$cached" || hint "failed to install glsec into $cache_dir"
+
+exec "$cached" "$@"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path'); printf '%s' \"$f\" | grep -qE '\\.gitlab-ci\\.yml$|\\.gitlab/.*\\.ya?ml$' && \"${CLAUDE_PLUGIN_ROOT}/bin/glsec\" \"$f\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/scan/SKILL.md
+++ b/skills/scan/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: scan
+description: Run glsec to scan this project's GitLab CI/CD configuration for security issues
+disable-model-invocation: true
+---
+
+Scan the current project's GitLab CI/CD configuration for security issues and report the findings.
+
+Run glsec recursively over the project so every `.gitlab-ci.yml` (including nested ones) is checked:
+
+```sh
+glsec --recursive .
+```
+
+If that reports no CI config files were found, the project may use a non-default
+filename — fall back to scanning an explicit path the user names, e.g.
+`glsec path/to/pipeline.yml`.
+
+Then, for each finding, explain:
+
+- the rule ID and severity (`error` / `warn`),
+- what the risk is, and
+- how to remediate it.
+
+`glsec explain <RULE-ID>` gives the full rationale and a safe-alternative example for any rule.


### PR DESCRIPTION
Closes #280.

Packages glsec as a [Claude Code](https://claude.com/claude-code) plugin, shipped from this repo (no separate plugin repo, no committed binaries). Install:

```
/plugin marketplace add glsec/glsec
/plugin install glsec@glsec
```

## What's added

```
.claude-plugin/plugin.json        # plugin manifest (version 1.5.0)
.claude-plugin/marketplace.json   # repo is its own marketplace (source: "./")
bin/glsec                         # POSIX wrapper — resolves a real glsec binary, no Go
hooks/hooks.json                  # PostToolUse scan on GitLab CI file edits
skills/scan/SKILL.md              # user-invoked /glsec:scan
```

## The wrapper (`bin/glsec`)

`bin/` is added to the Bash tool's PATH, so bare `glsec` resolves here. The wrapper resolves a real binary **without a Go toolchain**, in order:

1. an existing `glsec` already on `PATH` (skips itself to avoid recursion);
2. a cached download (`${XDG_CACHE_HOME:-~/.cache}/glsec/glsec-<version>-<os>-<arch>`);
3. the prebuilt release asset `glsec_<VERSION>_<os>_<arch>.tar.gz` from GitHub Releases — **verified against `checksums.txt`** (sha256), extracted, `chmod +x`, cached, then `exec`'d.

linux + darwin only (amd64/arm64); uses `curl` or `wget`; clear install hint + non-zero exit on any unsupported OS / missing tool / download failure. `VERSION` is pinned to `1.5.0` and must move in lockstep with releases.

## Decisions / deviations from the issue

- **`glsec .` → `glsec --recursive .`**: the issue's hook/skill used `glsec .`, but that errors (`is a directory`, exit 2) — glsec treats a positional dir as a literal file. The skill now uses `glsec --recursive .`; the hook scans the **specific edited file** (`"$f"`), which is more precise and sidesteps the issue entirely.
- **Hook references `${CLAUDE_PLUGIN_ROOT}/bin/glsec`** rather than bare `glsec`: per the plugin reference, that variable is the reliable way to address a bundled executable from a hook process. The skill uses bare `glsec` (Bash tool, where `bin/` is on PATH).
- **`author.url`, `license: Apache-2.0`** confirmed valid against the plugin.json schema.
- **No MCP server**, per the v1 scope in the issue.

## Testing

Verified the wrapper end-to-end (temporarily pinning `VERSION=1.4.0` to hit a real release):

- **PATH passthrough + self-recursion skip:** with the wrapper dir first on PATH and a real `glsec` after it, the wrapper exec's the real one and does not loop. ✅
- **Download + checksum-verify + cache + exec:** fetched `glsec_1.4.0_linux_amd64.tar.gz`, verified sha256 against `checksums.txt`, ran `--version`. ✅
- **Cache hit on second run** (no network). ✅
- **Nonexistent release** (`VERSION=99.99.99`) → install hint, exit 1. ✅
- **Hook command:** matching `.gitlab-ci.yml` path invokes the wrapper with that file; non-matching path (`main.go`) is a no-op. ✅
- All JSON manifests valid; `sh -n bin/glsec` clean; `go test ./...` + `golangci-lint` green.

End-to-end install inside Claude Code on linux/darwin can only be verified once **v1.5.0 is released** (the wrapper downloads that tag's asset) — that's the follow-up release.

## Release coupling

`plugin.json` `version` and the wrapper `VERSION` are both `1.5.0`; the upcoming v1.5.0 release publishes the assets the wrapper fetches. Bumping these is now part of the release version-pin step.
