### PR TITLE
chore: bump version pins to 1.5.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glsec",
   "description": "Static security scanner for GitLab CI/CD pipelines",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "glsec",
     "url": "https://github.com/glsec/glsec"

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
       - id: glsec
 ```
@@ -285,13 +285,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.5.0
+    name: ghcr.io/glsec/glsec:1.5.1
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.5.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.5.1`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -299,7 +299,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.5.0"
+  GLSEC_VERSION: "1.5.1"
 
 glsec:
   stage: test
@@ -321,7 +321,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.5.0
+    name: ghcr.io/glsec/glsec:1.5.1
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -340,7 +340,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.5.0
+    name: ghcr.io/glsec/glsec:1.5.1
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true

--- a/bin/glsec
+++ b/bin/glsec
@@ -12,7 +12,7 @@
 # Supports linux + darwin only. VERSION is kept in lockstep with the release.
 set -eu
 
-VERSION="1.5.0"
+VERSION="1.5.1"
 REPO="glsec/glsec"
 
 hint() {


### PR DESCRIPTION
Release prep for **v1.5.1**.

Bumps the glsec-release version pins from `1.5.0` to `1.5.1`:

- README: pre-commit `rev`, Docker image tags (3×) + pin note, `GLSEC_VERSION`
- `.claude-plugin/plugin.json` `version`
- `bin/glsec` wrapper `VERSION` (the plugin downloads this tag's release assets)

The GitLab CI Catalog **component** pins (`@v1.0.3`) are intentionally left as-is. After this merges I'll push the `v1.5.1` tag to trigger GoReleaser.

## What v1.5.1 contains (since v1.5.0)

A patch release of accuracy fixes — no new rules, no breaking changes — validated by scanning 262 then 972 popular public gitlab.com pipelines:

- **GL021** false positives eliminated (43 → 3 across 972 repos; the 3 remaining are genuine plaintext token leaks): output-aware detection (#303), `--password-stdin` / cross-line (#297), credential-helper strings (#310)
- **GL032** no longer mislabels public/host keys or non-key `.ssh/` files; message generalized (#298, #304)
- **GL035** message corrected — token exposure is conditional, not guaranteed in logs (#300)
- **GL009** only flags GitLab instance-root audiences, not service subdomains like `vault.gitlab.net` (101 → 2 findings) (#308)
- **Block-scalar findings** now report correct line numbers (#309)
