### PR TITLE
docs: bump README version refs to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.7.0
+    rev: v1.8.0
     hooks:
       - id: glsec
 ```
@@ -312,13 +312,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.7.0
+    name: ghcr.io/glsec/glsec:1.8.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.7.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.8.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -326,7 +326,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.7.0"
+  GLSEC_VERSION: "1.8.0"
 
 glsec:
   stage: test
@@ -348,7 +348,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.7.0
+    name: ghcr.io/glsec/glsec:1.8.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -367,7 +367,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.7.0
+    name: ghcr.io/glsec/glsec:1.8.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
Prepares the v1.8.0 release: bumps the glsec Docker image tag (`ghcr.io/glsec/glsec:1.7.0` → `:1.8.0`), the `GLSEC_VERSION` variable, and the pre-commit `rev` (`v1.7.0` → `v1.8.0`) in the README.

The GitLab CI Catalog component refs (`@v1.0.8`) are left unchanged — the catalog component follows a separate release cycle published on gitlab.com.

After merge, the `v1.8.0` tag is pushed to trigger the GoReleaser release workflow.

## v1.8.0 contents (since v1.7.0)

3 new rules + 3 rule extensions, all from the 2026-06-22 peer gap analysis:
- **GL073** — anonymous artifact exposure (`artifacts:public: true` / `artifacts:access: all`)
- **GL074** — tautological (always-true) `rules:if` conditions
- **GL075** — opt-in `allowed_include_sources` allowlist for `include:` provenance
- **GL042** — also flags `pip --trusted-host` (package-index TLS bypass)
- **GL013** — also detects production via `environment:deployment_tier`
- **GL065** — folds Docker Hub host aliases to `docker.io` (FP hardening)

Pre-release false-positive scan against ~200 real gitlab.com pipelines: clean — GL073 produced 2 true positives (`access: all`), the other new matchers produced no findings, no false positives.