### PR TITLE
fix: scope GL069 allow-unauthenticated to apt (gcloud run FP)

### DIFF
--- a/rules/gl069.go
+++ b/rules/gl069.go
@@ -24,7 +24,10 @@ type pkgAuthCheck struct {
 // GL042 covers). Each is a high-signal, explicit bypass flag.
 var pkgAuthChecks = []pkgAuthCheck{
 	{
-		re:  regexp.MustCompile(`--allow-unauthenticated\b`),
+		// Scoped to an apt command on the same line: "--allow-unauthenticated"
+		// is also a GCP Cloud Run flag (gcloud run deploy --allow-unauthenticated)
+		// meaning public service access, which is unrelated to package signatures.
+		re:  regexp.MustCompile(`\b(?:apt-get|apt|aptitude)\b[^\n]*--allow-unauthenticated\b`),
 		msg: `apt "--allow-unauthenticated" disables package signature verification — an unsigned or tampered package from a compromised or MITM'd mirror would install without error; import the repository signing key and reference it with signed-by= instead`,
 	},
 	{
@@ -36,7 +39,7 @@ var pkgAuthChecks = []pkgAuthCheck{
 		msg: `apt source marked "[trusted=yes]" disables package signature verification for that repository — use "signed-by=<keyring>" to verify packages against the repository's GPG key instead`,
 	},
 	{
-		re:  regexp.MustCompile(`--allow-untrusted\b`),
+		re:  regexp.MustCompile(`\bapk\b[^\n]*--allow-untrusted\b`),
 		msg: `apk "--allow-untrusted" disables package signature verification — an unsigned or tampered package would install without error; add the repository's signing key to /etc/apk/keys instead`,
 	},
 }

--- a/rules/gl069_test.go
+++ b/rules/gl069_test.go
@@ -44,6 +44,8 @@ func TestGL069_NotFlagged(t *testing.T) {
 		"apt-key add key.gpg",                         // intentionally out of scope
 		"add-apt-repository ppa:openmw/openmw",        // intentionally out of scope
 		"# apt-get install --allow-unauthenticated x", // comment
+		"gcloud run deploy svc --allow-unauthenticated --region us",   // GCP Cloud Run public access, not apt
+		"apk add curl",                                                // normal apk
 	}
 	for _, line := range clean {
 		if f := findings069(t, "job:\n  script:\n    - '"+escapeSingle(line)+"'\n"); len(f) != 0 {


### PR DESCRIPTION
## What

Fixes a false positive in **GL069** found while scanning 200 real public GitLab pipelines before release.

## The false positive

GL069 matched `--allow-unauthenticated` anywhere on a line. But that flag is also a **GCP Cloud Run** flag — `gcloud run deploy … --allow-unauthenticated` means "allow public (unauthenticated) HTTP access to the service", which has nothing to do with apt package-signature verification. One of the 200 pipelines (`labcoat-server`) tripped it:

```yaml
gcloud run deploy labcoat-server \
  --image "$IMAGE" \
  --allow-unauthenticated          # ← flagged as a package-signature bypass (wrong)
```

## Fix

Scope the apt check to an apt command on the **same line**: `\b(?:apt-get|apt|aptitude)\b[^\n]*--allow-unauthenticated`. The apk `--allow-untrusted` check is scoped to `apk` the same way for symmetry/precision. (`[^\n]` matters because a `|` block scalar is one node — the package manager and flag must be on the same physical command line.)

## Validation

Re-scanned the same 200 pipelines after the fix:

| Rule | Before | After | Notes |
|---|---|---|---|
| GL069 | 1 | **0** | the single hit was the Cloud Run FP — now gone |
| GL068 | 4 | 4 | all true positives (real `set -x` / `set -xe`) |
| GL070 | 2 | 2 | all true positives (`gcloud auth activate-service-account --key-file`) |

The fixture still fires all four GL069 forms (apt and flag on one line). Added a regression test for `gcloud run deploy … --allow-unauthenticated` and normal `apk add`.

`go test ./...` green; `golangci-lint run ./...` 0 issues.
