### PR TITLE
GL065: fold Docker Hub host aliases to docker.io

### DIFF
--- a/docs/rules/GL065.md
+++ b/docs/rules/GL065.md
@@ -21,6 +21,7 @@ allowed_registries:
 
 - **No-op when unset** — without `allowed_registries`, nothing is flagged (so the default behaviour does not complain about every `docker.io` image).
 - **Registry host** is the part before the first `/` when it contains a `.` or `:port` (or is `localhost`). Bare images like `node:20` and Docker Hub namespaces like `myorg/app` resolve to `docker.io` implicitly.
+- **Docker Hub aliases** — the canonical Docker Hub hostnames `index.docker.io` and `registry-1.docker.io` are folded to `docker.io`, so allowlisting `docker.io` also permits `index.docker.io/library/node:20`.
 - **Bare-host entries** (`registry.example.com`) match by host; **namespace entries** (`ghcr.io/myorg`) match as a host/namespace prefix, so `ghcr.io/myorg/app` is allowed but `ghcr.io/other/app` is not.
 - **Variable hosts are exempt** — `image: $MY_IMAGE` or `image: $REGISTRY/app` cannot be resolved statically and are not flagged (a resolvable host with a variable path, e.g. `docker.io/$IMAGE`, is still checked).
 

--- a/rules/gl065.go
+++ b/rules/gl065.go
@@ -105,15 +105,29 @@ func registryHostUnresolvable(ref string) bool {
 	return strings.Contains(first, "$")
 }
 
+// dockerHubAliases are the canonical Docker Hub hostnames that all refer to the
+// same registry as the implicit "docker.io"; they are folded together so an
+// allowlisted "docker.io" matches images pulled via any of them.
+var dockerHubAliases = map[string]bool{
+	"docker.io":            true,
+	"index.docker.io":      true,
+	"registry-1.docker.io": true,
+}
+
 // normalizeRegistry returns the registry host and the reference normalized to
 // carry an explicit, lowercased host. The first path segment is the registry
 // only when it contains a "." or ":port" (or is "localhost"); bare images
-// (node:20) and Docker Hub namespaces (myorg/app) resolve to docker.io.
+// (node:20) and Docker Hub namespaces (myorg/app) resolve to docker.io. The
+// canonical Docker Hub hostnames (index.docker.io, registry-1.docker.io) are
+// folded to docker.io.
 func normalizeRegistry(ref string) (host, normalized string) {
 	if i := strings.Index(ref, "/"); i >= 0 {
 		first := ref[:i]
 		if first == "localhost" || strings.ContainsAny(first, ".:") {
 			host = strings.ToLower(first)
+			if dockerHubAliases[host] {
+				return "docker.io", "docker.io" + ref[i:]
+			}
 			return host, host + ref[i:]
 		}
 	}

--- a/rules/gl065_test.go
+++ b/rules/gl065_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/glsec/glsec/internal/finding"
@@ -67,6 +68,41 @@ build:
 `, []string{"docker.io"})
 	if len(f) != 0 {
 		t.Errorf("expected no finding when docker.io is allowlisted, got %d", len(f))
+	}
+}
+
+func TestGL065_DockerHubAliasesFoldToDockerIO(t *testing.T) {
+	for _, ref := range []string{
+		"index.docker.io/library/node:20",
+		"registry-1.docker.io/library/node:20",
+	} {
+		f := findings065(t, "build:\n  image: "+ref+"\n", []string{"docker.io"})
+		if len(f) != 0 {
+			t.Errorf("expected no finding for %q when docker.io is allowlisted, got %d", ref, len(f))
+		}
+	}
+}
+
+func TestGL065_DockerHubAliasNamespacePrefix(t *testing.T) {
+	clean := findings065(t, `
+build:
+  image: index.docker.io/myorg/app:1.0.0
+`, []string{"docker.io/myorg"})
+	if len(clean) != 0 {
+		t.Errorf("expected no finding for index.docker.io/myorg under docker.io/myorg, got %d", len(clean))
+	}
+}
+
+func TestGL065_DockerHubAliasStillFlaggedWhenNotAllowed(t *testing.T) {
+	f := findings065(t, `
+build:
+  image: index.docker.io/library/node:20
+`, []string{"registry.example.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for index.docker.io when only registry.example.com allowed, got %d", len(f))
+	}
+	if got := f[0].Message; !strings.Contains(got, `registry "docker.io"`) {
+		t.Errorf("expected folded host docker.io in message, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes #343.

## What changed

`normalizeRegistry` now folds the canonical Docker Hub hostnames `index.docker.io` and `registry-1.docker.io` to `docker.io`. Previously they were treated as distinct hosts, so an `allowed_registries: [docker.io]` allowlist false-positived on legitimate images pulled via those aliases:

```yaml
# allowed_registries: [docker.io]
build:
  image: index.docker.io/library/node:20   # was flagged, now allowed
```

## Why

`index.docker.io` and `registry-1.docker.io` are the official Docker Hub registry hostnames — the same registry as the implicit `docker.io`. Folding them removes a false positive when Docker Hub is on the allowlist, without weakening the check.

## Behaviour preserved

- The folded host is reported as `docker.io`, so namespace allowlist entries still work: `index.docker.io/myorg/app` matches `docker.io/myorg`.
- A Docker Hub alias is **still flagged** when Docker Hub is not allowlisted (e.g. only `registry.example.com` allowed) — folding only changes the host label, not whether it matches.
- No-op when `allowed_registries` is unset (unchanged).

## How to test

```sh
go test ./rules/ -run TestGL065
```

New tests cover both aliases folding to `docker.io`, alias namespace-prefix matching, and an alias still being flagged when Docker Hub is not on the allowlist.

Verified locally: `go test ./...`, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml`, `golangci-lint run ./...` (0 issues). Dogfooded: with `allowed_registries: [docker.io]`, `index.docker.io/library/node:20` is now clean while `quay.io/org/tool` still fires.