### PR TITLE
docs: pin ASVS mapping to 4.0.3, document why not 5.0.0

### DIFF
--- a/.github/workflows/check-framework-versions.yml
+++ b/.github/workflows/check-framework-versions.yml
@@ -1,12 +1,14 @@
 name: Check framework versions
 
 # Monthly check for newer releases of the security frameworks glsec maps to.
-# When a newer version is found, opens an issue so the mapping can be reviewed
-# before the pinned version constant is bumped.
+# When a release newer than the last reviewed one is found, opens an issue so
+# the mapping can be reviewed.
 #
-# Currently checks OWASP ASVS (rules/asvs.go). The OWASP Top 10 CI/CD Security
-# Risks taxonomy is a living document without a release feed and is reviewed
-# manually.
+# Currently checks OWASP ASVS (rules/asvs.go). The mapping is pinned to ASVS
+# 4.0.3 on purpose — 5.0.0 dropped the CI/CD build-pipeline requirements glsec
+# lints (#290) — so the check compares against ASVSReviewedThrough, not the
+# pinned mapping version. The OWASP Top 10 CI/CD Security Risks taxonomy is a
+# living document without a release feed and is reviewed manually.
 
 on:
   schedule:
@@ -34,9 +36,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          pinned=$(grep -oP 'ASVSVersion = "\K[^"]+' rules/asvs.go)
-          if [ -z "$pinned" ]; then
-            echo "could not read ASVSVersion from rules/asvs.go" >&2
+          # The mapping is pinned to ASVSVersion (4.0.3) deliberately; ASVS 5.0.0
+          # dropped the CI/CD build-pipeline requirements glsec lints (see #290).
+          # We therefore alert on releases newer than ASVSReviewedThrough — the
+          # newest release already reviewed — not on every release past the pin.
+          reviewed=$(grep -oP 'ASVSReviewedThrough = "\K[^"]+' rules/asvs.go)
+          if [ -z "$reviewed" ]; then
+            echo "could not read ASVSReviewedThrough from rules/asvs.go" >&2
             exit 1
           fi
 
@@ -47,9 +53,15 @@ jobs:
             | sed -E 's/^v//; s/_release$//' \
             | sort -V | tail -1)
 
-          echo "OWASP ASVS: pinned=$pinned latest=$latest"
-          if [ -z "$latest" ] || [ "$latest" = "$pinned" ]; then
-            echo "ASVS mapping is up to date."
+          echo "OWASP ASVS: reviewed_through=$reviewed latest=$latest"
+          if [ -z "$latest" ] || [ "$latest" = "$reviewed" ]; then
+            echo "No ASVS release newer than the last reviewed one."
+            exit 0
+          fi
+          # Only alert when latest is strictly newer than what we have reviewed.
+          newer=$(printf '%s\n%s\n' "$reviewed" "$latest" | sort -V | tail -1)
+          if [ "$newer" = "$reviewed" ]; then
+            echo "Latest ASVS release ($latest) is not newer than reviewed ($reviewed)."
             exit 0
           fi
 
@@ -59,5 +71,5 @@ jobs:
             exit 0
           fi
 
-          body="OWASP ASVS \`$latest\` is available; glsec maps to \`$pinned\` (\`ASVSVersion\` in \`rules/asvs.go\`). Review the V14 (Build and Deploy) requirement mapping against the new release, update it if needed, then bump \`ASVSVersion\`. Related: #156."
+          body="OWASP ASVS \`$latest\` is available; the glsec mapping was last reviewed against \`$reviewed\` (\`ASVSReviewedThrough\` in \`rules/asvs.go\`) and is deliberately pinned to \`ASVSVersion\` (4.0.3) because ASVS 5.0.0 removed the CI/CD build-pipeline requirements glsec lints. Review the V14 (Build and Deploy) mapping against \`$latest\`; if still the best fit, just bump \`ASVSReviewedThrough\`, otherwise update the mapping and \`ASVSVersion\` too. See #290."
           gh issue create --title "$title" --label "enhancement" --body "$body"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -129,6 +129,8 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 
 A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) v4.0.3 Chapter V14 requirements, surfaced in JSON output (`asvs` field) and SARIF (an `OWASP ASVS` taxonomy) for compliance evidence.
 
