### PR TITLE
chore: bump version pins to 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: glsec
 ```
@@ -285,13 +285,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.4.0
+    name: ghcr.io/glsec/glsec:1.5.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.4.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.5.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -299,7 +299,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.4.0"
+  GLSEC_VERSION: "1.5.0"
 
 glsec:
   stage: test
@@ -321,7 +321,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.4.0
+    name: ghcr.io/glsec/glsec:1.5.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -340,7 +340,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.4.0
+    name: ghcr.io/glsec/glsec:1.5.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
Release prep for **v1.5.0**.

Bumps the glsec-release version pins in the README from `1.4.0` to `1.5.0` ahead of tagging:

- pre-commit `rev: v1.4.0 → v1.5.0`
- Docker image tags `ghcr.io/glsec/glsec:1.4.0 → :1.5.0` (3×) and the surrounding pin note
- `GLSEC_VERSION: "1.4.0" → "1.5.0"`

The GitLab CI Catalog **component** pins (`@v1.0.3`) are intentionally left as-is — they version the component, not the glsec release. The plugin manifest + wrapper `VERSION` are already `1.5.0` (from #280).

After this merges I'll push the `v1.5.0` tag to trigger the GoReleaser release.

## What v1.5.0 contains (since v1.4.0)

- **GL065** registry-allowlist rule (#265)
- **GL066** hardcoded `DOCKER_AUTH_CONFIG` rule (#267)
- **GL067** analyzer-registry repoint rule (#268)
- `--recursive --name` / `recursive_patterns:` for non-default CI filenames (#270)
- Pre-commit hook manifest (#272)
- Claude Code plugin (#280)
