### PR TITLE
fix: GL021 false positives on --password-stdin and cross-line blocks (#295)

### DIFF
--- a/docs/rules/GL021.md
+++ b/docs/rules/GL021.md
@@ -37,6 +37,14 @@ debug:
     - echo "Token length${CI_JOB_TOKEN:+ (set)}"
 ```
 
+**Pipe the secret into a command's stdin** (not flagged) — the value goes to the command, not the log:
+
+```yaml
+build:
+  before_script:
+    - echo "$CI_REGISTRY_PASSWORD" | docker login --username "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
+```
+
 ## Known limitations
 
 - Lines where `: ` (colon space) appears inside the script command may be parsed by YAML as a mapping and will not be scanned. Use single-quoted scalars in `.gitlab-ci.yml` to avoid YAML parsing ambiguity: `- 'echo $MY_TOKEN'`.

--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/parser"
@@ -25,6 +26,12 @@ var (
 	// safeCheckRe matches patterns that reference the variable without printing its value:
 	// length checks (-n "$VAR"), default expansions (${VAR:-}, ${VAR:+}), and masked prints.
 	safeCheckRe = regexp.MustCompile(`\[\s*(?:-n|-z)\s+|:\-|:\+`)
+
+	// stdinPipeRe matches the safe idiom where an echo/printf is piped into a
+	// command reading the secret from stdin (e.g. `echo "$PASS" | docker login
+	// --password-stdin`). The value goes to the command's stdin, not the job
+	// log — this is the very pattern GL029 recommends.
+	stdinPipeRe = regexp.MustCompile(`\|[^|]*--[A-Za-z-]*stdin\b`)
 )
 
 func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
@@ -40,27 +47,35 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 				if item.Kind != yaml.ScalarNode {
 					continue
 				}
-				line := item.Value
-				if !printCmdRe.MatchString(line) {
-					continue
+				// Match per physical line: a `|` block scalar is one item but
+				// many commands, so an echo on one line must not be paired with
+				// a secret on another.
+				for i, line := range strings.Split(item.Value, "\n") {
+					if !printCmdRe.MatchString(line) {
+						continue
+					}
+					match := secretVarRe.FindString(line)
+					if match == "" {
+						continue
+					}
+					// Skip lines that only check the variable's presence, not its value.
+					if safeCheckRe.MatchString(line) {
+						continue
+					}
+					// Skip the `echo "$SECRET" | … --password-stdin` idiom.
+					if stdinPipeRe.MatchString(line) {
+						continue
+					}
+					findings = append(findings, finding.Finding{
+						RuleID:   "GL021",
+						Severity: finding.Warn,
+						Job:      name.Value,
+						Message:  fmt.Sprintf("script prints secret variable %s — value may appear in job logs", match),
+						File:     file,
+						Line:     item.Line + i,
+						Col:      item.Column,
+					})
 				}
-				match := secretVarRe.FindString(line)
-				if match == "" {
-					continue
-				}
-				// Skip lines that only check the variable's presence, not its value.
-				if safeCheckRe.MatchString(line) {
-					continue
-				}
-				findings = append(findings, finding.Finding{
-					RuleID:   "GL021",
-					Severity: finding.Warn,
-					Job:      name.Value,
-					Message:  fmt.Sprintf("script prints secret variable %s — value may appear in job logs", match),
-					File:     file,
-					Line:     item.Line,
-					Col:      item.Column,
-				})
 			}
 		}
 	})

--- a/rules/gl021_test.go
+++ b/rules/gl021_test.go
@@ -145,6 +145,51 @@ debug:
 	}
 }
 
+func TestGL021_PasswordStdin_NoFinding(t *testing.T) {
+	// `echo "$SECRET" | docker login --password-stdin` pipes the value to the
+	// command's stdin, not the job log — the idiom GL029 recommends.
+	f := findings021(t, `
+build:
+  before_script:
+    - echo "${CI_REGISTRY_PASSWORD}" | docker login --username "${CI_REGISTRY_USER}" --password-stdin "${CI_REGISTRY}"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for --password-stdin idiom, got %d", len(f))
+	}
+}
+
+func TestGL021_BlockScalarCrossLine_NoFinding(t *testing.T) {
+	// echo (non-secret) and the secret var are on different lines of one block
+	// scalar — the secret is passed as a curl header, never printed.
+	f := findings021(t, `
+deps:
+  script:
+    - |
+      if curl -H "JOB-TOKEN: $CI_JOB_TOKEN" -sLO "$PACKAGE_URL"; then
+        echo "Found dependencies in package registry."
+      fi
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when echo and secret are on different lines, got %d", len(f))
+	}
+}
+
+func TestGL021_BlockScalarSameLine_Finding(t *testing.T) {
+	// A real leak inside a block scalar (echo + secret on the same line) must
+	// still be caught.
+	f := findings021(t, `
+deps:
+  script:
+    - |
+      echo "starting"
+      echo "$DEPLOY_TOKEN"
+      echo "done"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for echo of secret inside block scalar, got %d", len(f))
+	}
+}
+
 func TestGL021_LineNumber(t *testing.T) {
 	f := findings021(t, `
 debug:


### PR DESCRIPTION
Fixes #295.

GL021 raised a finding whenever a print command (`echo`/`printf`/`print`) and a secret-suffixed variable both appeared **anywhere in the same script item**, with no exemption for the stdin idiom. That produced two false positives, both found dogfooding v1.5.0 against public gitlab.com pipelines.

## Fixes

**1. `--password-stdin` idiom (the secure pattern GL029 recommends)**

```yaml
- echo "${CI_REGISTRY_PASSWORD}" | docker login --username "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
```

The value is piped to the command's stdin, not the job log. Now exempted via `stdinPipeRe` (`\|[^|]*--[A-Za-z-]*stdin\b`).

**2. `echo` and secret on different lines of one block scalar**

```yaml
- |
  if curl -H "JOB-TOKEN: $CI_JOB_TOKEN" -sLO "$PACKAGE_URL"; then
    echo "Found dependencies in package registry."
  fi
```

The secret is a curl header (never printed); the only `echo` prints a non-secret string on another line. The rule now matches **per physical line** (`strings.Split(item.Value, "\n")`) instead of per block-scalar item, so `echo` and the secret must be on the same command. Finding line numbers are reported per matching line (`item.Line + i`).

## Not weakened

A genuine leak inside a block scalar (echo + secret on the **same** line) is still caught — covered by a new test. Single-line `echo $SECRET`, `printf`, brace-expansion, before_script, and presence-check cases are unchanged.

## Tests

- `TestGL021_PasswordStdin_NoFinding` — FP1 gone
- `TestGL021_BlockScalarCrossLine_NoFinding` — FP2 gone
- `TestGL021_BlockScalarSameLine_Finding` — real in-block leak still flagged
- All existing GL021 tests pass; full `go test ./...` + `golangci-lint` green.
- Verified on the original files: GL021 no longer fires on gitlab-org/container-registry or inkscape/inkscape.

Doc updated with the stdin-pipe safe alternative.
