### PR TITLE
feat: add GL072 to flag needs:project artifact download with mutable or variable ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-71 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+72 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070 |
-| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069 |
+| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -51,6 +51,7 @@ Mutable references that allow silent substitution of images, templates, or packa
 | [GL026](rules/GL026.md) | `warn`  | `git clone`/`checkout` uses a mutable ref (branch or tag) instead of a pinned commit SHA |
 | [GL064](rules/GL064.md) | `warn`  | `include: component:` path is one edit from a popular component under a different namespace (typosquat) |
 | [GL069](rules/GL069.md) | `warn`  | Package signature/auth verification bypassed (`apt --allow-unauthenticated`, `[trusted=yes]`, `apk --allow-untrusted`) |
+| [GL072](rules/GL072.md) | `warn`  | `needs:project` cross-project artifact download with a mutable branch or variable `ref:` — the consumed artifacts can be poisoned |
 
 ---
 

--- a/docs/rules/GL072.md
+++ b/docs/rules/GL072.md
@@ -1,0 +1,68 @@
+# GL072 — `needs:project` artifact download with mutable or variable `ref`
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+glsec flags [`needs:project`](https://docs.gitlab.com/ci/yaml/#needsproject) entries — cross-project artifact downloads — whose `ref:` is **mutable** or **variable-controlled**.
+
+`needs:project` downloads artifacts from another project's job:
+
+```yaml
+build_job:
+  needs:
+    - project: my-group/my-project
+      job: build-1
+      ref: main
+      artifacts: true
+```
+
+The artifacts come from the **latest successful** run of that job on the given `ref` — there is no pinning to a specific pipeline or commit. So:
+
+- **Mutable ref** (`ref: main`) — anyone who can land a commit on the other project's `main` controls the binaries, configs, or generated YAML this job consumes.
+- **Variable ref** (`ref: $ARTIFACTS_DOWNLOAD_REF`) — GitLab allows CI/CD variables in `project:`, `job:`, and `ref:`, so a settable variable makes the artifact source attacker-choosable at pipeline time.
+
+This is the `needs:` analogue of [GL003](GL003.md) (unpinned `include:` ref) and reuses the same mutable-ref classification: a commit SHA is pinned, branch names like `main`/`master`/`develop`/`production`/`latest`/`HEAD` are mutable, and tags are treated as allowed.
+
+## Trigger examples
+
+```yaml
+consume_mutable:
+  needs:
+    - project: my-group/my-project
+      job: build
+      ref: main                       # mutable branch
+      artifacts: true
+
+consume_variable:
+  needs:
+    - project: my-group/my-project
+      job: build
+      ref: $ARTIFACTS_DOWNLOAD_REF     # variable-controlled
+      artifacts: true
+```
+
+## Safe alternative
+
+Pin `ref:` to a commit SHA or release tag:
+
+```yaml
+consume_pinned:
+  needs:
+    - project: my-group/my-project
+      job: build
+      ref: 3fa92b1c4d5e6f7081920a1b2c3d4e5f60718293   # commit SHA
+      artifacts: true
+```
+
+## What is not flagged
+
+- `ref:` pinned to a commit SHA or a release tag (e.g. `v1.2.3`).
+- `needs:project` with `artifacts: false` — nothing is downloaded, so there is no poisoning risk.
+- Plain same-pipeline `needs:` (`needs: [other_job]`) and `needs:pipeline:` — out of scope; no cross-project artifact source.
+
+## References
+
+- [GitLab: `needs:project`](https://docs.gitlab.com/ci/yaml/#needsproject)
+- GL003: `include:` with a mutable or missing ref

--- a/rules/all.go
+++ b/rules/all.go
@@ -75,5 +75,6 @@ func All() []rule.Rule {
 		GL069,
 		GL070,
 		GL071,
+		GL072,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -73,6 +73,7 @@ var cweIDs = map[string]string{
 	"GL069": "CWE-494",
 	"GL070": "CWE-798",
 	"GL071": "CWE-691",
+	"GL072": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl072.go
+++ b/rules/gl072.go
@@ -1,0 +1,89 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl072 struct{}
+
+var GL072 = &gl072{}
+
+func (r *gl072) ID() string { return "GL072" }
+
+// refVarRe matches a CI/CD variable reference ($VAR or ${VAR}) inside a ref.
+var refVarRe = regexp.MustCompile(`\$\{?[A-Za-z_]`)
+
+func (r *gl072) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		needs := parser.FindKey(job, "needs")
+		if needs == nil || needs.Kind != yaml.SequenceNode {
+			return
+		}
+		for _, item := range needs.Content {
+			if item.Kind != yaml.MappingNode {
+				continue
+			}
+			project := parser.FindKey(item, "project")
+			if project == nil {
+				continue // plain needs: or needs:pipeline: — out of scope
+			}
+			if artifactsDisabled(item) {
+				continue // no artifact download → no poisoning risk
+			}
+			refNode := parser.FindKey(item, "ref")
+			if refNode == nil || refNode.Kind != yaml.ScalarNode {
+				continue
+			}
+			if f := checkNeedsRef(project, refNode, file); f != nil {
+				f.Job = name.Value
+				findings = append(findings, *f)
+			}
+		}
+	})
+
+	return findings
+}
+
+func checkNeedsRef(project, refNode *yaml.Node, file string) *finding.Finding {
+	if refVarRe.MatchString(refNode.Value) {
+		return &finding.Finding{
+			RuleID:   "GL072",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"cross-project artifact download from %q uses a variable ref %q — the artifact source is chosen at pipeline time; pin ref: to a commit SHA or release tag",
+				project.Value, refNode.Value,
+			),
+			File: file,
+			Line: refNode.Line,
+			Col:  refNode.Column,
+		}
+	}
+	if isMutableRef(refNode.Value) {
+		return &finding.Finding{
+			RuleID:   "GL072",
+			Severity: finding.Warn,
+			Message: fmt.Sprintf(
+				"cross-project artifact download from %q uses mutable ref %q — anyone who can push to that ref controls the consumed artifacts; pin ref: to a commit SHA or release tag",
+				project.Value, refNode.Value,
+			),
+			File: file,
+			Line: refNode.Line,
+			Col:  refNode.Column,
+		}
+	}
+	return nil
+}
+
+// artifactsDisabled reports whether the needs entry explicitly sets
+// artifacts: false. Absent defaults to true (artifacts are downloaded).
+func artifactsDisabled(item *yaml.Node) bool {
+	a := parser.FindKey(item, "artifacts")
+	return a != nil && a.Kind == yaml.ScalarNode && a.Value == "false"
+}

