### PR TITLE
fix: GL035 message accuracy — exposure is conditional (#299)

### DIFF
--- a/docs/rules/GL035.md
+++ b/docs/rules/GL035.md
@@ -5,13 +5,13 @@
 
 ## What glsec checks
 
-glsec flags script lines where a `git clone`, `git push`, `git fetch`, `git pull`, or `git remote` command uses a URL containing embedded userinfo credentials in the form `https://user:token@host`. This pattern causes the token to appear in:
+glsec flags script lines where a `git clone`, `git push`, `git fetch`, `git pull`, or `git remote` command uses a URL containing embedded userinfo credentials in the form `https://user:token@host`. This exposes the token through:
 
-- Job logs (Git prints the remote URL when pushing/fetching)
-- Shell trace output when `set -x` or `CI_DEBUG_TRACE` is active
-- `.git/config` inside the container, which may be archived by `artifacts: untracked: true`
+- **The runner's process table** — the credential is an argument of the running command (`ps` shows it) regardless of logging.
+- **`.git/config`** inside the container, which may be archived by `artifacts: untracked: true`.
+- **The job log, *conditionally*** — only when `CI_DEBUG_TRACE` / `set -x` is active (the shell trace then expands the variable), or when the tool does not redact credentials in its own output.
 
-Even when the token comes from a CI variable (not hardcoded), the fully-expanded URL including the token value appears in the log.
+Note that, by default, the token does **not** appear in the job log: GitLab echoes the raw script text with the variable unexpanded (e.g. `git push https://ci:${TOKEN}@…`), and Git itself strips the userinfo from its remote output (`To https://gitlab.com/org/repo.git`). The risk is real but defence-in-depth — it materialises under debug tracing, with non-redacting tools (`curl -v`, `wget`), or via the process table. Even a CI-variable token (not hardcoded) is affected.
 
 ## Trigger example
 
@@ -23,16 +23,26 @@ deploy:
 
 ## Safe alternative
 
-Use `git remote set-url` to configure the remote, then push without embedding credentials in the command that Git logs:
+Keep the token out of the URL — and ideally off the command line entirely.
+
+Prefer an **SSH remote** with a deploy key stored in a protected CI variable (see GL030, GL032); the credential never appears in a URL, in `.git/config`, or as a command argument:
 
 ```yaml
 deploy:
   script:
-    - git remote set-url origin "https://gitlab-ci-token:${CI_JOB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
-    - git push origin HEAD:main
+    - git push git@${CI_SERVER_HOST}:${CI_PROJECT_PATH}.git HEAD:main
 ```
 
-Or use SSH remotes with a key stored in a protected CI variable (see GL030, GL032).
+Or feed the token to Git through a **credential helper / `GIT_ASKPASS`** that reads it from the environment, so it is never written into the URL or persisted:
+
+```yaml
+deploy:
+  script:
+    - git config credential.helper '!f() { echo "username=gitlab-ci-token"; echo "password=$CI_JOB_TOKEN"; }; f'
+    - git push "https://${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" HEAD:main
+```
+
+> Note: `git remote set-url origin "https://user:${TOKEN}@host/…"` is **not** a fix — it still embeds the credential in the URL and is flagged by this rule.
 
 ## References
 

--- a/rules/gl035.go
+++ b/rules/gl035.go
@@ -61,7 +61,7 @@ func checkGitCredURL(node *yaml.Node, file, job string) []finding.Finding {
 				RuleID:   "GL035",
 				Severity: finding.Warn,
 				Job:      job,
-				Message:  "git command uses URL with embedded credentials (user:token@host) — the expanded URL including the token appears in job logs; use a credential helper or CI_JOB_TOKEN without embedding it in the URL",
+				Message:  "git command uses URL with embedded credentials (user:token@host) — the credential sits in the runner's process table and in .git/config, and reaches the job log if CI_DEBUG_TRACE is enabled or the tool does not redact it (git redacts its own output, many tools do not); use a credential helper, an auth header, or an SSH remote instead of embedding it in the URL",
 				File:     file,
 				Line:     item.Line,
 				Col:      item.Column,


### PR DESCRIPTION
Fixes #299.

GL035 claimed the embedded token "appears in job logs" / "the fully-expanded URL including the token value appears in the log". That's false in the default case, verified against a real successful `translations:daily` run in public inkscape/inkscape (job 14623496440):

```
$ git push https://ci:${TRANSLATION_TOKEN}@gitlab.com/inkscape/translations.git ${CI_COMMIT_BRANCH}
To https://gitlab.com/inkscape/translations.git
   eca5e70..d56937f  master -> master
```

GitLab echoes the raw script text (`${TRANSLATION_TOKEN}` unexpanded, no `CI_DEBUG_TRACE`), and git strips the userinfo from its own output. No token in the log.

## Change (detection unchanged)

- **Message** reworded to be accurate and conditional: the credential is always in the runner's **process table** and **`.git/config`**, but only reaches the **job log** under `CI_DEBUG_TRACE`/`set -x` or with tools that don't redact (git redacts; `curl -v`/`wget` don't).
- **Doc** corrected: the "Job logs (Git prints the remote URL …)" bullet was wrong; added the default-case note (unexpanded trace + git redaction). Replaced the "safe alternative" — the old `git remote set-url … user:token@host` example is itself a GL035 trigger — with an SSH remote and a credential-helper approach that keep the token out of the URL/.git/config (and the new examples don't self-trigger the rule).

Severity stays `warn`. Regex/detection untouched — still fires on both inkscape `translations:daily`/`weekly` lines, just with the corrected message.

## Tests
All existing GL035 tests pass (they don't assert message text); full `go test ./...` + `golangci-lint` green.
