### PR TITLE
fix: GL021 output-aware — only flag secrets actually printed to the log (#301)

### DIFF
--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -24,14 +24,12 @@ var (
 	secretVarRe = regexp.MustCompile(`\$\{?[A-Za-z_][A-Za-z0-9_]*(?:_TOKEN|_SECRET|_PASSWORD|_PASSWD|_PASS|_PWD|_KEY|_CREDENTIAL|_CERT)\}?`)
 
 	// safeCheckRe matches patterns that reference the variable without printing its value:
-	// length checks (-n "$VAR"), default expansions (${VAR:-}, ${VAR:+}), and masked prints.
-	safeCheckRe = regexp.MustCompile(`\[\s*(?:-n|-z)\s+|:\-|:\+`)
+	// length checks (-n "$VAR", test -n "$VAR"), default expansions (${VAR:-}, ${VAR:+}).
+	safeCheckRe = regexp.MustCompile(`\[\s*(?:-n|-z)\s+|\btest\s+-[nz]\b|:\-|:\+`)
 
-	// stdinPipeRe matches the safe idiom where an echo/printf is piped into a
-	// command reading the secret from stdin (e.g. `echo "$PASS" | docker login
-	// --password-stdin`). The value goes to the command's stdin, not the job
-	// log — this is the very pattern GL029 recommends.
-	stdinPipeRe = regexp.MustCompile(`\|[^|]*--[A-Za-z-]*stdin\b`)
+	// singleQuotedRe matches single-quoted spans, whose contents the shell does
+	// not expand (so a secret reference inside them is literal text).
+	singleQuotedRe = regexp.MustCompile(`'[^']*'`)
 )
 
 func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
@@ -48,22 +46,10 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 					continue
 				}
 				// Match per physical line: a `|` block scalar is one item but
-				// many commands, so an echo on one line must not be paired with
-				// a secret on another.
+				// many commands.
 				for i, line := range strings.Split(item.Value, "\n") {
-					if !printCmdRe.MatchString(line) {
-						continue
-					}
-					match := secretVarRe.FindString(line)
-					if match == "" {
-						continue
-					}
-					// Skip lines that only check the variable's presence, not its value.
-					if safeCheckRe.MatchString(line) {
-						continue
-					}
-					// Skip the `echo "$SECRET" | … --password-stdin` idiom.
-					if stdinPipeRe.MatchString(line) {
+					match, ok := printedSecret(line)
+					if !ok {
 						continue
 					}
 					findings = append(findings, finding.Finding{
@@ -81,4 +67,66 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 	})
 
 	return findings
+}
+
+// printedSecret reports whether a script line actually prints a secret variable
+// to stdout/stderr (i.e. the job log). It returns false when the printed value
+// is instead redirected to a file, piped into another command, captured by a
+// command/process substitution, or single-quoted (not expanded) — none of which
+// reach the log absent debug tracing.
+func printedSecret(line string) (string, bool) {
+	// Single-quoted spans are literal; blank them so a `$VAR` inside one does
+	// not count as a reference.
+	s := singleQuotedRe.ReplaceAllString(line, " ")
+	if safeCheckRe.MatchString(s) {
+		return "", false
+	}
+
+	for _, loc := range secretVarRe.FindAllStringIndex(s, -1) {
+		start, end := loc[0], loc[1]
+
+		// Find the command segment the secret belongs to (split on shell
+		// command separators).
+		left := start - 1
+		for left >= 0 && !isShellSep(s[left]) {
+			left--
+		}
+		right := end
+		for right < len(s) && !isShellSep(s[right]) {
+			right++
+		}
+
+		// The secret must be an argument of a print command in this segment.
+		if !printCmdRe.MatchString(s[left+1 : start]) {
+			continue
+		}
+		seg := s[left+1 : right]
+		// Output redirected to a file (`>` / `>>`): not logged.
+		if strings.Contains(seg, ">") {
+			continue
+		}
+		// Output piped into another command: not logged.
+		if right < len(s) && s[right] == '|' {
+			continue
+		}
+		// Inside `$(…)` or `<(…)` command/process substitution: captured, not logged.
+		if left >= 0 && s[left] == '(' && (left == 0 || s[left-1] == '$' || s[left-1] == '<') {
+			continue
+		}
+		return s[start:end], true
+	}
+	return "", false
+}
+
+// isShellSep reports whether b separates shell commands (pipeline, list, or
+// substitution boundaries). Note `{`/`}` are intentionally excluded: they close
+// `${VAR}` brace expansions far more often than they group commands, and
+// treating them as separators truncates a segment mid-variable (hiding a later
+// redirect or pipe).
+func isShellSep(b byte) bool {
+	switch b {
+	case '|', '&', ';', '(', ')':
+		return true
+	}
+	return false
 }

--- a/rules/gl021_test.go
+++ b/rules/gl021_test.go
@@ -190,6 +190,122 @@ deps:
 	}
 }
 
