### PR TITLE
GL022: extend version-pinning to yum, dnf, zypper, go install

### DIFF
--- a/docs/rules/GL022.md
+++ b/docs/rules/GL022.md
@@ -24,6 +24,10 @@ glsec flags two categories of problematic package manager usage in CI scripts:
 | gem | `gem install bundler` | `gem install bundler -v 2.5.6` |
 | cargo | `cargo install cargo-audit` | `cargo install cargo-audit --version 0.20.0` |
 | composer | `composer require guzzlehttp/guzzle` | `composer require guzzlehttp/guzzle:^7.8` |
+| yum | `yum install httpd` | `yum install httpd-2.4.6` |
+| dnf | `dnf install nginx` | `dnf install nginx-1.20.1` |
+| zypper | `zypper install curl` (also `zypper in`) | `zypper install curl=7.66.0` |
+| go install | `go install example.com/cmd@latest` | `go install example.com/cmd@v1.2.3` |
 
 ### Explicit update commands (always flagged)
 
@@ -63,4 +67,6 @@ build:
 - `npm install` without `-g` / `--global` is not flagged — it installs from `package.json` (see GL023 for lockfile concerns).
 - `npm install -g @scope/pkg` (scoped package without version) is flagged; `@scope/pkg@version` is safe.
 - `composer install` (reads `composer.lock`) is not flagged — only `composer require` (adds a new package) and `composer update` (updates to latest) are.
+- `go install` of a remote module without `@version` (or with `@latest`) is flagged; `@v1.2.3` is safe. Local builds (`go install`, `go install ./cmd/...`) are not flagged.
+- Installs whose package argument is a CI variable (e.g. `apt-get install -y $PKG`, `yum install $PKG`) are not flagged — the version can't be checked statically.
 - For project-level dependency lockfile concerns (e.g. `npm install` vs `npm ci`), see GL023.

--- a/rules/gl022.go
+++ b/rules/gl022.go
@@ -73,7 +73,37 @@ var (
 			pinned:  regexp.MustCompile(`:\S`),
 			skip:    nil,
 		},
+		{
+			manager: "yum",
+			trigger: regexp.MustCompile(`\byum\s+install\b`),
+			pinned:  regexp.MustCompile(`\b\S+-\d`),
+			skip:    nil,
+		},
+		{
+			manager: "dnf",
+			trigger: regexp.MustCompile(`\bdnf\s+install\b`),
+			pinned:  regexp.MustCompile(`\b\S+-\d`),
+			skip:    nil,
+		},
+		{
+			manager: "zypper",
+			trigger: regexp.MustCompile(`\bzypper\s+(?:install|in)\b`),
+			pinned:  regexp.MustCompile(`\b\S+=\d`),
+			skip:    nil,
+		},
+		{
+			manager: "go",
+			trigger: regexp.MustCompile(`\bgo\s+install\b`),
+			pinned:  regexp.MustCompile(`@v?\d`),
+			// Local builds (no module, or a relative/absolute path target) need no version.
+			skip: regexp.MustCompile(`\bgo\s+install\s*$|\bgo\s+install\s+(?:-\S+\s+)*[./]`),
+		},
 	}
+
+	// pmVarPkg matches an install whose first non-flag argument is a CI variable
+	// (e.g. `apt-get install -y $PKG`). The version can't be checked statically, so
+	// the line is skipped to avoid false positives.
+	pmVarPkg = regexp.MustCompile(`\b(?:install|add|require|in)\s+(?:-\S+\s+)*["']?\$\{?[A-Za-z_]`)
 
 	pmUpdateChecks = []pmUpdateCheck{
 		{"npm", regexp.MustCompile(`\bnpm\s+update\b`)},
@@ -125,6 +155,9 @@ func checkPMLine(line, file string, lineNum, col int) *finding.Finding {
 			continue
 		}
 		if ic.skip != nil && ic.skip.MatchString(line) {
+			continue
+		}
+		if pmVarPkg.MatchString(line) {
 			continue
 		}
 		if ic.pinned != nil && ic.pinned.MatchString(line) {

--- a/rules/gl022_test.go
+++ b/rules/gl022_test.go
@@ -241,6 +241,186 @@ build:
 	}
 }
 
