### PR TITLE
feat: add GL069 to flag package signature/auth bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-68 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+69 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068 |
-| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064 |
+| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -49,6 +49,7 @@ Mutable references that allow silent substitution of images, templates, or packa
 | [GL046](rules/GL046.md) | `warn`  | `cache: key:` derived from user-controlled variable — attacker can craft a branch name to collide with and poison the cache of a protected pipeline |
 | [GL026](rules/GL026.md) | `warn`  | `git clone`/`checkout` uses a mutable ref (branch or tag) instead of a pinned commit SHA |
 | [GL064](rules/GL064.md) | `warn`  | `include: component:` path is one edit from a popular component under a different namespace (typosquat) |
+| [GL069](rules/GL069.md) | `warn`  | Package signature/auth verification bypassed (`apt --allow-unauthenticated`, `[trusted=yes]`, `apk --allow-untrusted`) |
 
 ---
 

--- a/docs/rules/GL069.md
+++ b/docs/rules/GL069.md
@@ -1,0 +1,44 @@
+# GL069 — package signature/authentication verification bypassed
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags package-manager invocations in `script` / `before_script` / `after_script` that turn off the package manager's **signature/authentication** check:
+
+- `apt-get … --allow-unauthenticated`
+- `-o APT::Get::AllowUnauthenticated=true`
+- a `[trusted=yes]` deb source (e.g. `echo "deb [trusted=yes] http://repo …" >> /etc/apt/sources.list`)
+- `apk … --allow-untrusted`
+
+With verification off, a compromised or MITM'd mirror can serve an unsigned or tampered package that installs without error — a supply-chain foothold inside the pipeline. This is a *different* control from TLS verification (the transport), which [GL042](GL042.md) covers; a repository can be reached over HTTPS and still serve unsigned packages.
+
+`apt-key add` and `add-apt-repository ppa:…` are intentionally **not** flagged — they add a signing key rather than disabling verification, and are far noisier.
+
+## Trigger example
+
+```yaml
+build:
+  script:
+    - apt-get install -y --allow-unauthenticated somepkg              # skips package signature check
+    - echo "deb [trusted=yes] http://repo.example/ ./" >> /etc/apt/sources.list
+```
+
+## Safe alternative
+
+Keep signature verification on. Import the repository's signing key into a dedicated keyring and reference it with `signed-by=` instead of `[trusted=yes]`:
+
+```yaml
+script:
+  - curl -fsSL https://repo.example/key.gpg | gpg --dearmor -o /usr/share/keyrings/example.gpg
+  - echo "deb [signed-by=/usr/share/keyrings/example.gpg] https://repo.example/ ./" >> /etc/apt/sources.list.d/example.list
+  - apt-get update && apt-get install -y somepkg
+```
+
+## References
+
+- [Debian wiki: SecureApt](https://wiki.debian.org/SecureApt)
+- [apk-add: `--allow-untrusted`](https://wiki.alpinelinux.org/wiki/Apk_spec)
+- GL042: TLS certificate verification disabled (`curl -k`, `--no-check-certificate`)
+- GL011: download-and-execute pattern in script

--- a/rules/all.go
+++ b/rules/all.go
@@ -72,5 +72,6 @@ func All() []rule.Rule {
 		GL066,
 		GL067,
 		GL068,
+		GL069,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -70,6 +70,7 @@ var cweIDs = map[string]string{
 	"GL066": "CWE-798",
 	"GL067": "CWE-829",
 	"GL068": "CWE-532",
+	"GL069": "CWE-494",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl069.go
+++ b/rules/gl069.go
@@ -1,0 +1,67 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl069 struct{}
+
+var GL069 = &gl069{}
+
+func (r *gl069) ID() string { return "GL069" }
+
+type pkgAuthCheck struct {
+	re  *regexp.Regexp
+	msg string
+}
+
+// pkgAuthChecks match package-manager invocations that turn off signature /
+// authentication verification (a different control from TLS verification, which
+// GL042 covers). Each is a high-signal, explicit bypass flag.
+var pkgAuthChecks = []pkgAuthCheck{
+	{
+		re:  regexp.MustCompile(`--allow-unauthenticated\b`),
+		msg: `apt "--allow-unauthenticated" disables package signature verification — an unsigned or tampered package from a compromised or MITM'd mirror would install without error; import the repository signing key and reference it with signed-by= instead`,
+	},
+	{
+		re:  regexp.MustCompile(`(?i)allowunauthenticated"?\s*=\s*"?(?:true|1|yes)\b`),
+		msg: `apt option "APT::Get::AllowUnauthenticated=true" disables package signature verification — unsigned packages install without error; keep verification on and trust the repository via its signing key (signed-by=) instead`,
+	},
+	{
+		re:  regexp.MustCompile(`(?i)\[[^][]*\btrusted\s*=\s*(?:yes|true|1)\b[^][]*\]`),
+		msg: `apt source marked "[trusted=yes]" disables package signature verification for that repository — use "signed-by=<keyring>" to verify packages against the repository's GPG key instead`,
+	},
+	{
+		re:  regexp.MustCompile(`--allow-untrusted\b`),
+		msg: `apk "--allow-untrusted" disables package signature verification — an unsigned or tampered package would install without error; add the repository's signing key to /etc/apk/keys instead`,
+	},
+}
+
+func (r *gl069) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		if strings.HasPrefix(strings.TrimSpace(line.Value), "#") {
+			return
+		}
+		for _, c := range pkgAuthChecks {
+			if !c.re.MatchString(line.Value) {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL069",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  c.msg,
+				File:     file,
+				Line:     line.Line,
+				Col:      line.Column,
+			})
+			break
+		}
+	})
+	return findings
+}