+func TestGL021_RedirectToFile_NoFinding(t *testing.T) {
+	f := findings021(t, `
+deploy:
+  script:
+    - echo "$AWS_ACCESS_KEY_ID" >> ~/.s3cfg
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for redirect to file, got %d", len(f))
+	}
+}
+
+func TestGL021_PipeToConsumer_NoFinding(t *testing.T) {
+	f := findings021(t, `
+deploy:
+  script:
+    - echo "$CARGO_TOKEN" | cargo login
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for echo piped into a command, got %d", len(f))
+	}
+}
+
+func TestGL021_SshAddStdin_NoFinding(t *testing.T) {
+	// The very idiom GL032's message recommends; the key never hits the log.
+	f := findings021(t, `
+deploy:
+  script:
+    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for echo piped into ssh-add, got %d", len(f))
+	}
+}
+
+func TestGL021_ProcessSubstitution_NoFinding(t *testing.T) {
+	f := findings021(t, `
+deploy:
+  script:
+    - ssh-add <(echo "$DEPLOY_SSH_KEY")
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for process substitution, got %d", len(f))
+	}
+}
+
+func TestGL021_CommandSubstitution_NoFinding(t *testing.T) {
+	f := findings021(t, `
+query:
+  script:
+    - 'export AUTH="Basic $(echo -n "$MIMIR_API_USER:$MIMIR_API_KEY" | base64)"'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for command substitution, got %d", len(f))
+	}
+}
+
+func TestGL021_SingleQuotedLiteral_NoFinding(t *testing.T) {
+	f := findings021(t, `
+notice:
+  script:
+    - "echo '$GITLAB_STATE_CLEANER_TOKEN is deprecated'"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for single-quoted literal, got %d", len(f))
+	}
+}
+
+func TestGL021_PresenceCheckTestN_NoFinding(t *testing.T) {
+	f := findings021(t, `
+guard:
+  script:
+    - 'test -n "$GITLAB_TOKEN" || { echo "GITLAB_TOKEN not set"; exit 1; }'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for test -n presence check, got %d", len(f))
+	}
+}
+
+func TestGL021_SecretAsCommandArg_NoFinding(t *testing.T) {
+	// echo is an unrelated warning on the same line; the secret is an argument
+	// of a different command, not printed.
+	f := findings021(t, `
+publish:
+  script:
+    - 'gnome-extensions upload --password "$EGO_PASSWORD" "$FILE" || { echo "upload failed"; exit 1; }'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when secret is an arg of a non-print command, got %d", len(f))
+	}
+}
+
+func TestGL021_BraceVarRedirect_NoFinding(t *testing.T) {
+	// Regression: the closing `}` of ${VAR} must not be treated as a command
+	// separator, or the trailing redirect is missed and this is flagged.
+	f := findings021(t, `
+deploy:
+  script:
+    - echo "secret_key = ${AWS_SECRET_ACCESS_KEY}" >> ~/.s3cfg
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for brace-var redirect to file, got %d", len(f))
+	}
+}
+
+func TestGL021_EchoWithTextPrefix_Finding(t *testing.T) {
+	// A genuine leak: the secret is printed to the log alongside text.
+	f := findings021(t, `
+debug:
+  script:
+    - echo "token=$API_TOKEN"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for echoed secret with text, got %d", len(f))
+	}
+}
+
 func TestGL021_LineNumber(t *testing.T) {
 	f := findings021(t, `
 debug:


### PR DESCRIPTION
Fixes #301.

GL021 fired whenever a print command (`echo`/`printf`/`print`) and a secret-suffixed variable appeared together, regardless of where the output actually went. On a scan of **262 popular public gitlab.com repos this produced 43 findings — all 43 were false positives** (redirects to files, pipes into tools, command/process substitution, single-quoted literals, or the secret being an argument of a *different* command on the same line).

## Fix: output-aware detection

A line is now flagged only when the secret is actually printed to stdout/stderr (the job log). `printedSecret()`:

1. blanks single-quoted spans (shell doesn't expand them) — `echo '$TOKEN is deprecated'` → no finding;
2. keeps the existing presence-check skip, extended to `test -n`/`test -z`;
3. locates the secret's command segment (split on `| & ; ( )`) and requires a print command **to the left** of the secret in that segment — so `docker login -p "$X"` or `test -n "$X"` next to an unrelated `echo` no longer match;
4. skips the segment when its output is **redirected** (`>`/`>>`), **piped** (`|`), or sits inside **`$(…)` / `<(…)`** substitution.

`{`/`}` are deliberately *not* treated as command separators — they close `${VAR}` brace expansions far more often than they group commands, and treating them as separators truncated a segment mid-variable (hiding a trailing redirect). That bug is covered by a regression test.

## Result

- 262-repo scan: **GL021 43 → 0** (`--no-cache`); every former hit was a non-logging pattern.
- Genuine leaks still flagged: `echo "$DEPLOY_PASSWORD"`, `echo "token=$API_TOKEN"`, secret-on-same-line inside a block scalar — covered by tests.
- Supersedes the narrower #295 fix (`--password-stdin` is now handled by the general pipe rule).

## Tests

10 new no-finding cases (redirect, pipe, ssh-add stdin, process/command substitution, single-quote, `test -n`, secret-as-arg, brace-var+redirect) plus true-positive guards. Full `go test ./...` + `golangci-lint` green.

## Note (not fixed here)

Dogfooding also surfaced that the result **cache key doesn't distinguish same-version `+dirty` dev rebuilds**, so a rebuilt binary can serve stale findings (released versions differ by tag, so users are unaffected). Mentioning for awareness; out of scope. GL032 false positives are tracked separately in #302.