+> **Why v4.0.3 and not 5.0.0?** ASVS 5.0.0 restructured the standard and removed the V14 "Configuration" CI/CD and build-pipeline requirements — build environment isolation, pipeline integrity, security-tooling gates and the like have no equivalent in 5.0.0, which narrowed its scope to the application itself. Since those controls are exactly what glsec lints, v4.0.3 V14 remains the most accurate mapping for a CI/CD security linter. The pin is reviewed against each new ASVS release (see [#290](https://github.com/glsec/glsec/issues/290)).
+
 | ASVS requirement | Rules |
 |---|---|
 | V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016, GL065, GL067 |

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -1,9 +1,22 @@
 package rules
 
 // ASVSVersion is the OWASP ASVS release the V14 (Build and Deploy) mappings
-// below are pinned to. Bump only after reviewing the mapping against the new
-// release.
+// below are pinned to.
+//
+// This pin is deliberate, not stale. ASVS 5.0.0 restructured the standard and
+// removed the V14 "Configuration" CI/CD and build-pipeline requirements that
+// glsec lints — "requirements that did not align with the intended scope of the
+// standard ... have been removed". The build/deploy/isolation/tooling controls
+// have no equivalent in 5.0.0, so 4.0.3 V14 remains the best fit for a CI/CD
+// security linter. See issue #290 for the per-requirement gap analysis.
 const ASVSVersion = "4.0.3"
+
+// ASVSReviewedThrough is the newest ASVS release the mapping above has been
+// reviewed against. The check-framework-versions workflow only flags releases
+// newer than this, so it stays quiet about 5.0.0 (reviewed, deliberately not
+// adopted) while still alerting on any future release that warrants a fresh
+// look. Bump this after each such review.
+const ASVSReviewedThrough = "5.0.0"
 
 // asvsRequirements maps a rule ID to the OWASP ASVS v4.0.3 V14 requirement(s)
 // it provides evidence for.


### PR DESCRIPTION
## What

Reviews the OWASP ASVS V14 (Build and Deploy) mapping against the new **ASVS 5.0.0** release (issue #290) and **deliberately keeps the mapping pinned to v4.0.3**, documenting why.

## Why

ASVS 5.0.0 restructured the standard and **removed the V14 "Configuration" CI/CD and build-pipeline requirements** — exactly the domain glsec lints. Per the standard itself: *"requirements that did not align with the intended scope of the standard ... have been removed."* The old V14 chapter no longer exists; its content was split into **V13 Configuration** (secrets) and **V15 Secure Coding and Architecture** (dependencies), and much was dropped.

Per-requirement gap analysis (4.0.3 V14 → 5.0.0):

| glsec (4.0.3 V14) | ASVS 5.0.0 | Status |
|---|---|---|
| V14.2.1 trusted/maintained sources | 15.1.2 (SBOM) | ✅ match |
| V14.2.2 up to date & pinned | 15.2.1 / 15.1.1 | ⚠️ "pinning" dropped |
| V14.2.3 integrity verified | 15.2.4 (dependency confusion) | ⚠️ weak; explicit integrity check dropped |
| V14.3.1 pipeline config protected | — | ❌ no equivalent |
| V14.3.2 security tooling gates build | — | ❌ no equivalent |
| V14.3.3 secrets not in source/logs | 13.3.1 | ⚠️ source/artifacts only, not logs |
| V14.3.4 build env isolated | — | ❌ no equivalent |
| V14.4.1 minimise 3rd-party CI/CD | — | ❌ no equivalent |

4 of 8 requirements have **no equivalent** in 5.0.0. Adopting 5.0.0 would strip the ASVS mapping from rules like GL008, GL019, GL039, GL007, GL015, GL025 and collapse all secrets rules onto a single requirement. For a CI/CD security linter, **v4.0.3 V14 is the more accurate mapping**, so we keep it.

## Changes

- `rules/asvs.go` — `ASVSVersion` stays `4.0.3`; comment now explains the deliberate pin. New `ASVSReviewedThrough = "5.0.0"` records the newest release reviewed.
- `.github/workflows/check-framework-versions.yml` — compares the latest release against `ASVSReviewedThrough` instead of the mapping version, so it no longer opens a fresh issue every month for 5.0.0, but still alerts on any release newer than 5.0.0.
- `docs/rules.md` — adds a "Why v4.0.3 and not 5.0.0?" note.

## How to test

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green.
- Mapping output (JSON `asvs` field, SARIF `OWASP ASVS` 4.0.3 taxonomy) is unchanged.

Closes #290.
