### PR TITLE
Add GL073: flag anonymous artifact exposure (artifacts:public / access)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-72 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+73 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
-| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070 |
+| Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070, GL073 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -32,6 +32,7 @@ Secrets hardcoded, leaked through logs, or forwarded to unintended consumers.
 | [GL062](rules/GL062.md) | `warn`  | `printenv` or bare `env` dumps every variable (including secrets) to the job log |
 | [GL068](rules/GL068.md) | `warn`  | `set -x` / xtrace in a script traces expanded commands — including secrets — to the job log |
 | [GL070](rules/GL070.md) | `warn`  | Static cloud service-account credential in script (`gcloud --key-file`, `aws_secret_access_key`, `az --password`) — prefer keyless OIDC |
+| [GL073](rules/GL073.md) | `warn`/`error` | Artifacts exposed to unauthenticated users (`artifacts:public: true` / `artifacts:access: all`) — `error` when an exposed path looks sensitive |
 
 ---
 

--- a/docs/rules/GL073.md
+++ b/docs/rules/GL073.md
@@ -1,0 +1,61 @@
+# GL073 — Artifacts exposed to unauthenticated users (`public: true` / `access: all`)
+
+**Severity:** `warn` (raised to `error` when an exposed path looks sensitive)  
+**OWASP:** [CICD-SEC-6 – Insufficient Credential Hygiene](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene)
+
+## What glsec checks
+
+glsec flags jobs whose [`artifacts:`](https://docs.gitlab.com/ci/yaml/#artifacts) block makes the produced artifacts downloadable by **anonymous, unauthenticated users**. Two mutually exclusive keywords control this:
+
+- [`artifacts:public: true`](https://docs.gitlab.com/ci/yaml/#artifactspublic) — the legacy keyword; artifacts are downloadable without authentication.
+- [`artifacts:access: all`](https://docs.gitlab.com/ci/yaml/#artifactsaccess) — values are `all` | `developer` | `none`; `all` makes artifacts publicly downloadable.
+
+[GL005](GL005.md) inspects *which files* land in artifacts; GL073 inspects *who can download them*. A job that produces build output, reports, or — worse — a file matching a sensitive pattern, and exposes it anonymously, is an explicit data-exposure vector.
+
+When an exposed artifact path also matches GL005's sensitive-file patterns (`.env`, `*.pem`, `*credential*`, `kubeconfig`, `*.tfstate`, …) the finding is raised to **`error`**.
+
+## Trigger examples
+
+```yaml
+expose_public:
+  artifacts:
+    public: true            # downloadable without a GitLab account
+    paths:
+      - build/
+
+expose_access_all:
+  artifacts:
+    access: all             # same effect via the newer keyword
+    paths:
+      - dist/
+
+expose_secret:
+  artifacts:
+    access: all
+    paths:
+      - config/credentials.json   # error: sensitive path exposed anonymously
+```
+
+## Safe alternative
+
+Restrict who can download the artifacts:
+
+```yaml
+build:
+  artifacts:
+    access: developer       # only project members; or "none" to forbid download
+    paths:
+      - build/
+```
+
+## What is not flagged
+
+- An `artifacts:` block with **no** `public`/`access` key — the default is not flagged, to avoid firing on every artifacts block.
+- `artifacts:public: false`.
+- `artifacts:access: developer` or `artifacts:access: none`.
+
+## References
+
+- [GitLab: `artifacts:public`](https://docs.gitlab.com/ci/yaml/#artifactspublic)
+- [GitLab: `artifacts:access`](https://docs.gitlab.com/ci/yaml/#artifactsaccess)
+- GL005: sensitive file patterns in `artifacts:` paths

--- a/rules/all.go
+++ b/rules/all.go
@@ -76,5 +76,6 @@ func All() []rule.Rule {
 		GL070,
 		GL071,
 		GL072,
+		GL073,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -74,6 +74,7 @@ var cweIDs = map[string]string{
 	"GL070": "CWE-798",
 	"GL071": "CWE-691",
 	"GL072": "CWE-829",
+	"GL073": "CWE-538",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl073.go
+++ b/rules/gl073.go
@@ -1,0 +1,103 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl073 struct{}
+
+var GL073 = &gl073{}
+
+func (r *gl073) ID() string { return "GL073" }
+
+func (r *gl073) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		if artifactsNode := parser.FindKey(def, "artifacts"); artifactsNode != nil {
+			findings = append(findings, checkArtifactExposure(artifactsNode, file)...)
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		artifactsNode := parser.FindKey(job, "artifacts")
+		if artifactsNode == nil {
+			return
+		}
+		for _, f := range checkArtifactExposure(artifactsNode, file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func checkArtifactExposure(node *yaml.Node, file string) []finding.Finding {
+	keyNode, exposeDesc := artifactExposure(node)
+	if keyNode == nil {
+		return nil
+	}
+
+	severity := finding.Warn
+	msg := fmt.Sprintf(
+		"artifacts exposed to unauthenticated users (%s) — anyone can download them without a GitLab account; restrict with artifacts:access: developer (or none)",
+		exposeDesc,
+	)
+	if sensitive := sensitiveArtifactPath(node); sensitive != "" {
+		severity = finding.Error
+		msg = fmt.Sprintf(
+			"artifacts exposed to unauthenticated users (%s) and include a sensitive path %q — secrets are downloadable without a GitLab account; restrict with artifacts:access: developer (or none)",
+			exposeDesc, sensitive,
+		)
+	}
+
+	return []finding.Finding{{
+		RuleID:   "GL073",
+		Severity: severity,
+		Message:  msg,
+		File:     file,
+		Line:     keyNode.Line,
+		Col:      keyNode.Column,
+	}}
+}
+
+// artifactExposure reports the key node and a description when the artifacts
+// block explicitly grants anonymous access via public: true or access: all.
+// The absent/default case is deliberately not flagged to avoid firing on every
+// artifacts block.
+func artifactExposure(node *yaml.Node) (*yaml.Node, string) {
+	if k, v := parser.FindKeyNode(node, "public"); v != nil && v.Kind == yaml.ScalarNode {
+		if strings.EqualFold(v.Value, "true") {
+			return k, "public: true"
+		}
+	}
+	if k, v := parser.FindKeyNode(node, "access"); v != nil && v.Kind == yaml.ScalarNode {
+		if strings.EqualFold(v.Value, "all") {
+			return k, "access: all"
+		}
+	}
+	return nil, ""
+}
+
+func sensitiveArtifactPath(node *yaml.Node) string {
+	seqNode := parser.FindKey(node, "paths")
+	if seqNode == nil || seqNode.Kind != yaml.SequenceNode {
+		return ""
+	}
+	for _, item := range seqNode.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if matchesSensitivePattern(item.Value) != "" {
+			return item.Value
+		}
+	}
+	return ""
+}

--- a/rules/gl073_test.go
+++ b/rules/gl073_test.go
@@ -1,0 +1,190 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings073rule(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL073.Check(doc.Root, "test.yml")
+}
+
+func TestGL073_PublicTrue(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    public: true
+    paths:
+      - build/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for public: true, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+	if !strings.Contains(f[0].Message, "public: true") {
+		t.Errorf("expected public:true in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL073_AccessAll(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    access: all
+    paths:
+      - dist/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for access: all, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+	if !strings.Contains(f[0].Message, "access: all") {
+		t.Errorf("expected access:all in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL073_AccessAllCaseInsensitive(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    access: ALL
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for access: ALL, got %d", len(f))
+	}
+}
+
+func TestGL073_PublicWithSensitivePath(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    public: true
+    paths:
+      - config/credentials.json
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error for sensitive exposed path, got %s", f[0].Severity)
+	}
+	if !strings.Contains(f[0].Message, "credentials.json") {
+		t.Errorf("expected sensitive path in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL073_AccessAllWithSensitivePath(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    access: all
+    paths:
+      - secrets/id_rsa
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error, got %s", f[0].Severity)
+	}
+}
+
+func TestGL073_AccessDeveloper_NoFinding(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    access: developer
+    paths:
+      - build/
+`)
+	if len(f) != 0 {
+		t.Errorf("access: developer is not anonymous exposure — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL073_AccessNone_NoFinding(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    access: none
+`)
+	if len(f) != 0 {
+		t.Errorf("access: none — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL073_PublicFalse_NoFinding(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    public: false
+    paths:
+      - build/
+`)
+	if len(f) != 0 {
+		t.Errorf("public: false — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL073_AbsentExposure_NoFinding(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  artifacts:
+    paths:
+      - build/
+    expire_in: 1 week
+`)
+	if len(f) != 0 {
+		t.Errorf("no public/access key — expected no finding (default not flagged), got %d", len(f))
+	}
+}
+
+func TestGL073_DefaultBlock(t *testing.T) {
+	f := findings073rule(t, `
+default:
+  artifacts:
+    public: true
+    paths:
+      - build/
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding from default artifacts block, got %d", len(f))
+	}
+}
+
+func TestGL073_NoArtifacts_NoFinding(t *testing.T) {
+	f := findings073rule(t, `
+build_job:
+  script:
+    - make build
+`)
+	if len(f) != 0 {
+		t.Errorf("no artifacts — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL073_JobNameSet(t *testing.T) {
+	f := findings073rule(t, `
+my_build:
+  artifacts:
+    access: all
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Job != "my_build" {
+		t.Errorf("expected Job=my_build, got %q", f[0].Job)
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -75,6 +75,7 @@ var owaspCategories = map[string][]string{
 	"GL070": {"CICD-SEC-6"},
 	"GL071": {"CICD-SEC-1"},
 	"GL072": {"CICD-SEC-3"},
+	"GL073": {"CICD-SEC-6"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl073-artifacts-anonymous-exposure.yml
+++ b/testdata/fixtures/gl073-artifacts-anonymous-exposure.yml
@@ -1,0 +1,20 @@
+stages:
+  - build
+
+expose_access_all:
+  stage: build
+  script:
+    - make build
+  artifacts:
+    access: all
+    paths:
+      - dist/
+
+expose_secret:
+  stage: build
+  script:
+    - make build
+  artifacts:
+    access: all
+    paths:
+      - config/credentials.json


### PR DESCRIPTION
Closes #338.

## What changed

New rule **GL073** flags jobs whose `artifacts:` block makes artifacts downloadable by **anonymous, unauthenticated users**:

- `artifacts:public: true` (legacy keyword)
- `artifacts:access: all`

This complements **GL005** (which inspects *which files* land in artifacts) by inspecting *who can download them*.

## Why

A job can expose build output, reports, or sensitive files to anyone — no GitLab account required — via either keyword, and no rule caught this. `artifacts:access:` defaults to `all`, but only the **explicit** exposure is flagged to avoid firing on every artifacts block.

## Behaviour

| Case | Result |
|------|--------|
| `public: true` / `access: all` | `warn` |
| …and an exposed `paths:` entry matches a GL005 sensitive pattern (`*credential*`, `*.pem`, `id_rsa`, `*.tfstate`, …) | `error` |
| absent `public`/`access` (default) | not flagged |
| `public: false`, `access: developer`, `access: none` | not flagged |

OWASP CICD-SEC-6 (Insufficient Credential Hygiene) · CWE-538 (Insertion of Sensitive Information into Externally-Accessible File or Directory) — same mapping as GL005.

## How to test

```sh
go test ./...
glsec testdata/fixtures/gl073-artifacts-anonymous-exposure.yml
```

The fixture produces one `warn` (`access: all`) and one `error` (`access: all` + `config/credentials.json`).

## Notes

- The fixture uses `access: all` only; the bundled SchemaStore schema used by the `check-jsonschema` CI job no longer accepts the deprecated `public` keyword, so `public: true` coverage lives in the unit tests instead.
- Verified locally: `go test ./...`, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml`, `golangci-lint run ./...` (0 issues).