### PR TITLE
feat: add GL070 to flag static cloud service-account credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-69 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+70 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068 |
+| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -31,6 +31,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL059](rules/GL059.md) | `warn`  | `docker build --build-arg` with a secret-keyword name bakes the value into image layer metadata (visible via `docker history`) |
 | [GL062](rules/GL062.md) | `warn`  | `printenv` or bare `env` dumps every variable (including secrets) to the job log |
 | [GL068](rules/GL068.md) | `warn`  | `set -x` / xtrace in a script traces expanded commands — including secrets — to the job log |
+| [GL070](rules/GL070.md) | `warn`  | Static cloud service-account credential in script (`gcloud --key-file`, `aws_secret_access_key`, `az --password`) — prefer keyless OIDC |
 
 ---
 

--- a/docs/rules/GL070.md
+++ b/docs/rules/GL070.md
@@ -1,0 +1,44 @@
+# GL070 — static cloud service-account credential used in CI
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags `script` / `before_script` / `after_script` commands that authenticate to a cloud provider with a **long-lived static service-account credential**:
+
+- **GCP** — `gcloud auth activate-service-account` or any `gcloud … --key-file`
+- **AWS** — `aws configure set aws_secret_access_key …`, or `AWS_SECRET_ACCESS_KEY=…` set in a script line
+- **Azure** — `az login --service-principal … --password …`
+
+A static SA key is broad, long-lived, and exfiltratable: a compromised job, a key written to an artifact, or a debug trace exposes it for as long as the key is valid. GitLab, Google, and AWS all recommend **keyless OIDC** instead — short-lived, audience-scoped tokens via `id_tokens:` + Workload Identity Federation / `AssumeRoleWithWebIdentity`.
+
+This targets the *authentication pattern*, not a leaked value (unlike [GL006](GL006.md)); the key usually comes from a CI variable, so the concern is the use of a static credential at all. The keyless forms — `gcloud … --cred-file`, `az login --service-principal --federated-token` — are not flagged. Pairs with [GL009](GL009.md), which keeps the `id_tokens:` audience narrow.
+
+## Trigger example
+
+```yaml
+deploy:
+  script:
+    - gcloud auth activate-service-account --key-file "$GCP_KEY"   # static SA key
+```
+
+## Safe alternative
+
+Use OIDC / Workload Identity Federation with a scoped `id_tokens:` audience:
+
+```yaml
+deploy:
+  id_tokens:
+    GCP_TOKEN:
+      aud: "https://iam.googleapis.com/projects/…/providers/…"
+  script:
+    - gcloud auth login --cred-file=<(echo "$GCP_TOKEN" | build-wif-config)   # short-lived, keyless
+```
+
+## References
+
+- [GitLab: Connect to cloud services with OpenID Connect](https://docs.gitlab.com/ee/ci/cloud_services/)
+- [Google: Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [AWS: AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
+- GL009: overbroad `id_tokens:` audience

--- a/rules/all.go
+++ b/rules/all.go
@@ -73,5 +73,6 @@ func All() []rule.Rule {
 		GL067,
 		GL068,
 		GL069,
+		GL070,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -71,6 +71,7 @@ var cweIDs = map[string]string{
 	"GL067": "CWE-829",
 	"GL068": "CWE-532",
 	"GL069": "CWE-494",
+	"GL070": "CWE-798",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl070.go
+++ b/rules/gl070.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl070 struct{}
+
+var GL070 = &gl070{}
+
+func (r *gl070) ID() string { return "GL070" }
+
+type staticCredCheck struct {
+	match func(string) bool
+	msg   string
+}
+
+var (
+	// gcloud activate-service-account, or any gcloud --key-file. The keyless
+	// WIF form uses --cred-file (not --key-file), so it is not matched.
+	gcpKeyRe = regexp.MustCompile(`\bgcloud\b.*(?:\bactivate-service-account\b|--key-file\b)`)
+	// aws configure set aws_secret_access_key …
+	awsConfigRe = regexp.MustCompile(`\baws\s+configure\s+set\s+aws_secret_access_key\b`)
+	// AWS_SECRET_ACCESS_KEY=… assigned/exported in a script line.
+	awsEnvRe = regexp.MustCompile(`\bAWS_SECRET_ACCESS_KEY\s*=`)
+)
+
+var staticCredChecks = []staticCredCheck{
+	{
+		match: gcpKeyRe.MatchString,
+		msg:   `gcloud authenticates with a static service-account key — a long-lived, broad, exfiltratable credential; use keyless Workload Identity Federation with an id_tokens: audience and gcloud auth login --cred-file instead`,
+	},
+	{
+		match: awsConfigRe.MatchString,
+		msg:   `aws configure set aws_secret_access_key uses a long-lived static access key — prefer keyless OIDC: an id_tokens: token with sts:AssumeRoleWithWebIdentity instead`,
+	},
+	{
+		match: awsEnvRe.MatchString,
+		msg:   `AWS_SECRET_ACCESS_KEY set in script uses a long-lived static access key — prefer keyless OIDC: an id_tokens: token with sts:AssumeRoleWithWebIdentity instead`,
+	},
+	{
+		match: isAzureStaticLogin,
+		msg:   `az login --service-principal with a static --password is a long-lived credential — use keyless OIDC: az login --service-principal --federated-token "$ID_TOKEN" with an id_tokens: audience instead`,
+	},
+}
+
+// isAzureStaticLogin reports an az service-principal login that authenticates
+// with a static password rather than a (keyless) federated OIDC token.
+func isAzureStaticLogin(line string) bool {
+	return strings.Contains(line, "az login") &&
+		strings.Contains(line, "--service-principal") &&
+		strings.Contains(line, "--password") &&
+		!strings.Contains(line, "--federated-token")
+}
+
+func (r *gl070) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		if strings.HasPrefix(strings.TrimSpace(line.Value), "#") {
+			return
+		}
+		for _, c := range staticCredChecks {
+			if !c.match(line.Value) {
+				continue
+			}
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL070",
+				Severity: finding.Warn,
+				Job:      job,
+				Message:  c.msg,
+				File:     file,
+				Line:     line.Line,
+				Col:      line.Column,
+			})
+			break
+		}
+	})
+	return findings
+}

