### PR TITLE
docs: bump CI Catalog component pins to v1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.3
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.5
 
 stages:
   - test
@@ -258,7 +258,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.3
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.5
 
 stages:
   - test


### PR DESCRIPTION
Bumps the GitLab CI Catalog **component** pins in the README from `@v1.0.3` to `@v1.0.5` (the latest published component release, 2026-05-26).

The Catalog component (`gitlab.com/glsec-io/glsec/glsec`) is a separate artifact with its own `v1.0.x` version line, published from the `gitlab.com/glsec-io/glsec` project — independent of the glsec binary releases (`v1.5.x`). This only refreshes the stale doc examples to the newest component tag; it is unrelated to the v1.5.1 binary release.
