### PR TITLE
docs: bump CI Catalog component pins to v1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.5
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.6
 
 stages:
   - test
@@ -258,7 +258,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.5
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.6
 
 stages:
   - test


### PR DESCRIPTION
Bumps the README CI Catalog component pins from `@v1.0.5` to `@v1.0.6`, the version just published from `gitlab.com/glsec-io/glsec` whose `version` input now defaults to the glsec `1.5.1` image. Keeps the documented component example paired with the v1.5.1 binary release. Docs-only.