### PR TITLE
feat: add GL071 to flag manual approval gate without allow_failure: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-70 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+71 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -161,7 +161,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
-| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055 |
+| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -99,6 +99,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL009](rules/GL009.md) | `warn`  | Overly broad OIDC `id_tokens` audience (GitLab ≥ 15.7) |
 | [GL017](rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
 | [GL043](rules/GL043.md) | `warn`  | Unanchored regex on user-controlled variable in `rules:if` — prefix match can be bypassed by crafting a matching value |
+| [GL071](rules/GL071.md) | `warn`  | Manual approval gate before a production deploy without `allow_failure: false` — optional by default, so the pipeline can deploy without it being triggered |
 | [GL055](rules/GL055.md) | `warn`  | `DOCKER_HOST` points at the host Docker socket (`/var/run/docker.sock`) — full control of the runner's Docker daemon |
 
 ---

--- a/docs/rules/GL071.md
+++ b/docs/rules/GL071.md
@@ -1,0 +1,73 @@
+# GL071 — Manual approval gate without `allow_failure: false`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
+
+## What glsec checks
+
+glsec flags a job that looks like a manual **approval gate** in front of a production deploy but does **not** actually block the pipeline.
+
+GitLab distinguishes two kinds of manual jobs ([job control docs](https://docs.gitlab.com/ci/jobs/job_control/#types-of-manual-jobs)):
+
+- **Optional** — `when: manual` defined at the **top level** of a job. `allow_failure` defaults to `true`, so the job's status does not contribute to the pipeline status. **Later stages run and the pipeline can succeed even if nobody triggers the job.**
+- **Blocking** — `allow_failure: false` (the default when `when: manual` is set **inside `rules:`**). The pipeline stops at that stage until an authorized user triggers the job.
+
+A top-level `when: manual` job placed before a production deploy is therefore a **no-op gate**: the deploy runs regardless of whether the "approval" was ever clicked.
+
+A job is flagged when **all** of the following hold:
+
+- it has a top-level `when: manual` (not inside `rules:`),
+- it does not set `allow_failure: false`,
+- it has no `environment:` of its own (it is a separate approval job, not the deploy), and
+- a production-like deploy job (an `environment:` whose name looks like `prod`/`production`/`live`/`staging`) exists in a **later stage**.
+
+## Trigger example
+
+```yaml
+stages: [build, approve, deploy]
+
+approve_prod:
+  stage: approve
+  when: manual          # optional → allow_failure: true by default
+  script: [echo approved]
+
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]  # runs even if approve_prod was never triggered
+```
+
+## Safe alternative
+
+Make the gate blocking with `allow_failure: false`:
+
+```yaml
+approve_prod:
+  stage: approve
+  when: manual
+  allow_failure: false  # pipeline stops here until triggered
+  script: [echo approved]
+```
+
+Or move the manual condition into `rules:`, where it is blocking by default:
+
+```yaml
+approve_prod:
+  stage: approve
+  rules:
+    - when: manual
+  script: [echo approved]
+```
+
+## What is not flagged
+
+- `when: manual` inside `rules:` — blocking by default.
+- A manual job with an explicit `allow_failure: false`.
+- A manual job with no later production-deploy job (e.g. an optional cleanup/teardown job — the main false-positive class).
+- The deploy job itself being manual — a manual deploy is a legitimate pattern; the gate problem is a *separate* approval job.
+
+## References
+
+- [GitLab: Types of manual jobs](https://docs.gitlab.com/ci/jobs/job_control/#types-of-manual-jobs)
+- GL012: `when: always` on a deploy job bypasses upstream quality gates
+- GL013: production deploy job has no branch restriction

--- a/rules/all.go
+++ b/rules/all.go
@@ -74,5 +74,6 @@ func All() []rule.Rule {
 		GL068,
 		GL069,
 		GL070,
+		GL071,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -72,6 +72,7 @@ var cweIDs = map[string]string{
 	"GL068": "CWE-532",
 	"GL069": "CWE-494",
 	"GL070": "CWE-798",
+	"GL071": "CWE-691",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl071.go
+++ b/rules/gl071.go
@@ -1,0 +1,130 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl071 struct{}
+
+var GL071 = &gl071{}
+
+func (r *gl071) ID() string { return "GL071" }
+
+// defaultStages is GitLab's implicit stage order when no top-level stages: is
+// declared. A job without an explicit stage: lands in "test".
+var defaultStages = []string{".pre", "build", "test", "deploy", ".post"}
+
+const defaultStage = "test"
+
+func (r *gl071) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+	stageIdx := buildStageIndex(mapping)
+
+	// Highest stage index that contains a production-like deploy job.
+	maxDeployIdx := -1
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if isHiddenJob(name.Value) || !isProdDeployJob(job) {
+			return
+		}
+		if idx, ok := jobStageIndex(job, stageIdx); ok && idx > maxDeployIdx {
+			maxDeployIdx = idx
+		}
+	})
+	if maxDeployIdx < 0 {
+		return nil
+	}
+
+	var findings []finding.Finding
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if isHiddenJob(name.Value) {
+			return
+		}
+		when := parser.FindKey(job, "when")
+		if when == nil || when.Kind != yaml.ScalarNode || when.Value != "manual" {
+			return
+		}
+		// rules: govern allow_failure (manual inside rules defaults to blocking),
+		// so a top-level when: is moot — don't second-guess it.
+		if parser.FindKey(job, "rules") != nil {
+			return
+		}
+		// Explicitly blocking — this is the recommended fix, not a finding.
+		if allowFailureFalse(job) {
+			return
+		}
+		// A manual deploy job is a legitimate pattern; the gate problem is a
+		// separate approval job, so skip jobs that deploy themselves.
+		if parser.FindKey(job, "environment") != nil {
+			return
+		}
+		idx, ok := jobStageIndex(job, stageIdx)
+		if !ok || idx >= maxDeployIdx {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL071",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message: fmt.Sprintf(
+				"manual job %q runs before a production deploy but does not set allow_failure: false — by default it is an optional gate, so later stages run and the pipeline can deploy without it being triggered; add allow_failure: false (or move when: manual into rules:)",
+				name.Value,
+			),
+			File: file,
+			Line: when.Line,
+			Col:  when.Column,
+		})
+	})
+
+	return findings
+}
+
+func buildStageIndex(mapping *yaml.Node) map[string]int {
+	stages := defaultStages
+	if node := parser.FindKey(mapping, "stages"); node != nil && node.Kind == yaml.SequenceNode {
+		var declared []string
+		for _, s := range node.Content {
+			if s.Kind == yaml.ScalarNode {
+				declared = append(declared, s.Value)
+			}
+		}
+		if len(declared) > 0 {
+			stages = declared
+		}
+	}
+	idx := make(map[string]int, len(stages))
+	for i, s := range stages {
+		idx[s] = i
+	}
+	return idx
+}
+
+func jobStageIndex(job *yaml.Node, stageIdx map[string]int) (int, bool) {
+	stage := defaultStage
+	if s := parser.FindKey(job, "stage"); s != nil && s.Kind == yaml.ScalarNode {
+		stage = s.Value
+	}
+	i, ok := stageIdx[stage]
+	return i, ok
+}
+
+func isProdDeployJob(job *yaml.Node) bool {
+	env := parser.FindKey(job, "environment")
+	if env == nil {
+		return false
+	}
+	name := extractEnvName(env)
+	return name != "" && isProdEnv(name)
+}
+
+func allowFailureFalse(job *yaml.Node) bool {
+	af := parser.FindKey(job, "allow_failure")
+	return af != nil && af.Kind == yaml.ScalarNode && af.Value == "false"
+}
+
+func isHiddenJob(name string) bool {
+	return len(name) > 0 && name[0] == '.'
+}