--- a/rules/gl072_test.go
+++ b/rules/gl072_test.go
@@ -1,0 +1,203 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings072rule(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL072.Check(doc.Root, "test.yml")
+}
+
+func TestGL072_MutableRef(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: main
+      artifacts: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for mutable ref, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+	if strings.Contains(f[0].Message, "variable") {
+		t.Errorf("expected mutable-ref message, got variable message: %q", f[0].Message)
+	}
+}
+
+func TestGL072_VariableRef(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: $ARTIFACTS_DOWNLOAD_REF
+      artifacts: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for variable ref, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "variable") {
+		t.Errorf("expected variable-specific message, got %q", f[0].Message)
+	}
+}
+
+func TestGL072_VariableRefBraced(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: ${DOWNLOAD_REF}
+      artifacts: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for ${VAR} ref, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "variable") {
+		t.Errorf("expected variable-specific message, got %q", f[0].Message)
+	}
+}
+
+func TestGL072_ShaRef_NoFinding(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: 3fa92b1c4d5e6f7081920a1b2c3d4e5f60718293
+      artifacts: true
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for pinned SHA ref, got %d", len(f))
+	}
+}
+
+func TestGL072_TagRef_NoFinding(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: v1.2.3
+      artifacts: true
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for tag ref, got %d", len(f))
+	}
+}
+
+func TestGL072_PlainNeeds_NoFinding(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - other_job
+    - job: another_job
+`)
+	if len(f) != 0 {
+		t.Errorf("plain same-pipeline needs — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL072_NeedsPipeline_NoFinding(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - pipeline: other/project
+      job: build-1
+`)
+	if len(f) != 0 {
+		t.Errorf("needs:pipeline is out of scope — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL072_ArtifactsFalse_NoFinding(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: main
+      artifacts: false
+`)
+	if len(f) != 0 {
+		t.Errorf("artifacts: false downloads nothing — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL072_ArtifactsAbsentDefaultsTrue(t *testing.T) {
+	// For needs:project, artifacts defaults to true, so an absent key still downloads.
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: main
+`)
+	if len(f) != 1 {
+		t.Fatalf("absent artifacts defaults to true — expected 1 finding, got %d", len(f))
+	}
+}
+
+func TestGL072_MultipleNeeds(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  needs:
+    - other_job
+    - project: ns/a
+      job: build
+      ref: develop
+      artifacts: true
+    - project: ns/b
+      job: build
+      ref: 3fa92b1c4d5e6f7081920a1b2c3d4e5f60718293
+      artifacts: true
+    - project: ns/c
+      job: build
+      ref: $REF
+      artifacts: true
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (develop + $REF), got %d", len(f))
+	}
+}
+
+func TestGL072_NoNeeds_NoFinding(t *testing.T) {
+	f := findings072rule(t, `
+build_job:
+  script:
+    - make build
+`)
+	if len(f) != 0 {
+		t.Errorf("no needs — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL072_JobNameSet(t *testing.T) {
+	f := findings072rule(t, `
+my_build:
+  needs:
+    - project: ns/group/project
+      job: build-1
+      ref: main
+      artifacts: true
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Job != "my_build" {
+		t.Errorf("expected Job=my_build, got %q", f[0].Job)
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -74,6 +74,7 @@ var owaspCategories = map[string][]string{
 	"GL069": {"CICD-SEC-3"},
 	"GL070": {"CICD-SEC-6"},
 	"GL071": {"CICD-SEC-1"},
+	"GL072": {"CICD-SEC-3"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl072-needs-project-ref.yml
+++ b/testdata/fixtures/gl072-needs-project-ref.yml
@@ -1,0 +1,22 @@
+stages:
+  - build
+
+consume_mutable:
+  stage: build
+  needs:
+    - project: my-group/my-project
+      job: build
+      ref: main
+      artifacts: true
+  script:
+    - ./use-artifacts.sh
+
+consume_variable:
+  stage: build
+  needs:
+    - project: my-group/my-project
+      job: build
+      ref: $ARTIFACTS_DOWNLOAD_REF
+      artifacts: true
+  script:
+    - ./use-artifacts.sh


### PR DESCRIPTION
Closes #329

## What changed

New rule **GL072** (CICD-SEC-3, CWE-829). Flags [`needs:project`](https://docs.gitlab.com/ci/yaml/#needsproject) cross-project artifact downloads whose `ref:` is a **mutable branch** or a **CI/CD variable**. This is the `needs:` analogue of GL003 (unpinned `include:` ref) — previously no rule touched `needs:` at all.

`needs:project` pulls artifacts from the *latest successful* run of another project's job on a given ref — there is no pinning to a pipeline or commit:

```yaml
build_job:
  needs:
    - project: my-group/my-project
      job: build
      ref: main          # whoever can push to that project's main controls these artifacts
      artifacts: true
```

With a variable ref (`ref: $ARTIFACTS_DOWNLOAD_REF`) the artifact source is attacker-choosable at pipeline time.

## Detection

For each job's `needs:` sequence, entries that are mappings with a `project:` key:
- **mutable ref** → warn (reuses GL003's `isMutableRef`: SHA = pinned, `main`/`master`/`develop`/`production`/`latest`/`HEAD`/… = mutable, tags allowed).
- **variable ref** (`$VAR` / `${VAR}`) → warn, with a distinct message (source chosen at pipeline time).

### Not flagged
- `ref:` pinned to a commit SHA or a release tag (`v1.2.3`).
- `artifacts: false` — nothing is downloaded, no poisoning risk. (Absent `artifacts` defaults to `true` for `needs:project`, so that case *is* flagged.)
- Plain same-pipeline `needs: [job]` and `needs:pipeline:` — out of scope (no cross-project artifact source).

## How to test
- `go test ./...` — 12 table-driven tests: mutable/variable/`${VAR}`/SHA/tag refs, plain needs, `needs:pipeline`, `artifacts: false`, `artifacts` absent-defaults-true, mixed sequence, job-name propagation.
- `golangci-lint run ./...` — clean.
- `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl072-needs-project-ref.yml` — schema-valid.
- Rule-consistency + README-table tests pass (doc, fixture, OWASP+CWE mapping, rules.md link, README row & count 71→72 all updated).

## False-positive scan
Scanned ~200 real top-starred public GitLab `.gitlab-ci.yml` pipelines: **0 GL072 findings**. 7 pipelines combine `needs:` and `project:`, but on inspection all use `needs: []` (decoupling) with their `project:` entries inside `include:` blocks — no real `needs:project` artifact downloads (it's a Premium/Ultimate feature, rare in public repos). Correct true-negative result; positive behavior is covered by the fixture (2 findings) and unit tests.