+// --- yum ---
+
+func TestGL022_YumUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - yum install -y httpd
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned yum install, got %d", len(f))
+	}
+}
+
+func TestGL022_YumPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - yum install -y httpd-2.4.6
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned yum install, got %d", len(f))
+	}
+}
+
+// --- dnf ---
+
+func TestGL022_DnfUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - dnf install -y nginx
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned dnf install, got %d", len(f))
+	}
+}
+
+func TestGL022_DnfPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - dnf install -y nginx-1.20.1
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned dnf install, got %d", len(f))
+	}
+}
+
+// --- zypper ---
+
+func TestGL022_ZypperUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - zypper install -y curl
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned zypper install, got %d", len(f))
+	}
+}
+
+func TestGL022_ZypperInUnpinned(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - zypper in -y curl
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for unpinned zypper in, got %d", len(f))
+	}
+}
+
+func TestGL022_ZypperPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - zypper install -y curl=7.66.0
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned zypper install, got %d", len(f))
+	}
+}
+
+func TestGL022_ZypperInfo_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - zypper info curl
+`)
+	if len(f) != 0 {
+		t.Errorf("zypper info is not an install — expected no finding, got %d", len(f))
+	}
+}
+
+// --- go install ---
+
+func TestGL022_GoInstallLatest(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - go install golang.org/x/tools/cmd/goimports@latest
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for go install @latest, got %d", len(f))
+	}
+}
+
+func TestGL022_GoInstallNoVersion(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - go install github.com/golangci/golangci-lint/cmd/golangci-lint
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for go install without @version, got %d", len(f))
+	}
+}
+
+func TestGL022_GoInstallPinned_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - go install golang.org/x/tools/cmd/goimports@v0.21.0
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned go install, got %d", len(f))
+	}
+}
+
+func TestGL022_GoInstallLocalPath_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - go install ./cmd/foo
+`)
+	if len(f) != 0 {
+		t.Errorf("local go install needs no version — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL022_GoInstallNoArgs_NoFinding(t *testing.T) {
+	f := findings022(t, `
+build:
+  script:
+    - go install
+`)
+	if len(f) != 0 {
+		t.Errorf("go install with no module builds the local package — expected no finding, got %d", len(f))
+	}
+}
+
+// --- variable package tokens (no FP) ---
+
+func TestGL022_VariablePackageToken_NoFinding(t *testing.T) {
+	for _, line := range []string{
+		"yum install -y $PKG",
+		"dnf install ${PKG}",
+		"zypper install $PKG",
+		"go install $TOOL",
+		"apt-get install -y $PKG",
+		"pip install ${PACKAGE}",
+	} {
+		if got := checkPMLine(line, "test.yml", 1, 1); got != nil {
+			t.Errorf("expected no finding for variable package token %q, got %+v", line, got)
+		}
+	}
+}
+
+func TestGL022_VariableNotPackageToken_StillFlagged(t *testing.T) {
+	// The package (cargo-audit) is a literal; the variable is only a flag value.
+	f := findings022(t, `
+build:
+  script:
+    - cargo install cargo-audit --root $HOME/.local
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding when only a flag value is a variable, got %d", len(f))
+	}
+}
+
 // --- update commands ---
 
 func TestGL022_ComposerUpdate(t *testing.T) {

--- a/testdata/fixtures/gl022-unpinned-packages.yml
+++ b/testdata/fixtures/gl022-unpinned-packages.yml
@@ -9,3 +9,7 @@ build:
     - npm install -g @angular/cli
     - apt-get install -y jq
     - composer require guzzlehttp/guzzle --no-interaction
+    - yum install -y httpd
+    - dnf install -y nginx
+    - zypper install -y curl
+    - go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
Closes #327

## What changed

Extends **GL022** (package-manager install without version pin) to cover four ecosystems it previously missed:

| Manager | Unpinned (flagged) | Pinned (safe) |
|---|---|---|
| yum | `yum install httpd` | `yum install httpd-2.4.6` |
| dnf | `dnf install nginx` | `dnf install nginx-1.20.1` |
| zypper | `zypper install curl` (also `zypper in`) | `zypper install curl=7.66.0` |
| go install | `go install mod@latest` / `go install mod` | `go install mod@v1.2.3` |

This is an extension of the existing rule, not a new GL code.

### Detection details
- **yum / dnf** — pinned form is `name-<version>` (`\S+-\d`), mirroring the existing apt/apk handling.
- **zypper** — matches both `zypper install` and the `zypper in` alias; pinned form is `name=<version>`. `zypper info` is not matched.
- **go install** — `@latest` and a missing `@version` are flagged; `@v1.2.3` is safe. Local builds (`go install`, `go install ./cmd/...`) are not flagged since they need no module version.

### Variable package tokens (FP guard)
Added a shared guard so installs whose **first non-flag argument is a CI variable** (e.g. `apt-get install -y $PKG`, `yum install $PKG`) are skipped — the version can't be checked statically. A variable that is only a *flag value* (e.g. `cargo install cargo-audit --root $HOME/.local`) still flags the literal package. This applies uniformly across all managers.

## How to test
- `go test ./...` — table-driven tests added for pinned + unpinned of each new manager, plus the go-install local/no-args/`@latest` cases and the variable-token guard.
- `golangci-lint run ./...` — clean.
- `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl022-unpinned-packages.yml` — fixture extended with the four managers, schema-valid.

## False-positive scan
Scanned against ~200 real top-starred public GitLab `.gitlab-ci.yml` pipelines. The new managers produced **12 findings, all true positives** (e.g. `dnf install -y gcc make ...`, `go install .../govulncheck@latest`, `yum install -y wget unzip`) — no false positives. Existing manager counts (apt-get, pip, apk, …) unchanged.