### PR TITLE
ci: run framework version check weekly on Mondays

### DIFF
--- a/.github/workflows/check-framework-versions.yml
+++ b/.github/workflows/check-framework-versions.yml
@@ -1,6 +1,6 @@
 name: Check framework versions
 
-# Monthly check for newer releases of the security frameworks glsec maps to.
+# Weekly check for newer releases of the security frameworks glsec maps to.
 # When a release newer than the last reviewed one is found, opens an issue so
 # the mapping can be reviewed.
 #
@@ -12,7 +12,7 @@ name: Check framework versions
 
 on:
   schedule:
-    - cron: "0 8 1 * *" # 08:00 UTC on the 1st of each month
+    - cron: "0 8 * * 1" # 08:00 UTC every Monday
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Changes the `check-framework-versions` schedule from monthly (1st of the month) to **weekly, Mondays at 08:00 UTC** (`0 8 * * 1`).

## Why

Catches a new ASVS release sooner. The job is a single GitHub API call and only opens an issue when a release newer than `ASVSReviewedThrough` appears, so weekly cadence adds negligible cost and no extra noise.

## Not included: OWASP Top 10 CI/CD

Considered adding the OWASP Top 10 CI/CD Security Risks taxonomy to the check, but it has **no versioned release feed** (0 GitHub releases, 0 tags — static document since 2022). There is no version to compare against, so it stays a manual review, as the workflow comment already documents.