### PR TITLE
GL042: flag pip --trusted-host (package-index TLS bypass)

### DIFF
--- a/docs/rules/GL042.md
+++ b/docs/rules/GL042.md
@@ -15,6 +15,7 @@ Detected patterns:
 | `wget` | `--no-check-certificate` |
 | `git` | `-c http.sslVerify=false` |
 | `npm` | `--strict-ssl=false`, `npm config set strict-ssl false` |
+| `pip` | `--trusted-host` (also `pip3` / `python -m pip`) |
 | env var | `GIT_SSL_NO_VERIFY=true` / `GIT_SSL_NO_VERIFY=1` (in `variables:` or inline) |
 
 ## Trigger example
@@ -28,6 +29,7 @@ build:
     - wget --no-check-certificate https://internal.example.com/file.zip
     - git -c http.sslVerify=false clone https://gitlab.example.com/org/repo.git
     - npm install --strict-ssl=false
+    - pip install --trusted-host pypi.org somepkg
 ```
 
 ## Safe alternatives

--- a/rules/gl042.go
+++ b/rules/gl042.go
@@ -47,6 +47,11 @@ var tlsChecks = []tlsCheck{
 		re:   regexp.MustCompile(`\bnpm\s+(?:config\s+set|set)\s+strict-ssl\s+false\b`),
 		msg:  `npm strict-ssl disabled via "npm config set" — TLS certificate verification disabled for all subsequent npm commands`,
 	},
+	{
+		tool: "pip",
+		re:   regexp.MustCompile(`\bpip[0-9]*\b.*--trusted-host\b`),
+		msg:  `pip invoked with "--trusted-host" — TLS certificate verification disabled for the package index, allowing a man-in-the-middle to swap package contents; add the proxy CA to the system trust store instead`,
+	},
 }
 
 // gitSSLNoVerifyRe matches GIT_SSL_NO_VERIFY=true/1 as a variable export or inline env.

--- a/rules/gl042_test.go
+++ b/rules/gl042_test.go
@@ -82,6 +82,34 @@ build:
 			wantHits: 1,
 		},
 		{
+			name: "pip --trusted-host",
+			yaml: `build:
+  script:
+    - pip install --trusted-host pypi.org somepkg`,
+			wantHits: 1,
+		},
+		{
+			name: "pip3 --trusted-host",
+			yaml: `build:
+  script:
+    - pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org somepkg`,
+			wantHits: 1,
+		},
+		{
+			name: "python -m pip --trusted-host",
+			yaml: `build:
+  script:
+    - python -m pip install --trusted-host pypi.org somepkg`,
+			wantHits: 1,
+		},
+		{
+			name: "pip install without --trusted-host — safe",
+			yaml: `build:
+  script:
+    - pip install somepkg`,
+			wantHits: 0,
+		},
+		{
 			name: "curl without -k — safe",
 			yaml: `build:
   script:

--- a/testdata/fixtures/gl042-tls-verification-disabled.yml
+++ b/testdata/fixtures/gl042-tls-verification-disabled.yml
@@ -1,3 +1,4 @@
 build:
   script:
     - curl -k https://internal.example.com/artifact.tar.gz
+    - pip install --trusted-host pypi.org somepkg


### PR DESCRIPTION
Closes #339.

## What changed

Extends **GL042** (TLS certificate verification disabled) to also flag pip's index TLS bypass:

```
pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org somepkg
```

`--trusted-host` tells pip to skip TLS certificate validation for that host's index and download URLs — the pip analogue of `curl -k`, and a man-in-the-middle vector for package contents. It's commonly pasted into CI to "fix" a corporate-proxy cert error.

## Why

GL042 already covered `curl`, `wget`, `git`, and `npm` TLS bypasses but not pip. GL069 covers package *signature* bypass (apt/apk), which is a different mechanism — `--trusted-host` is a TLS-verification bypass, so it belongs with GL042.

## Detection

New pattern `\bpip[0-9]*\b.*--trusted-host\b`, matched per script line via the same helper as the other GL042 checks (so it also covers `before_script`, `after_script`, and `hooks:pre_get_sources_script`). Covers `pip`, `pip3`, and `python -m pip`. `severity: warn`, consistent with the rest of GL042.

Not flagged: `pip install` without `--trusted-host`.

## How to test

```sh
go test ./rules/ -run TestGL042
glsec testdata/fixtures/gl042-tls-verification-disabled.yml
```

The fixture now emits a GL042 finding for both `curl -k` and `pip --trusted-host`.

Verified locally: `go test ./...`, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml`, `golangci-lint run ./...` (0 issues).