### PR TITLE
GL006: detect ghs_ App tokens and hyphenated OpenAI key variants

### DIFF
--- a/docs/rules/GL006.md
+++ b/docs/rules/GL006.md
@@ -17,9 +17,12 @@ glsec scans all `variables:` blocks (global, `default:`, and per-job) for scalar
 | PEM private key header | `-----BEGIN … PRIVATE KEY` |
 | GitHub PAT | `ghp_…` (36+ chars) |
 | GitHub fine-grained PAT | `github_pat_…` (82+ chars) |
+| GitHub App installation token | `ghs_…` (fixed-length and `ghs_<appid>_<jwt>` forms) |
 | Slack token | `xoxb-…` / `xoxp-…` / `xoxa-…` / `xoxs-…` / `xoxr-…` |
 | OpenAI API key | `sk-…` (32+ alphanum chars) |
 | OpenAI project API key | `sk-proj-…` (80+ chars) |
+| OpenAI service/admin API key | `sk-svcacct-…` / `sk-admin-…` / `sk-service-…` |
+| OpenAI realtime client secret | `ek_…` (32+ hex chars) |
 
 Values that are variable references (starting with `$`) are ignored.
 

--- a/rules/gl006.go
+++ b/rules/gl006.go
@@ -30,9 +30,14 @@ var secretPatterns = []secretPattern{
 	{"PEM private key", regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY`)},
 	{"GitHub PAT", regexp.MustCompile(`^ghp_[A-Za-z0-9]{36,}$`)},
 	{"GitHub fine-grained PAT", regexp.MustCompile(`^github_pat_[A-Za-z0-9_]{82,}$`)},
+	// Covers both the fixed-length ghs_<36+> form and the newer stateless
+	// ghs_<APPID>_<JWT> form (the JWT segment adds '.' separators).
+	{"GitHub App installation token", regexp.MustCompile(`^ghs_[A-Za-z0-9_.-]{36,}$`)},
 	{"Slack token", regexp.MustCompile(`^xox[baprs]-[A-Za-z0-9-]{10,}$`)},
 	{"OpenAI API key", regexp.MustCompile(`^sk-[A-Za-z0-9]{32,}$`)},
 	{"OpenAI project API key", regexp.MustCompile(`^sk-proj-[A-Za-z0-9_-]{80,}$`)},
+	{"OpenAI service/admin API key", regexp.MustCompile(`^sk-(?:svcacct|admin|service)-[A-Za-z0-9_-]{20,}$`)},
+	{"OpenAI realtime client secret", regexp.MustCompile(`^ek_[0-9a-f]{32,}$`)},
 }
 
 func (r *gl006) Check(doc *yaml.Node, file string) []finding.Finding {

--- a/rules/gl006_test.go
+++ b/rules/gl006_test.go
@@ -67,6 +67,45 @@ build:
 	}
 }
 
+func TestGL006_GitHubAppInstallationToken(t *testing.T) {
+	f := findings006(t, `
+variables:
+  GHS_FIXED: "ghs_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  GHS_STATELESS: "ghs_1234_eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiIxMjM0In0.c2lnbmF0dXJlLXBhcnQtaGVyZQ"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings for ghs_ tokens, got %d", len(f))
+	}
+}
+
+func TestGL006_OpenAIServiceAdminKey(t *testing.T) {
+	f := findings006(t, `
+variables:
+  SVC: "sk-svcacct-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  ADMIN: "sk-admin-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  SERVICE: "sk-service-myapp-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 3 {
+		t.Fatalf("expected 3 findings for OpenAI service/admin keys, got %d", len(f))
+	}
+}
+
+func TestGL006_OpenAIRealtimeSecret(t *testing.T) {
+	f := findings006(t, `
+variables:
+  RT: "ek_0123456789abcdef0123456789abcdef"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for OpenAI realtime client secret, got %d", len(f))
+	}
+}
+
 func TestGL006_SlackToken(t *testing.T) {
 	f := findings006(t, `
 variables:

--- a/testdata/fixtures/gl006-hardcoded-secrets.yml
+++ b/testdata/fixtures/gl006-hardcoded-secrets.yml
@@ -4,6 +4,9 @@ stages:
 variables:
   AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
   DEPLOY_TOKEN: "glpat-xxxxxxxxxxxxxxxxxxxx"
+  GH_APP_TOKEN: "ghs_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  OPENAI_SVC_KEY: "sk-svcacct-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  OPENAI_RT_SECRET: "ek_0123456789abcdef0123456789abcdef"
 
 deploy-job:
   stage: deploy


### PR DESCRIPTION
Closes #356.

## What changed

Extends the `secretPatterns` table in `rules/gl006.go` with three additional credential formats that previously slipped through GL006:

| Pattern | Regex | Notes |
|---------|-------|-------|
| GitHub App installation token | `^ghs_[A-Za-z0-9_.-]{36,}$` | Covers both the fixed-length `ghs_<36+>` form and the newer stateless `ghs_<appid>_<jwt>` form (the JWT segment adds `.` separators). |
| OpenAI service/admin API key | `^sk-(?:svcacct\|admin\|service)-[A-Za-z0-9_-]{20,}$` | The hyphenated role variants (`sk-svcacct-`, `sk-admin-`, `sk-service-<name>-`) that the anchored `^sk-[A-Za-z0-9]{32,}$` pattern could not match. |
| OpenAI realtime client secret | `^ek_[0-9a-f]{32,}$` | |

All additions are purely additive to the existing table. Prefixes stay specific and anchored to keep false-positive risk low. The `$VAR`-reference exemption (`strings.HasPrefix(v, "$")`) is unchanged.

## Why

These are high-value, long-lived credentials whose presence inline in `variables:` values is a real leak, and they are statically detectable — exactly what GL006 is for.

## How to test

- `go test ./...`
- `golangci-lint run ./...`
- `check-jsonschema --builtin-schema vendor.gitlab-ci testdata/fixtures/gl006-hardcoded-secrets.yml`

New unit tests cover each token shape; the `$VAR`-reference negative case is already covered by `TestGL006_VariableReference_NoFinding`. Fixture `gl006-hardcoded-secrets.yml` and the docs table in `docs/rules/GL006.md` were updated to match.

Note: the pre-release false-positive scan against the real-pipeline corpus should still run at release time as a gate before shipping.