### PR TITLE
Add GL075: opt-in allowlist for include sources (project / component / remote)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-74 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+75 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070, GL073 |
-| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072 |
+| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074 |

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -148,6 +148,7 @@ func main() {
 
 	rules.GL016.SetTrustedHosts(cfg.TrustedHosts)
 	rules.GL065.SetAllowedRegistries(cfg.AllowedRegistries)
+	rules.GL075.SetAllowedIncludeSources(cfg.AllowedIncludeSources)
 
 	// --gitlab-version flag overrides the config file value.
 	gitlabVersionStr := cfg.GitLabVersion

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -53,6 +53,7 @@ Mutable references that allow silent substitution of images, templates, or packa
 | [GL064](rules/GL064.md) | `warn`  | `include: component:` path is one edit from a popular component under a different namespace (typosquat) |
 | [GL069](rules/GL069.md) | `warn`  | Package signature/auth verification bypassed (`apt --allow-unauthenticated`, `[trusted=yes]`, `apk --allow-untrusted`) |
 | [GL072](rules/GL072.md) | `warn`  | `needs:project` cross-project artifact download with a mutable branch or variable `ref:` — the consumed artifacts can be poisoned |
+| [GL075](rules/GL075.md) | `warn`  | `include:` source (project / component / remote) not on the opt-in `allowed_include_sources` allowlist — provenance check complementing GL003's pinning |
 
 ---
 
@@ -140,7 +141,7 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 
 | ASVS requirement | Rules |
 |---|---|
-| V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016, GL065, GL067 |
+| V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016, GL065, GL067, GL075 |
 | V14.2.2 — Components up to date and pinned | GL001, GL022, GL023, GL026, GL041 |
 | V14.2.3 — Dependencies verified for integrity | GL020 |
 | V14.3.1 — Pipeline config protected from modification | GL003, GL019 |

--- a/docs/rules/GL075.md
+++ b/docs/rules/GL075.md
@@ -1,0 +1,50 @@
+# GL075 — `include:` source not on the allowlist
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
+
+## What glsec checks
+
+GL075 is an **opt-in** allowlist for the *provenance* of `include:` sources. When you configure `allowed_include_sources`, glsec flags any [`include:project`](https://docs.gitlab.com/ci/yaml/#includeproject), [`include:component`](https://docs.gitlab.com/ci/yaml/#includecomponent), or [`include:remote`](https://docs.gitlab.com/ci/yaml/#includeremote) whose source is **not** on the list.
+
+Included configuration runs with full pipeline privileges, so an include from an untrusted project, component, or host is a direct config-injection / supply-chain vector. [GL003](GL003.md) and [GL041](GL041.md) check that includes are *pinned* (immutable ref); GL075 complements them by checking *where the include comes from*. A pinned include from an attacker-controlled namespace is clean under GL003 but flagged here:
+
+```yaml
+include:
+  - project: attacker-group/evil-ci
+    ref: 1111111111111111111111111111111111111111   # pinned, but untrusted source
+    file: /pipeline.yml
+```
+
+## Configuration
+
+```yaml
+# .glsec.yml
+allowed_include_sources:
+  - my-group                       # any project under the my-group namespace
+  - my-group/ci-templates          # an exact project
+  - gitlab.com/trusted-components  # a component host/namespace prefix
+  - templates.example.com          # a remote host
+```
+
+Matching mirrors `allowed_registries` (GL065):
+
+- An entry **without** a `/` matches by the first path segment — the project namespace, the component host, or the remote host.
+- An entry **with** a `/` matches as a host/namespace **prefix** (so `my-group/ci-templates` allows `my-group/ci-templates` but not `my-group/other`).
+
+## What is not flagged
+
+- **No-op when unset** — without `allowed_include_sources`, nothing is flagged.
+- `include:local` and `include:template` — in-repo and GitLab-provided sources, not external.
+- Variable-expanded sources (`project: $TEMPLATE_PROJECT`, `remote: https://$HOST/ci.yml`) cannot be resolved statically.
+
+## Safe alternative
+
+Pull pipeline configuration only from namespaces, components, and hosts you control or trust, and list them in `allowed_include_sources`.
+
+## References
+
+- [GitLab: `include:project`](https://docs.gitlab.com/ci/yaml/#includeproject)
+- [GitLab: `include:component`](https://docs.gitlab.com/ci/yaml/#includecomponent)
+- [GitLab: `include:remote`](https://docs.gitlab.com/ci/yaml/#includeremote)
+- GL003: `include:` with a mutable or missing ref · GL065: `allowed_registries` (sibling allowlist)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,11 @@ type Config struct {
 	// host/namespace prefixes). When non-empty, GL065 flags any image/service
 	// from a registry not on the list. Empty disables the check.
 	AllowedRegistries []string `yaml:"allowed_registries"`
+	// AllowedIncludeSources is an opt-in allowlist of include sources (project
+	// namespaces, component hosts/paths, or remote hosts). When non-empty, GL075
+	// flags any include:project / include:component / include:remote whose source
+	// is not on the list. Empty disables the check.
+	AllowedIncludeSources []string `yaml:"allowed_include_sources"`
 	// ShellCheck holds optional ShellCheck integration settings.
 	ShellCheck ShellCheckConfig `yaml:"shellcheck"`
 	// Strict makes warn findings count as errors for exit-code purposes.
@@ -155,17 +160,18 @@ func parse(data []byte, path string) (*Config, error) {
 }
 
 var allowedTopLevelKeys = map[string]bool{
-	"rules":              true,
-	"min-severity":       true,
-	"gitlab-version":     true,
-	"trusted-hosts":      true,
-	"allowed_registries": true,
-	"strict":             true,
-	"no-exit-codes":      true,
-	"exclude_paths":      true,
-	"owasp":              true,
-	"owasp_exclude":      true,
-	"shellcheck":         true,
+	"rules":                   true,
+	"min-severity":            true,
+	"gitlab-version":          true,
+	"trusted-hosts":           true,
+	"allowed_registries":      true,
+	"allowed_include_sources": true,
+	"strict":                  true,
+	"no-exit-codes":           true,
+	"exclude_paths":           true,
+	"owasp":                   true,
+	"owasp_exclude":           true,
+	"shellcheck":              true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {

--- a/rules/all.go
+++ b/rules/all.go
@@ -78,5 +78,6 @@ func All() []rule.Rule {
 		GL072,
 		GL073,
 		GL074,
+		GL075,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -50,6 +50,7 @@ var asvsRequirements = map[string][]string{
 	"GL066": {"ASVS-V14.3.3"},
 	"GL067": {"ASVS-V14.2.1"},
 	"GL068": {"ASVS-V14.3.3"},
+	"GL075": {"ASVS-V14.2.1"},
 }
 
 // asvsRequirementNames maps an ASVS requirement ID to its short description.

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -76,6 +76,7 @@ var cweIDs = map[string]string{
 	"GL072": "CWE-829",
 	"GL073": "CWE-538",
 	"GL074": "CWE-691",
+	"GL075": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl075.go
+++ b/rules/gl075.go
@@ -1,0 +1,133 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl075 struct {
+	allowedSources []string
+}
+
+var GL075 = &gl075{}
+
+func (r *gl075) ID() string { return "GL075" }
+
+// SetAllowedIncludeSources configures the opt-in include-source allowlist. When
+// empty, the rule is a no-op and flags nothing (so the default behaviour does
+// not complain about every include).
+func (r *gl075) SetAllowedIncludeSources(sources []string) {
+	r.allowedSources = sources
+}
+
+func (r *gl075) Check(doc *yaml.Node, file string) []finding.Finding {
+	if len(r.allowedSources) == 0 {
+		return nil
+	}
+
+	mapping := parser.Unwrap(doc)
+	includeNode := parser.FindKey(mapping, "include")
+	if includeNode == nil {
+		return nil
+	}
+
+	var findings []finding.Finding
+	switch includeNode.Kind {
+	case yaml.SequenceNode:
+		for _, item := range includeNode.Content {
+			if item.Kind == yaml.MappingNode {
+				findings = append(findings, r.checkIncludeItem(item, file)...)
+			}
+		}
+	case yaml.MappingNode:
+		findings = append(findings, r.checkIncludeItem(includeNode, file)...)
+	}
+	return findings
+}
+
+func (r *gl075) checkIncludeItem(node *yaml.Node, file string) []finding.Finding {
+	if remote := parser.FindKey(node, "remote"); remote != nil {
+		host, normalized := remoteIncludeSource(remote.Value)
+		return r.flagIfDisallowed(remote, file, host, normalized,
+			"remote include %q is from a host not in the allowed_include_sources allowlist")
+	}
+	if component := parser.FindKey(node, "component"); component != nil {
+		host, normalized := componentIncludeSource(component.Value)
+		return r.flagIfDisallowed(component, file, host, normalized,
+			"component include %q is from a source not in the allowed_include_sources allowlist")
+	}
+	if project := parser.FindKey(node, "project"); project != nil {
+		host, normalized := projectIncludeSource(project.Value)
+		return r.flagIfDisallowed(project, file, host, normalized,
+			"project include %q is from a namespace not in the allowed_include_sources allowlist")
+	}
+	// local: and template: are not external sources.
+	return nil
+}
+
+func (r *gl075) flagIfDisallowed(node *yaml.Node, file, host, normalized, msgFmt string) []finding.Finding {
+	// Empty or variable-expanded sources cannot be resolved statically.
+	if host == "" || strings.Contains(normalized, "$") {
+		return nil
+	}
+	if registryAllowed(host, normalized, r.allowedSources) {
+		return nil
+	}
+	return []finding.Finding{{
+		RuleID:   "GL075",
+		Severity: finding.Warn,
+		Message:  fmt.Sprintf(msgFmt, node.Value),
+		File:     file,
+		Line:     node.Line,
+		Col:      node.Column,
+	}}
+}
+
+// projectIncludeSource maps "my-group/sub/project" to (namespace, fullPath).
+func projectIncludeSource(value string) (host, normalized string) {
+	if value == "" {
+		return "", ""
+	}
+	return strings.ToLower(firstPathSegment(value)), strings.ToLower(value)
+}
+
+// componentIncludeSource maps "gitlab.com/org/comp@1.0" to (host, host/path).
+func componentIncludeSource(value string) (host, normalized string) {
+	if value == "" {
+		return "", ""
+	}
+	src := value
+	if at := strings.LastIndex(src, "@"); at >= 0 {
+		src = src[:at]
+	}
+	return strings.ToLower(firstPathSegment(src)), strings.ToLower(src)
+}
+
+// remoteIncludeSource maps "https://host/path/file.yml" to (host, host/path).
+func remoteIncludeSource(value string) (host, normalized string) {
+	s := value
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if s == "" {
+		return "", ""
+	}
+	// drop query string / fragment
+	if q := strings.IndexAny(s, "?#"); q >= 0 {
+		s = s[:q]
+	}
+	s = strings.ToLower(s)
+	host = firstPathSegment(s)
+	return host, s
+}
+
+func firstPathSegment(path string) string {
+	if i := strings.Index(path, "/"); i >= 0 {
+		return path[:i]
+	}
+	return path
+}

--- a/rules/gl075_test.go
+++ b/rules/gl075_test.go
@@ -1,0 +1,198 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings075(t *testing.T, yaml string, allowed []string) []finding.Finding {
+	t.Helper()
+	r := &gl075{allowedSources: allowed}
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return r.Check(doc.Root, "test.yml")
+}
+
+func TestGL075_NoOpWhenUnset(t *testing.T) {
+	f := findings075(t, `
+include:
+  - project: other-group/evil
+    ref: 1111111111111111111111111111111111111111
+    file: /ci.yml
+`, nil)
+	if len(f) != 0 {
+		t.Errorf("expected no findings when allowlist is empty, got %d", len(f))
+	}
+}
+
+func TestGL075_ProjectDisallowed(t *testing.T) {
+	f := findings075(t, `
+include:
+  - project: other-group/evil
+    ref: 1111111111111111111111111111111111111111
+    file: /ci.yml
+`, []string{"my-group"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for untrusted project namespace, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn, got %s", f[0].Severity)
+	}
+	if !strings.Contains(f[0].Message, "other-group/evil") {
+		t.Errorf("expected project path in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL075_ProjectAllowedByNamespace(t *testing.T) {
+	f := findings075(t, `
+include:
+  - project: my-group/sub/ci-templates
+    ref: 1111111111111111111111111111111111111111
+    file: /ci.yml
+`, []string{"my-group"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for allowed namespace, got %d", len(f))
+	}
+}
+
+func TestGL075_ProjectAllowedByExactPath(t *testing.T) {
+	f := findings075(t, `
+include:
+  - project: my-group/ci-templates
+    ref: 1111111111111111111111111111111111111111
+    file: /ci.yml
+`, []string{"my-group/ci-templates"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for exact allowed path, got %d", len(f))
+	}
+}
+
+func TestGL075_NamespaceNotSubstring(t *testing.T) {
+	f := findings075(t, `
+include:
+  - project: my-group-evil/x
+    ref: 1111111111111111111111111111111111111111
+    file: /ci.yml
+`, []string{"my-group"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding — my-group-evil is not my-group, got %d", len(f))
+	}
+}
+
+func TestGL075_RemoteDisallowed(t *testing.T) {
+	f := findings075(t, `
+include:
+  - remote: https://untrusted.example.com/ci.yml
+`, []string{"gitlab.com"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for untrusted remote host, got %d", len(f))
+	}
+}
+
+func TestGL075_RemoteAllowedByHost(t *testing.T) {
+	f := findings075(t, `
+include:
+  - remote: https://gitlab.com/group/proj/-/raw/main/ci.yml
+`, []string{"gitlab.com"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for allowed remote host, got %d", len(f))
+	}
+}
+
+func TestGL075_RemoteAllowedByHostPathPrefix(t *testing.T) {
+	clean := findings075(t, `
+include:
+  - remote: https://cdn.example.com/ci/templates/build.yml
+`, []string{"cdn.example.com/ci"})
+	if len(clean) != 0 {
+		t.Errorf("expected no finding for allowed host/path prefix, got %d", len(clean))
+	}
+	flagged := findings075(t, `
+include:
+  - remote: https://cdn.example.com/other/build.yml
+`, []string{"cdn.example.com/ci"})
+	if len(flagged) != 1 {
+		t.Fatalf("expected 1 finding for path outside allowed prefix, got %d", len(flagged))
+	}
+}
+
+func TestGL075_ComponentDisallowed(t *testing.T) {
+	f := findings075(t, `
+include:
+  - component: gitlab.com/evil-org/comp@1.0
+`, []string{"gitlab.com/trusted"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for untrusted component source, got %d", len(f))
+	}
+}
+
+func TestGL075_ComponentAllowed(t *testing.T) {
+	f := findings075(t, `
+include:
+  - component: gitlab.com/trusted/comp@1.0
+`, []string{"gitlab.com/trusted"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for allowed component source, got %d", len(f))
+	}
+}
+
+func TestGL075_ComponentAllowedByHost(t *testing.T) {
+	f := findings075(t, `
+include:
+  - component: gitlab.com/any-org/comp@1.0
+`, []string{"gitlab.com"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding when whole component host is allowed, got %d", len(f))
+	}
+}
+
+func TestGL075_VariableSourceExempt(t *testing.T) {
+	f := findings075(t, `
+include:
+  - project: $TEMPLATE_PROJECT
+    ref: 1111111111111111111111111111111111111111
+    file: /ci.yml
+  - remote: https://$HOST/ci.yml
+`, []string{"my-group"})
+	if len(f) != 0 {
+		t.Errorf("expected no findings for variable-expanded sources, got %d", len(f))
+	}
+}
+
+func TestGL075_LocalAndTemplateIgnored(t *testing.T) {
+	f := findings075(t, `
+include:
+  - local: /ci/build.yml
+  - template: Security/SAST.gitlab-ci.yml
+`, []string{"my-group"})
+	if len(f) != 0 {
+		t.Errorf("expected no findings for local/template includes, got %d", len(f))
+	}
+}
+
+func TestGL075_SingleMappingForm(t *testing.T) {
+	f := findings075(t, `
+include:
+  project: other-group/evil
+  ref: 1111111111111111111111111111111111111111
+  file: /ci.yml
+`, []string{"my-group"})
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for single-mapping include form, got %d", len(f))
+	}
+}
+
+func TestGL075_NoInclude_NoFinding(t *testing.T) {
+	f := findings075(t, `
+build:
+  script: [make]
+`, []string{"my-group"})
+	if len(f) != 0 {
+		t.Errorf("expected no findings without include:, got %d", len(f))
+	}
+}

--- a/rules/main_test.go
+++ b/rules/main_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 )
 
-// TestMain configures the global GL065 singleton with an allowlist so its
-// fixture fires in TestRuleConsistency. GL065 is config-gated (a no-op without
-// an allowlist), and the consistency check exercises the global singleton.
-// Unit tests use their own local gl065 instances and are unaffected.
+// TestMain configures the config-gated global singletons (GL065, GL075) with an
+// allowlist so their fixtures fire in TestRuleConsistency. These rules are a
+// no-op without an allowlist, and the consistency check exercises the global
+// singletons. Unit tests use their own local instances and are unaffected.
 func TestMain(m *testing.M) {
 	GL065.SetAllowedRegistries([]string{"registry.example.com", "ghcr.io/myorg"})
+	GL075.SetAllowedIncludeSources([]string{"my-group", "gitlab.com/trusted-components"})
 	os.Exit(m.Run())
 }

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -77,6 +77,7 @@ var owaspCategories = map[string][]string{
 	"GL072": {"CICD-SEC-3"},
 	"GL073": {"CICD-SEC-6"},
 	"GL074": {"CICD-SEC-1"},
+	"GL075": {"CICD-SEC-3"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl075-untrusted-include-source.yml
+++ b/testdata/fixtures/gl075-untrusted-include-source.yml
@@ -1,0 +1,13 @@
+include:
+  - project: other-group/evil-ci
+    ref: 1111111111111111111111111111111111111111
+    file: /pipeline.yml
+  - project: my-group/ci-templates
+    ref: 2222222222222222222222222222222222222222
+    file: /build.yml
+  - component: gitlab.com/untrusted-org/scan@1.0.0
+
+build:
+  stage: build
+  script:
+    - make

--- a/testdata/fixtures/gl075-untrusted-include-source.yml
+++ b/testdata/fixtures/gl075-untrusted-include-source.yml
@@ -1,9 +1,9 @@
 include:
   - project: other-group/evil-ci
-    ref: 1111111111111111111111111111111111111111
+    ref: 3fa92b1c4d5e6f7081920a1b2c3d4e5f60718293
     file: /pipeline.yml
   - project: my-group/ci-templates
-    ref: 2222222222222222222222222222222222222222
+    ref: a1b2c3d4e5f60718293a4b5c6d7e8f9001122334
     file: /build.yml
   - component: gitlab.com/untrusted-org/scan@1.0.0
 


### PR DESCRIPTION
Closes #344.

## What changed

New **opt-in** rule **GL075** checks the *provenance* of `include:` sources. When `allowed_include_sources` is configured, glsec flags any `include:project`, `include:component`, or `include:remote` whose source is not on the list.

glsec already checks that includes are *pinned* (GL003 mutable/missing ref, GL041 component pinning), but never *where they come from*. A pinned include from an attacker-controlled namespace is clean today:

```yaml
include:
  - project: attacker-group/evil-ci
    ref: 3fa92b1c4d5e6f7081920a1b2c3d4e5f60718293   # pinned, but untrusted source
    file: /pipeline.yml
```

Included config runs with full pipeline privileges, so this is a direct config-injection / supply-chain vector. GL075 covers provenance; GL003/GL041 cover mutability.

## Configuration

```yaml
# .glsec.yml
allowed_include_sources:
  - my-group                       # any project under the namespace
  - my-group/ci-templates          # an exact project
  - gitlab.com/trusted-components  # a component host/namespace prefix
  - templates.example.com          # a remote host
```

Matching mirrors `allowed_registries` (GL065): an entry without `/` matches the first path segment (project namespace, component host, remote host); an entry with `/` matches as a host/namespace prefix.

## Not flagged

- **No-op when `allowed_include_sources` is unset** — no false positives by default (same design as GL065).
- `include:local` and `include:template` — not external sources.
- Variable-expanded sources (`project: $TEMPLATE_PROJECT`, `remote: https://$HOST/...`) — not statically resolvable.

## Wiring

- New config key `allowed_include_sources` (`internal/config/config.go`, registered in `allowedTopLevelKeys`).
- `cmd/glsec/main.go` calls `rules.GL075.SetAllowedIncludeSources(cfg.AllowedIncludeSources)`.
- OWASP CICD-SEC-3 · CWE-829 · ASVS V14.2.1 (same mapping as GL003/GL065).

## How to test

```sh
go test ./rules/ -run TestGL075
printf 'allowed_include_sources:\n  - my-group\n' > /tmp/c.yml
glsec --config=/tmp/c.yml testdata/fixtures/gl075-untrusted-include-source.yml
```

The fixture flags the `other-group` project and the untrusted `gitlab.com/untrusted-org` component, and stays silent on `my-group/ci-templates`. Without a config it produces nothing.

Verified locally: `go test ./...`, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml`, `golangci-lint run ./...` (0 issues).