### PR TITLE
fix: GL009 flags only GitLab instance-root audiences, not service subdomains (#305)

### DIFF
--- a/docs/rules/GL009.md
+++ b/docs/rules/GL009.md
@@ -6,7 +6,9 @@
 
 ## What glsec checks
 
-glsec flags `id_tokens:` entries whose `aud:` value is a GitLab instance URL (hostname contains `gitlab`). Such an audience is accepted by any service configured with that GitLab instance as an OIDC issuer, rather than being scoped to a specific cloud service.
+glsec flags `id_tokens:` entries whose `aud:` value is a GitLab **instance** URL — a host whose first DNS label is `gitlab` (`gitlab.com`, `gitlab.example.com`). Such an audience is accepted by any service configured with that GitLab instance as an OIDC issuer, rather than being scoped to a specific cloud service.
+
+A service that merely lives on a `gitlab.*` domain — e.g. `https://vault.gitlab.net` (a Vault server) or `https://registry.gitlab.com` — is a legitimate, scoped audience and is **not** flagged.
 
 ## Trigger example
 

--- a/rules/gl009.go
+++ b/rules/gl009.go
@@ -65,12 +65,18 @@ func checkAudNode(node *yaml.Node, file string) []finding.Finding {
 // isOverbroad returns true when the audience is a GitLab instance root URL.
 // Such an audience accepts OIDC tokens from any project on that instance,
 // rather than being scoped to a specific cloud service.
+//
+// The host must *be* a GitLab instance — its first DNS label is "gitlab"
+// (gitlab.com, gitlab.example.com). A service that merely lives on a gitlab.*
+// domain (vault.gitlab.net, registry.gitlab.com) is a legitimate, scoped
+// audience and is not flagged.
 func isOverbroad(aud string) bool {
 	u, err := url.Parse(aud)
-	if err != nil || u.Host == "" {
+	if err != nil || u.Hostname() == "" {
 		return false
 	}
-	return strings.Contains(strings.ToLower(u.Hostname()), "gitlab")
+	labels := strings.Split(strings.ToLower(u.Hostname()), ".")
+	return len(labels) >= 2 && labels[0] == "gitlab"
 }
 
 func overbroad(aud string, line, col int, file string) finding.Finding {

--- a/rules/gl009_test.go
+++ b/rules/gl009_test.go
@@ -101,6 +101,33 @@ deploy:
 	}
 }
 
+func TestGL009_VaultServiceSubdomain_NoFinding(t *testing.T) {
+	// vault.gitlab.net is a Vault service audience, not the GitLab instance.
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: "https://vault.gitlab.net"
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for service subdomain on a gitlab domain, got %d", len(f))
+	}
+}
+
+func TestGL009_RegistrySubdomain_NoFinding(t *testing.T) {
+	f := findings009(t, `
+deploy:
+  id_tokens:
+    TOKEN:
+      aud: "https://registry.gitlab.com"
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for registry subdomain, got %d", len(f))
+	}
+}
+
 func TestGL009_NoIdTokens_NoFinding(t *testing.T) {
 	f := findings009(t, `
 build:


### PR DESCRIPTION
Fixes #305.

GL009 treated **any** audience host containing `gitlab` as a GitLab instance root. On a scan of 972 public gitlab.com repos this produced 101 findings — **99 of them were `aud: https://vault.gitlab.net`**, the correct service-specific audience for HashiCorp Vault JWT auth, not a GitLab instance.

## Fix

`isOverbroad` now flags only when the host **is** a GitLab instance — its first DNS label is `gitlab` (`gitlab.com`, `gitlab.example.com`) — instead of any host containing the substring `gitlab`:

```go
labels := strings.Split(strings.ToLower(u.Hostname()), ".")
return len(labels) >= 2 && labels[0] == "gitlab"
```

So `vault.gitlab.net`, `registry.gitlab.com`, `sentry.gitlab.net` (services on a gitlab.* domain) are no longer flagged, while `gitlab.com` / `gitlab.example.com` instance roots still are.

## Result

- 972-repo scan: **GL009 101 → 2** (`--no-cache`); the 2 remaining are genuine `gitlab.com` instance-root audiences, the 99 Vault FPs are gone.
- Existing tests (`gitlab.com`, `gitlab.example.com`, list aud, multiple tokens) still pass; 2 new no-finding tests for `vault.gitlab.net` and `registry.gitlab.com`.
- Full `go test ./...` + `golangci-lint` green. Doc updated.
