### PR TITLE
GL013: detect production via environment:deployment_tier

### DIFF
--- a/docs/rules/GL013.md
+++ b/docs/rules/GL013.md
@@ -7,7 +7,12 @@
 
 glsec flags jobs that deploy to a production-like environment but have no `rules:` or `only:` clause to restrict which branches or conditions can trigger the deployment.
 
-A job is considered production-like if its `environment:` name contains (case-insensitive): `production`, `prod`, `live`, or `staging`. Both the scalar form and the `{name: ..., url: ...}` mapping form are checked.
+A job is considered production-like if either:
+
+- its `environment:` name contains (case-insensitive) `production`, `prod`, `live`, or `staging`; or
+- its [`environment:deployment_tier`](https://docs.gitlab.com/ci/yaml/#environmentdeployment_tier) is `production` or `staging` — this catches jobs whose name is an arbitrary string (e.g. `my-app`, `eu-west`) but which declare themselves a prod/staging target via the structured field.
+
+Both the scalar form and the `{name: ..., url: ...}` mapping form are checked.
 
 ## Trigger example
 
@@ -15,6 +20,13 @@ A job is considered production-like if its `environment:` name contains (case-in
 deploy-prod:
   stage: deploy
   environment: production   # no rules: — any branch can deploy
+  script: ./deploy-to-prod.sh
+
+deploy-eu:
+  stage: deploy
+  environment:
+    name: eu-west           # name not a prod keyword …
+    deployment_tier: production   # … but the tier declares it production
   script: ./deploy-to-prod.sh
 ```
 

--- a/rules/gl013.go
+++ b/rules/gl013.go
@@ -20,6 +20,10 @@ var prodKeywords = []string{
 	"production", "prod", "live", "staging",
 }
 
+// prodTiers are environment:deployment_tier values treated as production-like,
+// matching the name-keyword semantics (which also include staging).
+var prodTiers = []string{"production", "staging"}
+
 func (r *gl013) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 
@@ -29,7 +33,10 @@ func (r *gl013) Check(doc *yaml.Node, file string) []finding.Finding {
 			return
 		}
 		envName := extractEnvName(envNode)
-		if envName == "" || !isProdEnv(envName) {
+		tier := extractDeploymentTier(envNode)
+		byName := envName != "" && isProdEnv(envName)
+		byTier := isProdTier(tier)
+		if !byName && !byTier {
 			return
 		}
 		if hasExecutionRestriction(job) {
@@ -39,17 +46,55 @@ func (r *gl013) Check(doc *yaml.Node, file string) []finding.Finding {
 			RuleID:   "GL013",
 			Severity: finding.Warn,
 			Job:      name.Value,
-			Message: fmt.Sprintf(
-				"job %q deploys to %q but has no rules: or only: clause — any branch can trigger this deployment",
-				name.Value, envName,
-			),
-			File: file,
-			Line: envNode.Line,
-			Col:  envNode.Column,
+			Message:  gl013Message(name.Value, envName, tier, byName),
+			File:     file,
+			Line:     envNode.Line,
+			Col:      envNode.Column,
 		})
 	})
 
 	return findings
+}
+
+// gl013Message preserves the original name-based wording and adds a
+// deployment_tier-based variant when the job is only flagged via its tier.
+func gl013Message(job, envName, tier string, byName bool) string {
+	if byName {
+		return fmt.Sprintf(
+			"job %q deploys to %q but has no rules: or only: clause — any branch can trigger this deployment",
+			job, envName,
+		)
+	}
+	if envName != "" {
+		return fmt.Sprintf(
+			"job %q deploys to %q (deployment_tier: %s) but has no rules: or only: clause — any branch can trigger this deployment",
+			job, envName, tier,
+		)
+	}
+	return fmt.Sprintf(
+		"job %q has deployment_tier: %s but no rules: or only: clause — any branch can trigger this deployment",
+		job, tier,
+	)
+}
+
+func extractDeploymentTier(node *yaml.Node) string {
+	if node.Kind != yaml.MappingNode {
+		return ""
+	}
+	if v := parser.FindKey(node, "deployment_tier"); v != nil && v.Kind == yaml.ScalarNode {
+		return v.Value
+	}
+	return ""
+}
+
+func isProdTier(tier string) bool {
+	lower := strings.ToLower(tier)
+	for _, t := range prodTiers {
+		if lower == t {
+			return true
+		}
+	}
+	return false
 }
 
 func extractEnvName(node *yaml.Node) string {

--- a/rules/gl013_test.go
+++ b/rules/gl013_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/glsec/glsec/internal/finding"
@@ -125,6 +126,75 @@ deploy-prod:
 `)
 	if len(f) != 0 {
 		t.Errorf("expected no finding for mapping env with rules:, got %d", len(f))
+	}
+}
+
+func TestGL013_DeploymentTierProduction(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment:
+    name: my-app
+    deployment_tier: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for deployment_tier: production with non-prod name, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "deployment_tier: production") {
+		t.Errorf("expected tier in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL013_DeploymentTierStaging(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment:
+    name: eu-west
+    deployment_tier: staging
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for deployment_tier: staging, got %d", len(f))
+	}
+}
+
+func TestGL013_DeploymentTierWithRules_NoFinding(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment:
+    name: my-app
+    deployment_tier: production
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when rules: present, got %d", len(f))
+	}
+}
+
+func TestGL013_DeploymentTierDevelopment_NoFinding(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment:
+    name: my-app
+    deployment_tier: development
+  script: [./deploy.sh]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for deployment_tier: development with non-prod name, got %d", len(f))
+	}
+}
+
+func TestGL013_DeploymentTierNoName(t *testing.T) {
+	f := findings013(t, `
+deploy:
+  environment:
+    deployment_tier: production
+  script: [./deploy.sh]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for tier-only environment, got %d", len(f))
 	}
 }
 

--- a/testdata/fixtures/gl013-prod-deploy-no-restriction.yml
+++ b/testdata/fixtures/gl013-prod-deploy-no-restriction.yml
@@ -15,3 +15,12 @@ deploy-production:
   environment: production
   script:
     - ./deploy.sh
+
+deploy-eu-west:
+  stage: deploy
+  image: alpine:3.19
+  environment:
+    name: eu-west
+    deployment_tier: production
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
Closes #340.

## What changed

Extends **GL013** (production deploy without branch restriction) to also recognise production-like jobs by their structured [`environment:deployment_tier`](https://docs.gitlab.com/ci/yaml/#environmentdeployment_tier), not just by `environment:name` keywords.

```yaml
deploy-eu:
  environment:
    name: eu-west            # name is not a prod keyword …
    deployment_tier: production   # … but the tier declares it production
  script: ./deploy.sh
```

Previously this job was missed: its name (`eu-west`) matches none of `production`/`prod`/`live`/`staging`, so GL013 never fired even though it's a prod deploy with no `rules:`/`only:` gate.

## Detection

A job is now production-like if **either** its `environment:name` matches the existing keywords **or** its `environment:deployment_tier` is `production` or `staging` (mirroring the name keywords, which already include `staging`). The existing name-based finding message is unchanged; a tier-based variant is added:

- `job "X" deploys to "eu-west" (deployment_tier: production) but has no rules: or only: clause …`

## Not flagged

- `deployment_tier: development` / `testing` / `other`.
- A tier-flagged job that has a `rules:` or `only:` clause.

Confirmed the change adds no new findings on existing fixtures (only the GL013 fixture uses `deployment_tier`; all other GL013 hits remain name-based).

## How to test

```sh
go test ./rules/ -run TestGL013
glsec testdata/fixtures/gl013-prod-deploy-no-restriction.yml
```

The fixture now emits two GL013 warnings: the name-based `deploy-production` and the tier-based `deploy-eu-west`.

Verified locally: `go test ./...`, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml`, `golangci-lint run ./...` (0 issues).