### PR TITLE
Add GL074: flag tautological (always-true) rules:if conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-73 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+74 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -161,7 +161,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
-| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071 |
+| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -102,6 +102,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL017](rules/GL017.md) | `warn`  | Deploy/publish job has no `tags:` — can run on any runner including untrusted self-hosted |
 | [GL043](rules/GL043.md) | `warn`  | Unanchored regex on user-controlled variable in `rules:if` — prefix match can be bypassed by crafting a matching value |
 | [GL071](rules/GL071.md) | `warn`  | Manual approval gate before a production deploy without `allow_failure: false` — optional by default, so the pipeline can deploy without it being triggered |
+| [GL074](rules/GL074.md) | `warn`  | Tautological (always-true) `rules:if` condition — the gate is a no-op and the job runs in every context it was meant to restrict |
 | [GL055](rules/GL055.md) | `warn`  | `DOCKER_HOST` points at the host Docker socket (`/var/run/docker.sock`) — full control of the runner's Docker daemon |
 
 ---

--- a/docs/rules/GL074.md
+++ b/docs/rules/GL074.md
@@ -1,0 +1,53 @@
+# GL074 — Tautological (always-true) `rules:if` condition
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
+
+## What glsec checks
+
+glsec flags [`rules:if`](https://docs.gitlab.com/ci/yaml/#rulesif) conditions that are **provably always true**. Such a condition makes the gate it guards a no-op: a job meant to run only under specific circumstances silently runs everywhere — including contexts the author intended to exclude, such as fork merge requests or scheduled pipelines. When the gated job is privileged (a deploy, a release, a job that holds secrets), the ineffective gate is a security problem, not just a logic bug.
+
+Detected, conservatively (only expressions true regardless of any variable value):
+
+| Pattern | Example |
+|---------|---------|
+| A standalone `true` OR operand | `$CI_COMMIT_BRANCH \|\| true`, `true \|\| $X` |
+| A constant comparison of two literals | `"true" == "true"`, `"a" != "b"` |
+| The same variable compared `==` and `!=` to the **same** literal across an OR | `$CI_PIPELINE_SOURCE != "schedule" \|\| $CI_PIPELINE_SOURCE == "schedule"` |
+
+This complements [GL043](GL043.md) (unanchored regex in `rules:if`) and [GL039](GL039.md) (`|| true` silencing a script command). GL074 targets the **gate condition itself** being a tautology.
+
+## Trigger examples
+
+```yaml
+deploy:
+  rules:
+    - if: '$CI_COMMIT_BRANCH || true'                                            # standalone true
+    - if: '"true" == "true"'                                                     # constant comparison
+    - if: '$CI_PIPELINE_SOURCE != "schedule" || $CI_PIPELINE_SOURCE == "schedule"'  # A || !A
+```
+
+## Safe alternative
+
+Write a condition that actually restricts when the job runs:
+
+```yaml
+deploy:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+```
+
+## What is not flagged
+
+To keep false positives low, GL074 only reports conditions it can prove are always true. It deliberately does **not** flag:
+
+- `$A || $B` — an OR of two variables (false when both are empty).
+- `$X || true && $Y` — `&&` binds tighter, so this is `$X || $Y`, not always true.
+- `$V == "a" || $V != "b"` — different literals; false when `$V == "b"`.
+- `$VAR == $OTHER` — variable-to-variable comparison.
+
+## References
+
+- [GitLab: `rules:if`](https://docs.gitlab.com/ci/yaml/#rulesif)
+- [GitLab: CI/CD variable expressions](https://docs.gitlab.com/ci/jobs/job_rules/#cicd-variable-expressions)
+- GL043: unanchored regex on a user-controlled variable in `rules:if`

--- a/rules/all.go
+++ b/rules/all.go
@@ -77,5 +77,6 @@ func All() []rule.Rule {
 		GL071,
 		GL072,
 		GL073,
+		GL074,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -75,6 +75,7 @@ var cweIDs = map[string]string{
 	"GL071": "CWE-691",
 	"GL072": "CWE-829",
 	"GL073": "CWE-538",
+	"GL074": "CWE-691",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl074.go
+++ b/rules/gl074.go
@@ -1,0 +1,134 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl074 struct{}
+
+var GL074 = &gl074{}
+
+func (r *gl074) ID() string { return "GL074" }
+
+var (
+	// gl074CompRe matches a single "$VAR == "lit"" / "$VAR != "lit"" operand.
+	gl074CompRe = regexp.MustCompile(`^\$\{?(\w+)\}?\s*(==|!=)\s*["']([^"']*)["']$`)
+	// gl074TwoLiteralRe matches a literal-vs-literal comparison ("a" == "b").
+	gl074TwoLiteralRe = regexp.MustCompile(`^["']([^"']*)["']\s*(==|!=)\s*["']([^"']*)["']$`)
+)
+
+func (r *gl074) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	if wf := parser.FindKey(mapping, "workflow"); wf != nil {
+		if rulesNode := parser.FindKey(wf, "rules"); rulesNode != nil {
+			findings = append(findings, gl074CheckRules(rulesNode, file, "")...)
+		}
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		rulesNode := parser.FindKey(job, "rules")
+		if rulesNode == nil {
+			return
+		}
+		for _, f := range gl074CheckRules(rulesNode, file, "") {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func gl074CheckRules(node *yaml.Node, file, job string) []finding.Finding {
+	if node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for _, item := range node.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		ifNode := parser.FindKey(item, "if")
+		if ifNode == nil || ifNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		if reason := tautologyReason(ifNode.Value); reason != "" {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL074",
+				Severity: finding.Warn,
+				Job:      job,
+				Message: "rules:if condition is always true (" + reason +
+					") — the gate is a no-op; the job runs in every context this rule was meant to restrict",
+				File: file,
+				Line: ifNode.Line,
+				Col:  ifNode.Column,
+			})
+		}
+	}
+	return findings
+}
+
+// tautologyReason returns a short explanation when cond is provably always true,
+// or "" otherwise. It is deliberately conservative: it only reports expressions
+// that are true regardless of variable values, to avoid flagging legitimate
+// complex conditions.
+func tautologyReason(cond string) string {
+	operands := strings.Split(cond, "||") // top-level OR; "||" inside quotes is rare
+
+	// An OR is always true if any single operand — not narrowed by && — is
+	// itself always true.
+	for _, raw := range operands {
+		op := stripParens(strings.TrimSpace(raw))
+		if strings.Contains(op, "&&") {
+			continue
+		}
+		if op == "true" {
+			return `standalone "true" operand`
+		}
+		if m := gl074TwoLiteralRe.FindStringSubmatch(op); m != nil {
+			equal := m[1] == m[3]
+			if (m[2] == "==" && equal) || (m[2] == "!=" && !equal) {
+				return "constant comparison " + op
+			}
+		}
+	}
+
+	// A || !A: the same variable compared == and != to the same literal across
+	// two OR operands covers every possible value.
+	type comp struct{ op, lit string }
+	byVar := map[string][]comp{}
+	for _, raw := range operands {
+		op := stripParens(strings.TrimSpace(raw))
+		if strings.Contains(op, "&&") {
+			continue
+		}
+		if m := gl074CompRe.FindStringSubmatch(op); m != nil {
+			byVar[m[1]] = append(byVar[m[1]], comp{m[2], m[3]})
+		}
+	}
+	for v, comps := range byVar {
+		for i := range comps {
+			for j := range comps {
+				if i != j && comps[i].lit == comps[j].lit && comps[i].op != comps[j].op {
+					return "$" + v + ` compared both == and != to "` + comps[i].lit + `"`
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+func stripParens(s string) string {
+	for strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
+		s = strings.TrimSpace(s[1 : len(s)-1])
+	}
+	return s
+}

--- a/rules/gl074_test.go
+++ b/rules/gl074_test.go
@@ -1,0 +1,175 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings074rule(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL074.Check(doc.Root, "test.yml")
+}
+
+func TestGL074_OrTrue(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '$CI_COMMIT_BRANCH || true'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for '|| true', got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+}
+
+func TestGL074_LeadingTrue(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: 'true || $CI_COMMIT_BRANCH'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for 'true ||', got %d", len(f))
+	}
+}
+
+func TestGL074_ConstEqual(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '"true" == "true"'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for constant ==, got %d", len(f))
+	}
+}
+
+func TestGL074_ConstNotEqualDifferent(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '"a" != "b"'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for constant != different literals, got %d", len(f))
+	}
+}
+
+func TestGL074_VarEqAndNeqSameLiteral(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule" || $CI_PIPELINE_SOURCE == "schedule"'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for A || !A tautology, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "CI_PIPELINE_SOURCE") {
+		t.Errorf("expected variable in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL074_WorkflowRules(t *testing.T) {
+	f := findings074rule(t, `
+workflow:
+  rules:
+    - if: '$CI_COMMIT_BRANCH || true'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in workflow:rules, got %d", len(f))
+	}
+}
+
+func TestGL074_JobNameSet(t *testing.T) {
+	f := findings074rule(t, `
+my_deploy:
+  rules:
+    - if: '$X || true'
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Job != "my_deploy" {
+		t.Errorf("expected Job=my_deploy, got %q", f[0].Job)
+	}
+}
+
+// --- negative cases (must NOT fire) ---
+
+func TestGL074_NormalCondition_NoFinding(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+`)
+	if len(f) != 0 {
+		t.Errorf("normal conditions — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL074_OrOfTwoVars_NoFinding(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '$CI_COMMIT_TAG || $CI_COMMIT_BRANCH'
+`)
+	if len(f) != 0 {
+		t.Errorf("OR of two vars is not always true — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL074_TrueNarrowedByAnd_NoFinding(t *testing.T) {
+	// $X || (true && $Y) == $X || $Y — not always true.
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '$X || true && $CI_COMMIT_BRANCH'
+`)
+	if len(f) != 0 {
+		t.Errorf("true narrowed by && is not always true — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL074_DifferentLiterals_NoFinding(t *testing.T) {
+	// $V == "a" || $V != "b" — false when V == "b"; not always true.
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "a" || $CI_COMMIT_BRANCH != "b"'
+`)
+	if len(f) != 0 {
+		t.Errorf("different literals — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL074_StringEqVar_NoFinding(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  rules:
+    - if: '$CI_MERGE_REQUEST_TARGET_BRANCH_NAME == $CI_DEFAULT_BRANCH'
+`)
+	if len(f) != 0 {
+		t.Errorf("var == var — expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL074_NoRules_NoFinding(t *testing.T) {
+	f := findings074rule(t, `
+deploy:
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("no rules — expected no finding, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -76,6 +76,7 @@ var owaspCategories = map[string][]string{
 	"GL071": {"CICD-SEC-1"},
 	"GL072": {"CICD-SEC-3"},
 	"GL073": {"CICD-SEC-6"},
+	"GL074": {"CICD-SEC-1"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl074-tautological-rules-if.yml
+++ b/testdata/fixtures/gl074-tautological-rules-if.yml
@@ -1,0 +1,30 @@
+stages:
+  - deploy
+
+deploy_or_true:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH || true'
+
+deploy_tautology:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule" || $CI_PIPELINE_SOURCE == "schedule"'
+
+deploy_const_compare:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '"true" == "true"'
+
+deploy_safe:
+  stage: deploy
+  script:
+    - ./deploy.sh
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'


### PR DESCRIPTION
Closes #341.

## What changed

New rule **GL074** flags `rules:if` conditions that are **provably always true**. Such a condition makes the gate it guards a no-op: a job meant to run only under specific circumstances silently runs everywhere — including contexts the author meant to exclude (fork MRs, scheduled pipelines). When the gated job is privileged (deploy, release, secret-holding), the ineffective gate is a security problem.

## Detection (conservative)

Only expressions true regardless of any variable value are flagged:

| Pattern | Example |
|---------|---------|
| Standalone `true` OR operand | `$CI_COMMIT_BRANCH \|\| true`, `true \|\| $X` |
| Constant comparison of two literals | `"true" == "true"`, `"a" != "b"` |
| Same variable `==` and `!=` the **same** literal across an OR | `$CI_PIPELINE_SOURCE != "schedule" \|\| $CI_PIPELINE_SOURCE == "schedule"` |

This complements **GL043** (unanchored regex in `rules:if`) and **GL039** (`|| true` silencing a script command); GL074 targets the gate **condition** being a tautology.

## Not flagged (false-positive guards)

- `$A || $B` — OR of two variables.
- `$X || true && $Y` — `&&` binds tighter, so this is `$X || $Y`.
- `$V == "a" || $V != "b"` — different literals.
- `$VAR == $OTHER` — variable-to-variable comparison.

Verified the rule fires on none of the other ~70 fixtures.

## Mapping

OWASP CICD-SEC-1 (Insufficient Flow Control Mechanisms) · CWE-691 (Insufficient Control Flow Management) — same as GL071.

## How to test

```sh
go test ./rules/ -run TestGL074
glsec testdata/fixtures/gl074-tautological-rules-if.yml
```

The fixture emits three warnings (standalone true, A||!A, constant comparison) and stays silent on the safe `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH` job.

Verified locally: `go test ./...`, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml`, `golangci-lint run ./...` (0 issues).