--- a/rules/gl069_test.go
+++ b/rules/gl069_test.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings069(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL069.Check(doc.Root, "test.yml")
+}
+
+func TestGL069_Flagged(t *testing.T) {
+	flagged := []string{
+		"apt-get install -y --allow-unauthenticated somepkg",
+		"apt-get -o APT::Get::AllowUnauthenticated=true install -y foo",
+		`echo "deb [trusted=yes] http://repo.example/ ./" >> /etc/apt/sources.list`,
+		`echo "deb [arch=amd64 trusted=yes] http://repo/ ./" >> sources.list`,
+		"apk add --allow-untrusted somepkg",
+	}
+	for _, line := range flagged {
+		f := findings069(t, "job:\n  script:\n    - '"+escapeSingle(line)+"'\n")
+		if len(f) != 1 {
+			t.Errorf("expected 1 finding for %q, got %d", line, len(f))
+			continue
+		}
+		if f[0].RuleID != "GL069" || f[0].Severity != finding.Warn {
+			t.Errorf("unexpected finding for %q: %+v", line, f[0])
+		}
+	}
+}
+
+func TestGL069_NotFlagged(t *testing.T) {
+	clean := []string{
+		"apt-get install -y somepkg",                  // normal install
+		"apk add somepkg",                             // normal apk
+		`echo "deb [signed-by=/k.gpg] https://r/ ./"`, // verified source
+		"apt-key add key.gpg",                         // intentionally out of scope
+		"add-apt-repository ppa:openmw/openmw",        // intentionally out of scope
+		"# apt-get install --allow-unauthenticated x", // comment
+	}
+	for _, line := range clean {
+		if f := findings069(t, "job:\n  script:\n    - '"+escapeSingle(line)+"'\n"); len(f) != 0 {
+			t.Errorf("expected no finding for %q, got %d: %+v", line, len(f), f)
+		}
+	}
+}
+
+func escapeSingle(s string) string {
+	out := ""
+	for _, r := range s {
+		if r == '\'' {
+			out += "''"
+			continue
+		}
+		out += string(r)
+	}
+	return out
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -71,6 +71,7 @@ var owaspCategories = map[string][]string{
 	"GL066": {"CICD-SEC-6"},
 	"GL067": {"CICD-SEC-4"},
 	"GL068": {"CICD-SEC-6"},
+	"GL069": {"CICD-SEC-3"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl069-pkg-auth-bypass.yml
+++ b/testdata/fixtures/gl069-pkg-auth-bypass.yml
@@ -1,0 +1,13 @@
+# Package signature/auth verification disabled — unsigned packages install silently.
+build:
+  image: debian:12
+  script:
+    - apt-get update
+    - apt-get install -y --allow-unauthenticated somepkg
+    - 'echo "deb [trusted=yes] http://repo.example/ ./" >> /etc/apt/sources.list'
+    - apt-get -o APT::Get::AllowUnauthenticated=true install -y otherpkg
+
+alpine-build:
+  image: alpine:3.20
+  script:
+    - apk add --allow-untrusted somepkg


### PR DESCRIPTION
## What

Adds **GL069** — flags package-manager invocations that disable **signature/authentication** verification in `script` / `before_script` / `after_script`. Closes #316.

This is a different control from TLS verification (GL042): a repo can be reached over HTTPS and still serve unsigned packages. With signature checking off, a compromised or MITM'd mirror can serve a tampered package that installs without error — a supply-chain foothold in the pipeline. Previously such a line produced only GL022 (version pin), no security finding.

## What it detects

- `apt-get … --allow-unauthenticated`
- `-o APT::Get::AllowUnauthenticated=true`
- `[trusted=yes]` deb sources (e.g. `echo "deb [trusted=yes] http://repo …" >> sources.list`, also tolerates `[arch=amd64 trusted=yes]`)
- `apk … --allow-untrusted` (Alpine — the dominant CI base image)

### Scope decision

Per the issue, scoped to **high-signal explicit bypass flags**. `apt-key add` and `add-apt-repository ppa:…` are intentionally **not** flagged — they add a signing key rather than disabling verification, and are far noisier (the issue marked them "weaker, optional"). The doc states this explicitly.

apk `--allow-untrusted` is the apk equivalent of `--allow-unauthenticated`; included because it's the same risk class (CWE-494) and Alpine is the most common CI image. Everything else from the issue is apt.

- Severity: `warn`. OWASP: CICD-SEC-3. CWE-494.

## Implementation

- `rules/gl069.go` — `EachScriptLine` scan over a small table of bypass regexes, one finding per matching line.
- Registered in `rules/all.go`; mapped in `rules/owasp.go`, `rules/cwe.go`.
- `docs/rules/GL069.md`, `docs/rules.md` (CICD-SEC-3 table), `README.md` (Dependency & Image Pinning row, count 68 → 69).
- `testdata/fixtures/gl069-pkg-auth-bypass.yml` (passes the GitLab CI schema check), `rules/gl069_test.go` (all four trigger forms; non-triggers incl. normal installs, `signed-by=`, the out-of-scope apt-key/PPA, comments).

## How to test

```
go test ./...            # green (incl. rule-consistency suite)
golangci-lint run ./...  # 0 issues
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl069-*.yml  # ok

glsec --only GL069 testdata/fixtures/gl069-pkg-auth-bypass.yml  # four warnings
```