--- a/rules/gl070_test.go
+++ b/rules/gl070_test.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings070(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL070.Check(doc.Root, "test.yml")
+}
+
+func TestGL070_Flagged(t *testing.T) {
+	flagged := []string{
+		`gcloud auth activate-service-account --key-file "$GCP_KEY"`,
+		`gcloud auth activate-service-account --key-file=/tmp/key.json`,
+		`aws configure set aws_secret_access_key "$AWS_SECRET"`,
+		`export AWS_SECRET_ACCESS_KEY="$AWS_SECRET"`,
+		`az login --service-principal -u app --password "$SECRET" --tenant t`,
+	}
+	for _, line := range flagged {
+		f := findings070(t, "job:\n  script:\n    - '"+escapeSingle(line)+"'\n")
+		if len(f) != 1 {
+			t.Errorf("expected 1 finding for %q, got %d", line, len(f))
+			continue
+		}
+		if f[0].RuleID != "GL070" || f[0].Severity != finding.Warn {
+			t.Errorf("unexpected finding for %q: %+v", line, f[0])
+		}
+	}
+}
+
+func TestGL070_NotFlagged_Keyless(t *testing.T) {
+	clean := []string{
+		`gcloud auth login --cred-file=/tmp/wif.json`,                  // keyless WIF
+		`az login --service-principal -u app --federated-token "$TOK"`, // keyless OIDC
+		`aws sts assume-role-with-web-identity --role-arn arn`,         // keyless
+		`gcloud config set project my-project`,                         // unrelated
+		`# gcloud auth activate-service-account --key-file x`,          // comment
+	}
+	for _, line := range clean {
+		if f := findings070(t, "job:\n  script:\n    - '"+escapeSingle(line)+"'\n"); len(f) != 0 {
+			t.Errorf("expected no finding for %q, got %d: %+v", line, len(f), f)
+		}
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -72,6 +72,7 @@ var owaspCategories = map[string][]string{
 	"GL067": {"CICD-SEC-4"},
 	"GL068": {"CICD-SEC-6"},
 	"GL069": {"CICD-SEC-3"},
+	"GL070": {"CICD-SEC-6"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl070-static-cloud-creds.yml
+++ b/testdata/fixtures/gl070-static-cloud-creds.yml
@@ -1,0 +1,16 @@
+# Static cloud service-account credentials — prefer keyless OIDC.
+gcp-deploy:
+  image: google/cloud-sdk:slim
+  script:
+    - gcloud auth activate-service-account --key-file "$GCP_KEY"
+
+aws-deploy:
+  image: amazon/aws-cli:latest
+  script:
+    - aws configure set aws_secret_access_key "$AWS_SECRET"
+    - export AWS_SECRET_ACCESS_KEY="$AWS_SECRET"
+
+azure-deploy:
+  image: mcr.microsoft.com/azure-cli:latest
+  script:
+    - az login --service-principal -u "$APP_ID" --password "$SP_SECRET" --tenant "$TENANT"


### PR DESCRIPTION
## What

Adds **GL070** — flags `script` / `before_script` / `after_script` commands that authenticate to a cloud provider with a **long-lived static service-account credential**, nudging toward keyless OIDC. Closes #317.

A static SA key is broad, long-lived, and exfiltratable (a compromised job, a key in an artifact, or a debug trace exposes it for the key's whole lifetime). GitLab/Google/AWS all recommend keyless OIDC — short-lived, audience-scoped tokens via `id_tokens:` + Workload Identity Federation / `AssumeRoleWithWebIdentity`.

## What it detects

- **GCP** — `gcloud auth activate-service-account`, or any `gcloud … --key-file`
- **AWS** — `aws configure set aws_secret_access_key …`, or `AWS_SECRET_ACCESS_KEY=…` in a script line
- **Azure** — `az login --service-principal … --password …`

**Keyless forms are not flagged:** `gcloud … --cred-file` (WIF), `az login --service-principal --federated-token` (OIDC). The GCP check keys on `--key-file` specifically, and the Azure check requires `--password` and the absence of `--federated-token`.

### Design notes

- This targets the *authentication pattern*, not a leaked value — distinct from GL006 (hardcoded secret) / GL004 (CI_JOB_TOKEN). The credential usually comes from a CI variable, so the concern is using a static credential at all.
- Severity `warn` (best-practice nudge); each message points at the concrete OIDC replacement. Disable per-repo with `rules: { GL070: off }` or `--skip GL070` if not applicable.
- Pairs with GL009 (keeps the `id_tokens:` audience narrow) — together they push pipelines toward correctly-scoped keyless auth.
- OWASP: CICD-SEC-6. CWE-798.

## Implementation

- `rules/gl070.go` — `EachScriptLine` scan over a small check table (three regexes + one predicate for the Azure negative condition), one finding per matching line.
- Registered in `rules/all.go`; mapped in `rules/owasp.go`, `rules/cwe.go`.
- `docs/rules/GL070.md`, `docs/rules.md` (Credential Hygiene table), `README.md` (Credential Hygiene row, count 69 → 70).
- `testdata/fixtures/gl070-static-cloud-creds.yml` (passes the GitLab CI schema check), `rules/gl070_test.go` (all four trigger forms; keyless/unrelated/comment non-triggers).

## How to test

```
go test ./...            # green (incl. rule-consistency suite)
golangci-lint run ./...  # 0 issues
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl070-*.yml  # ok

glsec --only GL070 testdata/fixtures/gl070-static-cloud-creds.yml  # four warnings
```
