### PR TITLE
docs: bump catalog component refs to v1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.8
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.9
 
 stages:
   - test
@@ -285,7 +285,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.8
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.9
 
 stages:
   - test


### PR DESCRIPTION
Points the GitLab CI Catalog component examples in the README at the freshly published `@v1.0.9` (was `@v1.0.8`).

v1.0.9 of the catalog component (gitlab.com/glsec-io/glsec) defaults the glsec image to `1.8.0`, matching this release.