### PR TITLE
fix: GL032 excludes public/host keys and non-key .ssh files (#302)

### DIFF
--- a/docs/rules/GL032.md
+++ b/docs/rules/GL032.md
@@ -7,7 +7,12 @@
 
 glsec flags script lines that use `echo` or `printf` to write what appears to be an SSH private key to a file — specifically: lines that redirect or pipe to a `.ssh/` path, or that reference a CI variable whose name contains `PRIVATE` or `_KEY`. When debug tracing is active (`set -x` or `CI_DEBUG_TRACE`), the shell prints the expanded variable value — including the full private key — to the job log. GitLab explicitly warns: *"Never run a command like `cat` or `tee` on the variable because the SSH key is not masked if it appears in the job log."*
 
-Writing into `~/.ssh/config` or `~/.ssh/known_hosts` is **not** flagged — those hold SSH configuration, not key material (e.g. `echo "StrictHostKeyChecking no" >> ~/.ssh/config`). Disabling host-key checking that way is a separate concern caught by [GL048](GL048.md).
+The variable-name branch also catches non-SSH private credentials (`$GCP_SERVICE_ACCOUNT_KEY`, etc.), since the same debug-trace exposure applies; the finding message is therefore phrased generically.
+
+**Not flagged:**
+
+- **Public / host keys** — variables whose name contains `PUBLIC` or `HOST` (e.g. `$ATTIC_PUBLIC_KEY`, `$SSH_HOST_KEY`) are not secret.
+- **Non-key `.ssh/` files** — writing into `~/.ssh/config`, `~/.ssh/known_hosts`, or `~/.ssh/authorized_keys` (configuration / public keys), e.g. `echo "StrictHostKeyChecking no" >> ~/.ssh/config`. Disabling host-key checking that way is a separate concern caught by [GL048](GL048.md).
 
 ## Trigger example
 

--- a/rules/gl032.go
+++ b/rules/gl032.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/parser"
@@ -15,34 +16,24 @@ var GL032 = &gl032{}
 func (r *gl032) ID() string { return "GL032" }
 
 var (
-	// sshKeyVarRe matches echoing/printing a variable whose name implies a
-	// private key (contains PRIVATE or a _KEY suffix), to any destination.
-	sshKeyVarRe = regexp.MustCompile(
-		`\b(?:echo|printf)\b.*\$(?:\{[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*\}|[A-Za-z_]*(?:PRIVATE|_KEY)[A-Za-z_]*)`)
+	// echoPrintfRe matches a shell print command.
+	echoPrintfRe = regexp.MustCompile(`\b(?:echo|printf)\b`)
+
+	// keyVarRe matches a variable reference whose name implies key material
+	// (contains PRIVATE or a _KEY segment). Group 1 is the variable name.
+	keyVarRe = regexp.MustCompile(`\$\{?([A-Za-z0-9_]*(?:PRIVATE|_KEY)[A-Za-z0-9_]*)\}?`)
 
 	// sshRedirectRe matches echoing/printing redirected or piped into a file
-	// under an .ssh/ directory; the captured group is the target filename.
-	sshRedirectRe = regexp.MustCompile(
-		`\b(?:echo|printf)\b.*[|>].*\.ssh/([A-Za-z0-9._-]*)`)
+	// under an .ssh/ directory; group 1 is the target filename.
+	sshRedirectRe = regexp.MustCompile(`\b(?:echo|printf)\b.*[|>].*\.ssh/([A-Za-z0-9._-]*)`)
 )
 
-// sshNonKeyTargets are .ssh/ files that hold configuration, not key material,
-// so echoing into them is not a leaked private key (e.g. appending
-// "StrictHostKeyChecking no" to ~/.ssh/config).
+// sshNonKeyTargets are .ssh/ files that hold configuration or public keys, not
+// private key material, so echoing into them is not a leaked private key.
 var sshNonKeyTargets = map[string]bool{
-	"config":      true,
-	"known_hosts": true,
-}
-
-// sshKeyEchoLine reports whether a script line echoes/prints a private key.
-func sshKeyEchoLine(line string) bool {
-	if sshKeyVarRe.MatchString(line) {
-		return true
-	}
-	if m := sshRedirectRe.FindStringSubmatch(line); m != nil {
-		return !sshNonKeyTargets[m[1]]
-	}
-	return false
+	"config":          true,
+	"known_hosts":     true,
+	"authorized_keys": true,
 }
 
 func (r *gl032) Check(doc *yaml.Node, file string) []finding.Finding {
@@ -87,7 +78,7 @@ func checkSSHKeyEcho(node *yaml.Node, file, job string) []finding.Finding {
 				RuleID:   "GL032",
 				Severity: finding.Warn,
 				Job:      job,
-				Message:  "SSH private key written to file via echo — key value appears in job logs when debug tracing is active; use ssh-add with stdin instead: echo \"$KEY\" | ssh-add -",
+				Message:  "private key written via echo — its value appears in the job log when debug tracing (set -x / CI_DEBUG_TRACE) is active; feed it through stdin instead, e.g. echo \"$KEY\" | ssh-add -",
 				File:     file,
 				Line:     item.Line,
 				Col:      item.Column,
@@ -95,4 +86,33 @@ func checkSSHKeyEcho(node *yaml.Node, file, job string) []finding.Finding {
 		}
 	}
 	return findings
+}
+
+// sshKeyEchoLine reports whether a script line echoes/prints private key
+// material. It excludes public/host keys and writes into non-key .ssh/ files
+// (config, known_hosts, authorized_keys).
+func sshKeyEchoLine(line string) bool {
+	// Destination-based: echo redirected/piped into an .ssh/ key file.
+	if m := sshRedirectRe.FindStringSubmatch(line); m != nil && !sshNonKeyTargets[m[1]] {
+		return true
+	}
+	// Variable-name based: a private-key-named variable being printed.
+	return echoesPrivateKey(line)
+}
+
+// echoesPrivateKey reports whether a print command outputs a variable whose
+// name implies a private key, ignoring clearly-public ones (PUBLIC, HOST keys).
+func echoesPrivateKey(line string) bool {
+	loc := echoPrintfRe.FindStringIndex(line)
+	if loc == nil {
+		return false
+	}
+	for _, m := range keyVarRe.FindAllStringSubmatch(line[loc[1]:], -1) {
+		name := strings.ToUpper(m[1])
+		if strings.Contains(name, "PUBLIC") || strings.Contains(name, "HOST") {
+			continue
+		}
+		return true
+	}
+	return false
 }

--- a/rules/gl032_test.go
+++ b/rules/gl032_test.go
@@ -79,6 +79,37 @@ func TestGL032(t *testing.T) {
   - echo "$SSH_PRIVATE_KEY" >> ~/.ssh/config`,
 			wantHits: 1,
 		},
+		{
+			name: "public key variable — not a private key",
+			yaml: `before_script:
+  - echo "extra-trusted-public-keys = $ATTIC_PUBLIC_KEY" >> /etc/nix/nix.conf`,
+			wantHits: 0,
+		},
+		{
+			name: "host key into known_hosts via variable-name branch",
+			yaml: `before_script:
+  - echo "${SSH_HOST_KEY}" > ~/.ssh/known_hosts`,
+			wantHits: 0,
+		},
+		{
+			name: "public key written to authorized_keys",
+			yaml: `before_script:
+  - echo "${PUBLIC_KEY}" > ~/.ssh/authorized_keys`,
+			wantHits: 0,
+		},
+		{
+			name: "private key still flagged alongside public key on same line",
+			yaml: `before_script:
+  - echo "${PRIVATE_KEY}" > ~/.ssh/id_rsa && echo "${PUBLIC_KEY}" > ~/.ssh/authorized_keys`,
+			wantHits: 1,
+		},
+		{ //nolint:gosec // G101: non-SSH credential, test of generalized detection
+			name: "non-SSH key variable (GCP) flagged via generalized message",
+			yaml: `deploy:
+  script:
+    - echo "$GCP_SERVICE_ACCOUNT_KEY" | base64 -d > /tmp/gcloud-key.json`,
+			wantHits: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #302.

GL032's variable-name branch matched any variable containing `PRIVATE` or `_KEY`, so it flagged **public/host keys as private**, and the `config`/`known_hosts` destination exclusion (#298) only applied to the redirect branch — found dogfooding 262 public gitlab.com repos.

## Fix

- **Exclude public/host keys**: variables whose name contains `PUBLIC` or `HOST` (`$ATTIC_PUBLIC_KEY`, `$SSH_HOST_KEY`, …) are no longer treated as private keys.
- **Destination exclusion now covers both branches and adds `authorized_keys`**: writing into `~/.ssh/config`, `~/.ssh/known_hosts`, or `~/.ssh/authorized_keys` is never flagged, even when the variable name contains `_KEY` (e.g. `echo "${SSH_HOST_KEY}" > ~/.ssh/known_hosts`).
- **Generalized message**: the `_KEY` branch legitimately catches non-SSH credentials (`$GCP_SERVICE_ACCOUNT_KEY`, `$GOOGLE_PLAY_API_KEY`), so the message no longer says "SSH private key" — now "private key written via echo — its value appears in the job log when debug tracing (set -x / CI_DEBUG_TRACE) is active".
- The variable check now considers **all** key-like vars after the print command (not just the greedy-last) and allows digits in names — so `STAGING_AMD64_PRIVATE_KEY` and similar, previously missed, are now caught.

## Behaviour

| Line | Before | After |
|---|---|---|
| `echo "$ATTIC_PUBLIC_KEY" >> /etc/nix/...` | flagged ❌ | not flagged ✅ |
| `echo "${SSH_HOST_KEY}" > ~/.ssh/known_hosts` | flagged ❌ | not flagged ✅ |
| `echo "${PUBLIC_KEY}" > ~/.ssh/authorized_keys` | flagged ❌ | not flagged ✅ |
| `echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa` | flagged | flagged ✅ |
| `echo "$SSH_PRIVATE_KEY" >> ~/.ssh/config` | flagged | flagged ✅ (key-named var) |
| `echo "$GCP_SERVICE_ACCOUNT_KEY" \| base64 -d > f` | "SSH private key" | flagged, generalized msg ✅ |

262-repo scan: the public/host-key false positives are eliminated; the count is steady because digit-named private-key vars that were silently missed are now caught (a quality, not quantity, improvement).

## Tests

5 new cases (public-key var, host-key→known_hosts, public→authorized_keys, private+public same line, non-SSH GCP key). All existing GL032 cases pass; full `go test ./...` + `golangci-lint` green. Doc updated.
