### PR TITLE
fix: GL032 false positive on echo into ~/.ssh/config (#296)

### DIFF
--- a/docs/rules/GL032.md
+++ b/docs/rules/GL032.md
@@ -7,6 +7,8 @@
 
 glsec flags script lines that use `echo` or `printf` to write what appears to be an SSH private key to a file — specifically: lines that redirect or pipe to a `.ssh/` path, or that reference a CI variable whose name contains `PRIVATE` or `_KEY`. When debug tracing is active (`set -x` or `CI_DEBUG_TRACE`), the shell prints the expanded variable value — including the full private key — to the job log. GitLab explicitly warns: *"Never run a command like `cat` or `tee` on the variable because the SSH key is not masked if it appears in the job log."*
 
+Writing into `~/.ssh/config` or `~/.ssh/known_hosts` is **not** flagged — those hold SSH configuration, not key material (e.g. `echo "StrictHostKeyChecking no" >> ~/.ssh/config`). Disabling host-key checking that way is a separate concern caught by [GL048](GL048.md).
+
 ## Trigger example
 
 ```yaml

--- a/rules/gl032.go
+++ b/rules/gl032.go
@@ -14,19 +14,36 @@ var GL032 = &gl032{}
 
 func (r *gl032) ID() string { return "GL032" }
 
-// sshKeyEchoRe matches echo/printf piping or redirecting to an SSH key file path,
-// or echoing a variable with a key-like name to any destination.
-var sshKeyEchoRe = regexp.MustCompile(
-	`\b(?:echo|printf)\b` +
-		`.*` +
-		`(?:` +
-		// redirect or pipe to ssh key file
-		`[|>].*\.ssh/` +
-		`|` +
-		// variable name contains KEY or PRIVATE
-		`\$(?:\{[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*\}|[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*)` +
-		`)`,
+var (
+	// sshKeyVarRe matches echoing/printing a variable whose name implies a
+	// private key (contains PRIVATE or a _KEY suffix), to any destination.
+	sshKeyVarRe = regexp.MustCompile(
+		`\b(?:echo|printf)\b.*\$(?:\{[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*\}|[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*)`)
+
+	// sshRedirectRe matches echoing/printing redirected or piped into a file
+	// under an .ssh/ directory; the captured group is the target filename.
+	sshRedirectRe = regexp.MustCompile(
+		`\b(?:echo|printf)\b.*[|>].*\.ssh/([A-Za-z0-9._-]*)`)
 )
+
+// sshNonKeyTargets are .ssh/ files that hold configuration, not key material,
+// so echoing into them is not a leaked private key (e.g. appending
+// "StrictHostKeyChecking no" to ~/.ssh/config).
+var sshNonKeyTargets = map[string]bool{
+	"config":      true,
+	"known_hosts": true,
+}
+
+// sshKeyEchoLine reports whether a script line echoes/prints a private key.
+func sshKeyEchoLine(line string) bool {
+	if sshKeyVarRe.MatchString(line) {
+		return true
+	}
+	if m := sshRedirectRe.FindStringSubmatch(line); m != nil {
+		return !sshNonKeyTargets[m[1]]
+	}
+	return false
+}
 
 func (r *gl032) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
@@ -65,7 +82,7 @@ func checkSSHKeyEcho(node *yaml.Node, file, job string) []finding.Finding {
 		if item.Kind != yaml.ScalarNode {
 			continue
 		}
-		if sshKeyEchoRe.MatchString(item.Value) {
+		if sshKeyEchoLine(item.Value) {
 			findings = append(findings, finding.Finding{
 				RuleID:   "GL032",
 				Severity: finding.Warn,

--- a/rules/gl032_test.go
+++ b/rules/gl032_test.go
@@ -59,6 +59,26 @@ func TestGL032(t *testing.T) {
   - chmod 600 ~/.ssh/id_rsa`,
 			wantHits: 1,
 		},
+		{
+			name: "echo StrictHostKeyChecking into ~/.ssh/config — config, not a key",
+			yaml: `before_script:
+  - mkdir -p ~/.ssh
+  - echo "StrictHostKeyChecking no" >> ~/.ssh/config`,
+			wantHits: 0,
+		},
+		{
+			name: "echo into ~/.ssh/known_hosts — not a key",
+			yaml: `before_script:
+  - ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+  - echo "gitlab.com ssh-rsa AAAA..." >> ~/.ssh/known_hosts`,
+			wantHits: 0,
+		},
+		{
+			name: "echo key variable redirected into ~/.ssh/config still flagged",
+			yaml: `before_script:
+  - echo "$SSH_PRIVATE_KEY" >> ~/.ssh/config`,
+			wantHits: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #296.

GL032's regex flagged **any** `echo`/`printf` redirected or piped into a `.ssh/` path as a written SSH private key. But `~/.ssh/config` and `~/.ssh/known_hosts` hold configuration, not key material, so e.g.

```yaml
- echo "StrictHostKeyChecking no" >> ~/.ssh/config   # false positive
```

was wrongly reported (found dogfooding v1.5.0 on gitlab-org/gitaly).

## Fix

Split the single combined regex into two intents:

- `sshKeyVarRe` — echo/printf of a variable whose name implies a key (`PRIVATE` / `_KEY`), to any destination. **Unchanged behaviour.**
- `sshRedirectRe` — echo/printf redirected/piped into a `.ssh/` file, now **capturing the target filename**. The `.ssh/`-destination branch is skipped when the target is `config` or `known_hosts` (`sshNonKeyTargets`).

So config/known_hosts writes no longer fire, while echoing actual key material into `.ssh/` (`id_rsa`, etc.) and echoing a `*_KEY`/`*PRIVATE*` variable anywhere still do — including a key variable redirected into `~/.ssh/config` (the variable-name branch still catches that).

## Not weakened

- `echo "$ID_RSA" > ~/.ssh/id_rsa` → still flagged.
- `echo "$DEPLOY_SERVER_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/id_rsa` → still flagged.
- `echo "$SSH_PRIVATE_KEY" >> ~/.ssh/config` → still flagged (key-named variable).
- `StrictHostKeyChecking` disabling remains caught by **GL048**.

## Tests

Three new cases (config write, known_hosts write, key-var-into-config). All existing GL032 cases pass; full `go test ./...` + `golangci-lint` green. Verified on the gitaly file: GL032 gone, GL048 retained. Doc updated.
