### PR TITLE
fix: GL021 ignores echo inside quoted command arguments (credential helpers) (#306)

### DIFF
--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -17,8 +17,9 @@ var GL021 = &gl021{}
 func (r *gl021) ID() string { return "GL021" }
 
 var (
-	// printCmdRe matches shell output commands.
-	printCmdRe = regexp.MustCompile(`\b(?:echo|printf|print)\b`)
+	// assignRe matches a leading shell env assignment (VAR=value) that precedes
+	// a command without being one.
+	assignRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
 
 	// secretVarRe matches CI variable references whose names end with a secret-indicating suffix.
 	secretVarRe = regexp.MustCompile(`\$\{?[A-Za-z_][A-Za-z0-9_]*(?:_TOKEN|_SECRET|_PASSWORD|_PASSWD|_PASS|_PWD|_KEY|_CREDENTIAL|_CERT)\}?`)
@@ -96,8 +97,10 @@ func printedSecret(line string) (string, bool) {
 			right++
 		}
 
-		// The secret must be an argument of a print command in this segment.
-		if !printCmdRe.MatchString(s[left+1 : start]) {
+		// The secret must be an argument of a print command that is the
+		// segment's command — not an `echo` buried inside a quoted argument to
+		// another command (e.g. git config credential.helper "!echo $TOKEN").
+		if !segmentCommandPrints(s[left+1 : start]) {
 			continue
 		}
 		seg := s[left+1 : right]
@@ -116,6 +119,29 @@ func printedSecret(line string) (string, bool) {
 		return s[start:end], true
 	}
 	return "", false
+}
+
+// gl021PrefixTokens are leading tokens that introduce a command without being
+// one (group/subshell openers and shell keywords). Env assignments are matched
+// separately by assignRe.
+var gl021PrefixTokens = map[string]bool{
+	"{": true, "(": true, "!": true,
+	"then": true, "do": true, "else": true, "elif": true,
+}
+
+// segmentCommandPrints reports whether the command at the start of a segment is
+// a print command (echo/printf/print). It skips leading env assignments and
+// group/keyword openers, then checks the first real token — so an `echo` that
+// only appears inside a quoted argument (the secret is not actually printed)
+// does not count.
+func segmentCommandPrints(segHead string) bool {
+	for _, tok := range strings.Fields(segHead) {
+		if assignRe.MatchString(tok) || gl021PrefixTokens[tok] {
+			continue
+		}
+		return tok == "echo" || tok == "printf" || tok == "print"
+	}
+	return false
 }
 
 // isShellSep reports whether b separates shell commands (pipeline, list, or

--- a/rules/gl021_test.go
+++ b/rules/gl021_test.go
@@ -281,6 +281,19 @@ publish:
 	}
 }
 
+func TestGL021_CredentialHelperString_NoFinding(t *testing.T) {
+	// The echo lives inside a git credential-helper string argument; git
+	// consumes the helper's output, it is never printed to the log.
+	f := findings021(t, `
+update:
+  before_script:
+    - 'git config --local credential.helper "!echo \"password=$LOCKFILE_UPDATE_GITLAB_TOKEN\"; :"'
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for echo inside credential.helper string, got %d", len(f))
+	}
+}
+
 func TestGL021_BraceVarRedirect_NoFinding(t *testing.T) {
 	// Regression: the closing `}` of ${VAR} must not be treated as a command
 	// separator, or the trailing redirect is missed and this is flagged.


### PR DESCRIPTION
Fixes #306.

After #301, GL021 still flagged `echo` appearing inside a quoted string argument to another command — notably git credential helpers, where the echo's output is consumed by git, not printed to the log:

```yaml
- git config --local credential.helper "!echo \"password=$LOCKFILE_UPDATE_GITLAB_TOKEN\"; :"
```

## Fix

`printedSecret` previously accepted any `echo`/`printf`/`print` to the left of the secret in the segment. It now requires the print command to be the **segment's command** — the first real token, after skipping leading env assignments (`VAR=…`) and group/keyword openers (`{`, `(`, `!`, `then`, `do`, `else`, `elif`). An `echo` buried inside a quoted argument (the segment's command is `git config`, not `echo`) no longer counts.

## Result

- 972-repo scan: **GL021 5 → 3** — the 2 `git config credential.helper "!echo …"` false positives are gone; the 3 remaining are genuine plaintext leaks (`echo $CI_REGISTRY_PASSWORD`, `echo $CI_RUNNER_SHORT_TOKEN`, `echo "…${CI_JOB_TOKEN}"`).
- All existing GL021 tests pass (true positives, `{ echo`/`then echo` still flagged via the prefix-skip; presence checks, redirects, pipes, substitutions still skipped); new credential-helper test added.
- Full `go test ./...` + `golangci-lint` green.
