### PR TITLE
feat: add GL068 to flag shell xtrace (set -x) in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-67 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+68 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066 |
+| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -30,6 +30,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL052](rules/GL052.md) | `warn`  | User-controlled variable in `environment:name:` — attacker can craft a branch name that resolves to a protected environment and access its secrets |
 | [GL059](rules/GL059.md) | `warn`  | `docker build --build-arg` with a secret-keyword name bakes the value into image layer metadata (visible via `docker history`) |
 | [GL062](rules/GL062.md) | `warn`  | `printenv` or bare `env` dumps every variable (including secrets) to the job log |
+| [GL068](rules/GL068.md) | `warn`  | `set -x` / xtrace in a script traces expanded commands — including secrets — to the job log |
 
 ---
 
@@ -138,6 +139,6 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 | V14.2.3 — Dependencies verified for integrity | GL020 |
 | V14.3.1 — Pipeline config protected from modification | GL003, GL019 |
 | V14.3.2 — Security tools run and failures block the build | GL008, GL039 |
-| V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038, GL066 |
+| V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038, GL066, GL068 |
 | V14.3.4 — Build environment isolated | GL007, GL015, GL025 |
 | V14.4.1 — Third-party CI/CD service dependence minimised | GL041 |

--- a/docs/rules/GL068.md
+++ b/docs/rules/GL068.md
@@ -1,0 +1,44 @@
+# GL068 — shell xtrace (`set -x`) enabled in a script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags any command in `script`, `before_script`, or `after_script` (top-level, `default:`, or job-level) that turns on shell command tracing:
+
+- `set -x`
+- `set -euxo pipefail` — any clustered short-flag form containing `x`
+- `set -o xtrace`
+
+With xtrace on, the shell prints every command to the job log **after variable expansion**. Any secret-bearing command then appears in plaintext in the (often public) job log — `git push https://user:$TOKEN@…`, `curl -H "Authorization: Bearer $API_TOKEN"`, `deploy --key "$DEPLOY_KEY"`. This is the script-level twin of `CI_DEBUG_TRACE` (see [GL033](GL033.md)), and it is the activation that turns "uses a secret" rules like [GL021](GL021.md) and [GL035](GL035.md) into an actual leak.
+
+A line whose net effect leaves xtrace **off** — `set -x … ; set +x` scoped to a non-secret block on the same line — is not flagged. A bare `set -x` (or one disabled only on a later, separate line) is.
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - set -euxo pipefail        # flagged — traces expanded commands (incl. secrets) to the log
+    - git push "https://ci:${DEPLOY_TOKEN}@gitlab.example/repo.git" HEAD:main
+```
+
+## Safe alternative
+
+Prefer `set -euo pipefail` (no `x`). If you must trace for debugging, scope it tightly and keep secrets out of the traced region:
+
+```yaml
+script:
+  - set -x
+  - ./build.sh            # no secrets here
+  - set +x
+  - deploy --key "$KEY"   # secret-touching command runs with tracing off
+```
+
+## References
+
+- [Bash manual: `set -x` / `set -o xtrace`](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)
+- GL033: `CI_DEBUG_TRACE` committed — the GitLab-variable equivalent
+- GL021: secret variable value printed to job log via `echo`/`printf`
+- GL035: `git` command uses URL with embedded credentials

--- a/rules/all.go
+++ b/rules/all.go
@@ -71,5 +71,6 @@ func All() []rule.Rule {
 		GL065,
 		GL066,
 		GL067,
+		GL068,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -49,6 +49,7 @@ var asvsRequirements = map[string][]string{
 	"GL065": {"ASVS-V14.2.1"},
 	"GL066": {"ASVS-V14.3.3"},
 	"GL067": {"ASVS-V14.2.1"},
+	"GL068": {"ASVS-V14.3.3"},
 }
 
 // asvsRequirementNames maps an ASVS requirement ID to its short description.

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -69,6 +69,7 @@ var cweIDs = map[string]string{
 	"GL065": "CWE-829",
 	"GL066": "CWE-798",
 	"GL067": "CWE-829",
+	"GL068": "CWE-532",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl068.go
+++ b/rules/gl068.go
@@ -1,0 +1,92 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl068 struct{}
+
+var GL068 = &gl068{}
+
+func (r *gl068) ID() string { return "GL068" }
+
+// setCmdRe captures the argument list of each `set` command on a line, bounded
+// by statement separators so `echo set -x` or `unset` are not matched.
+var setCmdRe = regexp.MustCompile(`(?:^|[;&|(])\s*set\s+([^;&|)]*)`)
+
+func (r *gl068) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		if strings.HasPrefix(strings.TrimSpace(line.Value), "#") {
+			return
+		}
+		if !lineEnablesXtrace(line.Value) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL068",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "set -x enables shell xtrace — every command is printed to the job log after variable expansion, so any command referencing a secret (token in a git URL, Authorization header, --key flag) leaks it in plaintext; drop the x (use set -euo pipefail) or scope tracing with set +x around secret-touching commands",
+			File:     file,
+			Line:     line.Line,
+			Col:      line.Column,
+		})
+	})
+	return findings
+}
+
+// lineEnablesXtrace reports whether the net shell option state at the end of the
+// line has xtrace enabled. Tracking the net effect means a self-contained
+// `set -x …; set +x` block on one line (the documented way to scope tracing to a
+// non-secret section) is not flagged, while a bare `set -x` is.
+func lineEnablesXtrace(line string) bool {
+	enabled := false
+	touched := false
+	for _, m := range setCmdRe.FindAllStringSubmatch(line, -1) {
+		if on, ok := xtraceArg(m[1]); ok {
+			enabled = on
+			touched = true
+		}
+	}
+	return touched && enabled
+}
+
+// xtraceArg parses a `set` argument list and reports whether it changes the
+// xtrace option and to what value. It recognises clustered short flags
+// (-x, -euxo), their disabling form (+x), and the long form (-o xtrace /
+// +o xtrace). ok is false when the arguments do not touch xtrace at all.
+func xtraceArg(args string) (on, ok bool) {
+	tokens := strings.Fields(args)
+	for i := 0; i < len(tokens); i++ {
+		t := tokens[i]
+		if (t == "-o" || t == "+o") && i+1 < len(tokens) && tokens[i+1] == "xtrace" {
+			on, ok = t == "-o", true
+			i++
+			continue
+		}
+		if len(t) >= 2 && (t[0] == '-' || t[0] == '+') && isFlagCluster(t[1:]) && strings.ContainsRune(t, 'x') {
+			on, ok = t[0] == '-', true
+		}
+	}
+	return on, ok
+}
+
+// isFlagCluster reports whether s is a run of ASCII letters, i.e. a bundle of
+// single-character shell options such as "euxo".
+func isFlagCluster(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if !unicode.IsLetter(c) {
+			return false
+		}
+	}
+	return true
+}

--- a/rules/gl068_test.go
+++ b/rules/gl068_test.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings068(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL068.Check(doc.Root, "test.yml")
+}
+
+func TestGL068_Flags(t *testing.T) {
+	flagged := []string{
+		"set -x",
+		"set -euxo pipefail",
+		"set -xe",
+		"set -o xtrace",
+		`[[ "$TRACE" ]] && set -x`,
+	}
+	for _, line := range flagged {
+		f := findings068(t, "job:\n  script:\n    - '"+line+"'\n")
+		if len(f) != 1 {
+			t.Errorf("expected 1 finding for %q, got %d", line, len(f))
+			continue
+		}
+		if f[0].RuleID != "GL068" || f[0].Severity != finding.Warn {
+			t.Errorf("unexpected finding for %q: %+v", line, f[0])
+		}
+	}
+}
+
+func TestGL068_NotFlagged(t *testing.T) {
+	clean := []string{
+		"set -euo pipefail",          // no x
+		"set +x",                     // disabling
+		"set -o errexit",             // long form, not xtrace
+		"set -x; ./build.sh; set +x", // net effect off — scoped on one line
+		"echo set -x",                // not a set command
+		"unset XTRACE",               // not `set`
+		"# set -x",                   // comment
+	}
+	for _, line := range clean {
+		if f := findings068(t, "job:\n  script:\n    - '"+line+"'\n"); len(f) != 0 {
+			t.Errorf("expected no finding for %q, got %d: %+v", line, len(f), f)
+		}
+	}
+}
+
+func TestGL068_BeforeAndAfterScript(t *testing.T) {
+	f := findings068(t, `
+job:
+  before_script:
+    - set -x
+  after_script:
+    - set -o xtrace
+  script:
+    - echo hi
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (before+after script), got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -70,6 +70,7 @@ var owaspCategories = map[string][]string{
 	"GL065": {"CICD-SEC-4"},
 	"GL066": {"CICD-SEC-6"},
 	"GL067": {"CICD-SEC-4"},
+	"GL068": {"CICD-SEC-6"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl068-xtrace.yml
+++ b/testdata/fixtures/gl068-xtrace.yml
@@ -1,0 +1,13 @@
+# set -x / xtrace prints expanded commands — including secrets — to the job log.
+deploy:
+  image: alpine:3.20
+  script:
+    - set -euxo pipefail
+    - 'git push "https://ci:${DEPLOY_TOKEN}@gitlab.example/repo.git" HEAD:main'
+
+release:
+  image: alpine:3.20
+  before_script:
+    - set -o xtrace
+  script:
+    - 'curl -H "Authorization: Bearer $API_TOKEN" https://api.example/release'


### PR DESCRIPTION
## What

Adds **GL068** — flags shell xtrace (`set -x`) enabled in `script` / `before_script` / `after_script`. Closes #315.

With xtrace on, the shell prints every command to the job log **after variable expansion**, so any secret-bearing command (`git push https://user:$TOKEN@…`, `curl -H "Authorization: Bearer $API_TOKEN"`, `deploy --key "$DEPLOY_KEY"`) leaks in plaintext. This is the script-level twin of `CI_DEBUG_TRACE` (GL033) and the activation that turns GL021/GL035-style "uses a secret" findings into actual leaks.

## What it detects

- `set -x`
- `set -euxo pipefail` — any clustered short-flag form containing `x`
- `set -o xtrace`

Both `+`-disabling forms (`set +x`, `+o xtrace`) and non-xtrace options (`set -euo pipefail`, `set -o errexit`) are ignored, as are comments and non-`set` words (`echo set -x`, `unset …`).

### Open question (guarded / scoped forms)

The issue raised two edge cases:

- **Same-line scoping** — `set -x; ./build.sh; set +x`. GL068 tracks the **net option state at the end of the line**, so a self-contained enable+disable on one line is **not** flagged (it's the documented safe-scoping pattern), while a bare `set -x` is.
- **Guarded enable** — `[[ "$TRACE" ]] && set -x`. Intentionally **still flagged**: the exposure is real whenever the trace is enabled, and guard-detection is fragile. Documented in the rule doc.

- Severity: `warn`. OWASP: CICD-SEC-6. CWE-532. ASVS V14.3.3 (consistent with GL021/GL033).

## Implementation

- `rules/gl068.go` — `EachScriptLine` scan; `lineEnablesXtrace` computes net xtrace state; `xtraceArg` parses clustered/long `set` flags.
- Registered in `rules/all.go`; mapped in `rules/owasp.go`, `rules/cwe.go`, `rules/asvs.go`.
- `docs/rules/GL068.md`, `docs/rules.md` (rule table + ASVS V14.3.3 row), `README.md` (Credential Hygiene row, count 67 → 68).
- `testdata/fixtures/gl068-xtrace.yml` (passes the GitLab CI schema check), `rules/gl068_test.go` (trigger forms, non-trigger forms, before/after-script).

## How to test

```
go test ./...            # green (incl. rule-consistency suite)
golangci-lint run ./...  # 0 issues
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl068-*.yml  # ok

glsec --only GL068 testdata/fixtures/gl068-xtrace.yml   # two warnings
glsec explain GL068
```
