### PR TITLE
docs: bump README version refs to 1.7.0 / catalog v1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.5.1
+    rev: v1.7.0
     hooks:
       - id: glsec
 ```
@@ -275,7 +275,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.6
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.8
 
 stages:
   - test
@@ -285,7 +285,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.6
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.8
 
 stages:
   - test
@@ -312,13 +312,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.5.1
+    name: ghcr.io/glsec/glsec:1.7.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.5.1`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.7.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -326,7 +326,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.5.1"
+  GLSEC_VERSION: "1.7.0"
 
 glsec:
   stage: test
@@ -348,7 +348,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.5.1
+    name: ghcr.io/glsec/glsec:1.7.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -367,7 +367,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.5.1
+    name: ghcr.io/glsec/glsec:1.7.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
## What
Update all stale version references in the README now that **glsec v1.7.0** and **CI Catalog component v1.0.8** are released.

- GitLab CI Catalog component pins: `@v1.0.6` → `@v1.0.8` (both `glsec` and `glsec-code-quality`)
- GHCR image tag examples: `ghcr.io/glsec/glsec:1.5.1` → `:1.7.0` (Docker, SAST, Code Quality sections)
- pre-commit hook `rev: v1.5.1` → `v1.7.0`
- binary-download `GLSEC_VERSION: "1.5.1"` → `"1.7.0"`
- inline pin example `(1.5.1, not :latest)` → `(1.7.0, not :latest)`

## Why
The README image/version examples had drifted to 1.5.1 (two releases behind) and the catalog pin to v1.0.6. The component now defaults to the 1.7.0 image and is published as catalog v1.0.8, so the docs should match.

## How to test
- `grep -nE "1\.5\.1|1\.6\.0|@v1\.0\.[0-7]" README.md` returns nothing.
- Catalog refs resolve: `gitlab.com/glsec-io/glsec/glsec@v1.0.8` is published (verified via GitLab catalog API).
- GHCR `ghcr.io/glsec/glsec:1.7.0` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)