### PR TITLE
fix: correct line numbers for findings inside block scalars (#307)

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -74,6 +74,18 @@ func Unwrap(node *yaml.Node) *yaml.Node {
 	return node
 }
 
+// ScalarContentLine returns the source line of the i-th line of a scalar
+// node's value. For block scalars (literal "|" or folded ">"), node.Line points
+// at the indicator line and the content begins on the next line, so the offset
+// is shifted by one; for plain or quoted scalars node.Line is the content line
+// itself. Use this when reporting findings located within a multi-line scalar.
+func ScalarContentLine(node *yaml.Node, i int) int {
+	if node.Style&(yaml.LiteralStyle|yaml.FoldedStyle) != 0 {
+		return node.Line + 1 + i
+	}
+	return node.Line + i
+}
+
 // reservedKeys are top-level GitLab CI keys that are configuration, not job definitions.
 var reservedKeys = map[string]bool{
 	"stages":        true,

--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -58,7 +58,7 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 						Job:      name.Value,
 						Message:  fmt.Sprintf("script prints secret variable %s — value may appear in job logs", match),
 						File:     file,
-						Line:     item.Line + i,
+						Line:     parser.ScalarContentLine(item, i),
 						Col:      item.Column,
 					})
 				}

--- a/rules/gl021_test.go
+++ b/rules/gl021_test.go
@@ -306,6 +306,22 @@ debug:
 	}
 }
 
+func TestGL021_BlockScalarLineNumber(t *testing.T) {
+	// The secret echo is on file line 5; a block scalar's node.Line points at
+	// the `- |` line (3), so the offset must account for the indicator line.
+	f := findings021(t, `job:
+  script:
+    - |
+      echo "start"
+      echo "$DEPLOY_TOKEN"`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Line != 5 {
+		t.Errorf("expected line 5, got %d", f[0].Line)
+	}
+}
+
 func TestGL021_LineNumber(t *testing.T) {
 	f := findings021(t, `
 debug:


### PR DESCRIPTION
Fixes #307.

Findings located inside a literal/folded block scalar (`- |` / `- >`) were reported one line too early: `node.Line` points at the `|`/`>` indicator line, but the content begins on the next line. Per-line rules computed the finding line as `node.Line + i`, off by one for block scalars (correct for plain single-line items where `i == 0`).

Verified empirically: a `- |` scalar node has `Line` = the indicator line and `Style` = `yaml.LiteralStyle`.

## Fix

New shared helper `parser.ScalarContentLine(node, i)` returns the correct source line, shifting by one for block scalars (`LiteralStyle`/`FoldedStyle`):

```go
if node.Style&(yaml.LiteralStyle|yaml.FoldedStyle) != 0 {
    return node.Line + 1 + i
}
return node.Line + i
```

GL021 (the only rule currently splitting block scalars per line) now uses it; future per-line rules can too.

## Result

On `gitlab-com/gl-infra/production`, the genuine `echo "...${CI_JOB_TOKEN}"` finding is now reported at **line 67** (was 66). New test asserts the line inside a block scalar; full `go test ./...` + `golangci-lint` green.