--- a/rules/gl071_test.go
+++ b/rules/gl071_test.go
@@ -1,0 +1,222 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings071(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL071.Check(doc.Root, "test.yml")
+}
+
+func TestGL071_ManualGateBeforeProdDeploy(t *testing.T) {
+	f := findings071(t, `
+stages: [build, approve, deploy]
+approve_prod:
+  stage: approve
+  when: manual
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for optional manual gate, got %d", len(f))
+	}
+	if f[0].Job != "approve_prod" {
+		t.Errorf("expected finding on approve_prod, got %q", f[0].Job)
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL071_AllowFailureFalse_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, approve, deploy]
+approve_prod:
+  stage: approve
+  when: manual
+  allow_failure: false
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("explicit allow_failure: false is blocking — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_WhenManualInRules_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, approve, deploy]
+approve_prod:
+  stage: approve
+  rules:
+    - when: manual
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("when: manual inside rules is blocking by default — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_NoLaterDeploy_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, test, cleanup]
+teardown:
+  stage: cleanup
+  when: manual
+  script: [./teardown.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("manual job with no later prod deploy — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_DeployBeforeGate_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [deploy, approve]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+approve_prod:
+  stage: approve
+  when: manual
+  script: [echo approved]
+`)
+	if len(f) != 0 {
+		t.Errorf("deploy is not in a later stage than the gate — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_ManualDeployItself_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, deploy]
+deploy_prod:
+  stage: deploy
+  environment: production
+  when: manual
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("a manual deploy job is legitimate — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_GateBeforeNonProdDeploy_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, approve, deploy]
+approve:
+  stage: approve
+  when: manual
+  script: [echo approved]
+deploy_review:
+  stage: deploy
+  environment: review/feature-1
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("deploy target is not production — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_GateSameStageAsDeploy_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, deploy]
+approve_prod:
+  stage: deploy
+  when: manual
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("gate is in the same stage as the deploy — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_HiddenTemplate_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, approve, deploy]
+.approve_template:
+  stage: approve
+  when: manual
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("hidden job templates do not run — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL071_AllowFailureTrueExplicit_StillFlagged(t *testing.T) {
+	f := findings071(t, `
+stages: [build, approve, deploy]
+approve_prod:
+  stage: approve
+  when: manual
+  allow_failure: true
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("explicit allow_failure: true is still optional — expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL071_DefaultStages(t *testing.T) {
+	// No stages: declared — default order is .pre, build, test, deploy, .post.
+	f := findings071(t, `
+approve_prod:
+  stage: test
+  when: manual
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding using default stage order, got %d", len(f))
+	}
+}
+
+func TestGL071_NonManualJob_NoFinding(t *testing.T) {
+	f := findings071(t, `
+stages: [build, approve, deploy]
+approve_prod:
+  stage: approve
+  script: [echo approved]
+deploy_prod:
+  stage: deploy
+  environment: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("job is not manual — expected no finding, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -73,6 +73,7 @@ var owaspCategories = map[string][]string{
 	"GL068": {"CICD-SEC-6"},
 	"GL069": {"CICD-SEC-3"},
 	"GL070": {"CICD-SEC-6"},
+	"GL071": {"CICD-SEC-1"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl071-manual-approval-gate.yml
+++ b/testdata/fixtures/gl071-manual-approval-gate.yml
@@ -1,0 +1,21 @@
+stages:
+  - build
+  - approve
+  - deploy
+
+build_app:
+  stage: build
+  script:
+    - make build
+
+approve_prod:
+  stage: approve
+  when: manual
+  script:
+    - echo "approved"
+
+deploy_prod:
+  stage: deploy
+  environment: production
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
Closes #328

## What changed

New rule **GL071** (CICD-SEC-1, CWE-691). Flags a job that looks like a manual **approval gate** in front of a production deploy but does not actually block the pipeline.

GitLab makes top-level `when: manual` jobs *optional* by default (`allow_failure: true`), so a pattern like:

```yaml
stages: [build, approve, deploy]
approve_prod:
  stage: approve
  when: manual            # optional → allow_failure: true by default
  script: [echo approved]
deploy_prod:
  stage: deploy
  environment: production
  script: [./deploy.sh]   # runs whether or not approve_prod was triggered
```

is a no-op gate — `deploy_prod` deploys even if nobody clicks the approval.

## Detection

A job is flagged when **all** hold:
- top-level `when: manual` (not inside `rules:`),
- no explicit `allow_failure: false`,
- no `environment:` of its own (it's a separate approval job, not the deploy),
- a production-like deploy job (`environment:` name matching `prod`/`production`/`live`/`staging`, reusing GL013's prod detection) exists in a **later stage**.

Stage order is read from top-level `stages:`, falling back to GitLab's default order (`.pre, build, test, deploy, .post`); jobs without an explicit `stage:` default to `test`.

### Not flagged (false-positive guards)
- `when: manual` inside `rules:` — blocking by default.
- Explicit `allow_failure: false`.
- A manual job with no later production deploy (e.g. optional cleanup/teardown).
- The deploy job itself being manual — a manual deploy is legitimate.
- Hidden job templates (`.name`).

## How to test
- `go test ./...` — 13 table-driven tests covering every accept/reject case above (incl. default stage order, `allow_failure: true` still flagged, non-prod deploy target, same-stage gate, hidden templates).
- `golangci-lint run ./...` — clean.
- `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl071-manual-approval-gate.yml` — schema-valid.
- Rule-consistency + README-table tests pass (doc, fixture, OWASP+CWE mapping, rules.md link, README row & count all updated).

## False-positive scan
Scanned ~200 real top-starred public GitLab `.gitlab-ci.yml` pipelines: **0 GL071 findings**. 14 pipelines used both `when: manual` and `environment:`; all were correctly left unflagged — they either define the manual condition inside `rules:` (blocking by default) or set `allow_failure: false` explicitly. One pipeline (a large public mono-pipeline) is a textbook good example: a top-level `when: manual` `pause-for-approval` job paired with `allow_failure: false` — the rule correctly does not flag it, confirming it discriminates the real anti-pattern from the correct one.