### PR TITLE
fix: inject version ldflags into Docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,9 +35,17 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - name: Build date
+        id: date
+        run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ steps.date.outputs.date }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,12 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o glsec ./cmd/glsec
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+    -o glsec ./cmd/glsec
 
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
## Problem

`docker run ghcr.io/glsec/glsec:1.8.0 --version` reports `glsec dev (commit none, built unknown)` instead of the real version. The `Dockerfile` builds with `-ldflags="-s -w"` only — it never sets `-X main.version=...`, so `main.version` stays at its `"dev"` default. `resolvedVersion()`'s `debug.ReadBuildInfo()` fallback returns `(devel)` for a local `go build`, so the image label is always `dev`.

This affects every published image (v1.7.0 included), found while verifying the v1.8.0 release. The GoReleaser binaries (the `.tar.gz` release assets) are unaffected — they set the ldflags correctly.

## Fix

- `Dockerfile`: add `ARG VERSION/COMMIT/DATE` and pass them to the build via `-X main.version=... -X main.commit=... -X main.date=...`. Defaults keep a plain `docker build` working (`dev`/`none`/`unknown`).
- `docker.yml`: pass `build-args` from the metadata-action version (`{{version}}`), `github.sha`, and a build-date step.

## Verification

Built locally with the new Dockerfile:

```
$ docker build --build-arg VERSION=1.8.0 --build-arg COMMIT=$(git rev-parse --short HEAD) \
    --build-arg DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) -t glsec-verify:1.8.0 .
$ docker run --rm glsec-verify:1.8.0 --version
glsec 1.8.0 (commit 0757781, built 2026-06-22T11:08:20Z)
```