### PR TITLE
feat: add --no-ignores audit flag to bypass all suppressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ glsec explain GL001
 # baseline existing findings so only new violations are reported
 glsec --generate-ignore .gitlab-ci.yml
 glsec .gitlab-ci.yml  # now exits 0; new violations will be caught
+
+# audit mode: report everything, bypassing all glsec suppressions
+glsec --no-ignores .gitlab-ci.yml  # ignores inline # glsec:ignore and the .glsec-ignore baseline
 ```
 
 ### Exit codes
@@ -183,7 +186,7 @@ rules:
   SC2086: off
 ```
 
-ShellCheck's own inline directives (`# shellcheck disable=SC2086`) are also respected.
+ShellCheck's own inline directives (`# shellcheck disable=SC2086`) are also respected. `--no-ignores` bypasses glsec's suppressions (inline `# glsec:ignore` and the `.glsec-ignore` baseline) but **not** ShellCheck's native `# shellcheck disable=` directives, which are handled inside ShellCheck itself.
 
 ---
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -66,6 +66,7 @@ func main() {
 	strictFlag := flag.Bool("strict", false, "treat warn findings as errors for the exit code (output severity is unchanged)")
 	noExitCodesFlag := flag.Bool("no-exit-codes", false, "always exit 0 on successful execution, regardless of findings")
 	generateIgnoreFlag := flag.Bool("generate-ignore", false, "write all current findings to .glsec-ignore as a baseline and exit 0")
+	noIgnoresFlag := flag.Bool("no-ignores", false, "audit mode: bypass all glsec suppressions (inline # glsec:ignore directives and the .glsec-ignore baseline) for this run; report every finding")
 	noCacheFlag := flag.Bool("no-cache", false, "disable result cache for this run")
 	clearCacheFlag := flag.Bool("clear-cache", false, "remove all cached results and exit")
 	noColorFlag := flag.Bool("no-color", false, "disable colored output")
@@ -172,7 +173,7 @@ func main() {
 
 	colorEnabled := color.IsEnabled(*noColorFlag, os.Stdout)
 	stdoutIsTTY := color.IsTerminal(os.Stdout)
-	useCache := !*noCacheFlag && !*generateIgnoreFlag
+	useCache := !*noCacheFlag && !*generateIgnoreFlag && !*noIgnoresFlag
 
 	scanOpts := scanOptions{
 		cfg:            cfg,
@@ -183,6 +184,7 @@ func main() {
 		skip:           skipArgs,
 		useCache:       useCache,
 		generateIgnore: *generateIgnoreFlag,
+		noIgnores:      *noIgnoresFlag,
 	}
 
 	var allFindings []finding.Finding
@@ -230,6 +232,7 @@ type scanOptions struct {
 	skip           []string
 	useCache       bool
 	generateIgnore bool
+	noIgnores      bool
 }
 
 // scanRoot parses one root pipeline file (and its child pipelines), runs the
@@ -276,8 +279,9 @@ func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCoun
 		}
 	}
 
+	skipSuppress := opt.generateIgnore || opt.noIgnores
 	for _, d := range allDocs {
-		findings = append(findings, collectFindings(d, d.File, opt.cfg, opt.gitlabVersion, opt.generateIgnore)...)
+		findings = append(findings, collectFindings(d, d.File, opt.cfg, opt.gitlabVersion, skipSuppress)...)
 	}
 
 	if opt.useCache && cacheKey != "" {
@@ -527,7 +531,7 @@ func collectDocuments(doc *parser.Document, path string, excludePaths []string, 
 }
 
 // collectFindings runs all applicable rules against doc and returns the findings.
-func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, generateIgnore bool) []finding.Finding {
+func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, skipSuppress bool) []finding.Finding {
 	sm := suppress.Build(doc.Root)
 	sm.Merge(suppress.LoadIgnoreFile(suppress.IgnoreFile, path))
 
@@ -547,7 +551,7 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 			if !cfg.AboveMinSeverity(f) {
 				continue
 			}
-			if !generateIgnore && sm.IsSuppressed(f.Line, f.RuleID) {
+			if !skipSuppress && sm.IsSuppressed(f.Line, f.RuleID) {
 				continue
 			}
 			findings = append(findings, f)
@@ -563,7 +567,7 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 			if !cfg.AboveMinSeverity(f) {
 				continue
 			}
-			if !generateIgnore && sm.IsSuppressed(f.Line, f.RuleID) {
+			if !skipSuppress && sm.IsSuppressed(f.Line, f.RuleID) {
 				continue
 			}
 			findings = append(findings, f)

--- a/cmd/glsec/no_ignores_test.go
+++ b/cmd/glsec/no_ignores_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/glsec/glsec/internal/config"
+	"github.com/glsec/glsec/internal/parser"
+	"github.com/glsec/glsec/internal/suppress"
+	gitlabver "github.com/glsec/glsec/internal/version"
+)
+
+// node:latest triggers GL001; the inline directive suppresses it on that line.
+const inlineIgnoreYAML = "build:\n  image: node:latest  # glsec:ignore GL001 -- updated monthly\n  script: [echo hi]\n"
+
+func hasGL001(t *testing.T, content string, skipSuppress bool) bool {
+	t.Helper()
+	doc, err := parser.Parse([]byte(content), "test.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, f := range collectFindings(doc, "test.yml", config.Default(), gitlabver.Version{}, skipSuppress) {
+		if f.RuleID == "GL001" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCollectFindings_InlineIgnoreSuppresses(t *testing.T) {
+	if hasGL001(t, inlineIgnoreYAML, false) {
+		t.Fatal("expected GL001 suppressed by inline directive, but it was reported")
+	}
+}
+
+func TestCollectFindings_NoIgnoresBypassesInline(t *testing.T) {
+	if !hasGL001(t, inlineIgnoreYAML, true) {
+		t.Fatal("expected GL001 reported with --no-ignores, but it was suppressed")
+	}
+}
+
+// plainYAML has no inline directive; GL001 fires on line 2 (the image).
+const plainYAML = "build:\n  image: node:latest\n  script: [echo hi]\n"
+
+func TestCollectFindings_NoIgnoresBypassesBaseline(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile(suppress.IgnoreFile, []byte("test.yml:2 GL001\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if hasGL001(t, plainYAML, false) {
+		t.Fatal("expected GL001 suppressed by .glsec-ignore baseline, but it was reported")
+	}
+	if !hasGL001(t, plainYAML, true) {
+		t.Fatal("expected GL001 reported with --no-ignores despite baseline, but it was suppressed")
+	}
+}


### PR DESCRIPTION
## What

Adds a `--no-ignores` flag — an audit mode that runs a scan while bypassing **all of glsec's own suppression mechanisms**, so reviewers can see every finding that has been silenced in a repo without editing files or deleting the baseline. Closes #269.

## Behaviour

- Bypasses inline `# glsec:ignore <RULE> -- reason` directives **and** the `.glsec-ignore` baseline for this run.
- Does not modify any files; affects only the current run.
- Composes with existing flags (`--strict`, `--format`, `--only`/`--skip`, `min-severity`).
- Disables the result cache for the run (like `--generate-ignore`), so a previously-cached suppressed result can't mask findings.

### Scope decision (the issue's open question)

`--no-ignores` is scoped to **glsec's own suppression layers only**. ShellCheck's native `# shellcheck disable=...` directives are handled inside ShellCheck itself, not glsec's suppression map, so they are **not** affected — keeping the semantics clear, as the issue leaned toward. (glsec's own `# glsec:ignore SC####` directives *are* bypassed, since those are glsec's layer.)

## Implementation

Suppression is already centralized in `collectFindings`, where `--generate-ignore` already short-circuits the `IsSuppressed` check. `--no-ignores` reuses that path: the per-finding check is now gated on a combined `skipSuppress := generateIgnore || noIgnores`.

- `cmd/glsec/main.go` — new `--no-ignores` flag, threaded through `scanOptions`; cache disabled when set.
- `cmd/glsec/no_ignores_test.go` — tests that inline directives **and** the `.glsec-ignore` baseline suppress GL001 normally but are bypassed with `--no-ignores`.
- `README.md` — usage example + scope note vs. native ShellCheck directives.

## How to test

```
go test ./...            # green
golangci-lint run ./...  # 0 issues

# manual
printf 'build:\n  image: node:latest  # glsec:ignore GL001\n  script: [echo hi]\n' > /tmp/ci.yml
glsec /tmp/ci.yml               # GL001 suppressed
glsec --no-ignores /tmp/ci.yml  # GL001 reported
```
