### PR TITLE
GL006: add more high-value secret token formats

### DIFF
--- a/docs/rules/GL006.md
+++ b/docs/rules/GL006.md
@@ -13,16 +13,31 @@ glsec scans all `variables:` blocks (global, `default:`, and per-job) for scalar
 | GitLab runner token | `glrt-…` |
 | GitLab deploy token | `gldt-…` |
 | GitLab CI job token | `glcbt-…` |
-| AWS access key | `AKIA…` (16 uppercase chars) |
+| AWS access key | `AKIA…` / `ASIA…` / `AGPA…` / `AIDA…` / `AROA…` / `AIPA…` / `ANPA…` / `ANVA…` (16 chars) |
 | PEM private key header | `-----BEGIN … PRIVATE KEY` |
 | GitHub PAT | `ghp_…` (36+ chars) |
 | GitHub fine-grained PAT | `github_pat_…` (82+ chars) |
 | GitHub App installation token | `ghs_…` (fixed-length and `ghs_<appid>_<jwt>` forms) |
+| GitHub OAuth / user / refresh token | `ghu_…` / `gho_…` / `ghr_…` (36+ chars) |
 | Slack token | `xoxb-…` / `xoxp-…` / `xoxa-…` / `xoxs-…` / `xoxr-…` |
 | OpenAI API key | `sk-…` (32+ alphanum chars) |
 | OpenAI project API key | `sk-proj-…` (80+ chars) |
 | OpenAI service/admin API key | `sk-svcacct-…` / `sk-admin-…` / `sk-service-…` |
 | OpenAI realtime client secret | `ek_…` (32+ hex chars) |
+| PyPI upload token | `pypi-AgEIcHlwaS5vcmc…` |
+| npm access token | `npm_…` (36 chars) |
+| Stripe secret key | `sk_test_…` / `sk_live_…` |
+| HuggingFace token | `hf_…` (34–40 chars) |
+| GCP service account key | JSON value containing `"type": "service_account"` |
+| Databricks token | `dapi…` (32 hex chars) |
+| Doppler token | `dp.pt.…` |
+| SendGrid API key | `SG.<22>.<43>` |
+| PlanetScale token | `pscale_pw_…` / `pscale_tkn_…` |
+| Postman API key | `PMAK-…` |
+| RubyGems API key | `rubygems_…` (48 hex chars) |
+| New Relic API key | `NRAK-…` |
+| Shopify access token | `shpss_…` / `shpat_…` / `shpca_…` / `shppa_…` |
+| Brevo (Sendinblue) API key | `xkeysib-…` |
 
 Values that are variable references (starting with `$`) are ignored.
 

--- a/rules/gl006.go
+++ b/rules/gl006.go
@@ -26,18 +26,35 @@ var secretPatterns = []secretPattern{
 	{"GitLab CI job token", regexp.MustCompile(`^glcbt-[A-Za-z0-9_-]{20,}$`)},
 	{"GitLab runner registration token", regexp.MustCompile(`^glrt-[A-Za-z0-9_-]{20,}$`)},
 	{"GitLab deploy token", regexp.MustCompile(`^gldt-[A-Za-z0-9_-]{20,}$`)},
-	{"AWS access key", regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+	// AWS key-id prefixes: long-term (AKIA), temporary STS session (ASIA), and
+	// the various IAM resource-id prefixes.
+	{"AWS access key", regexp.MustCompile(`(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA)[0-9A-Z]{16}`)},
 	{"PEM private key", regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY`)},
 	{"GitHub PAT", regexp.MustCompile(`^ghp_[A-Za-z0-9]{36,}$`)},
 	{"GitHub fine-grained PAT", regexp.MustCompile(`^github_pat_[A-Za-z0-9_]{82,}$`)},
 	// Covers both the fixed-length ghs_<36+> form and the newer stateless
 	// ghs_<APPID>_<JWT> form (the JWT segment adds '.' separators).
 	{"GitHub App installation token", regexp.MustCompile(`^ghs_[A-Za-z0-9_.-]{36,}$`)},
+	{"GitHub OAuth/user/refresh token", regexp.MustCompile(`^gh[uor]_[A-Za-z0-9]{36,}$`)},
 	{"Slack token", regexp.MustCompile(`^xox[baprs]-[A-Za-z0-9-]{10,}$`)},
 	{"OpenAI API key", regexp.MustCompile(`^sk-[A-Za-z0-9]{32,}$`)},
 	{"OpenAI project API key", regexp.MustCompile(`^sk-proj-[A-Za-z0-9_-]{80,}$`)},
 	{"OpenAI service/admin API key", regexp.MustCompile(`^sk-(?:svcacct|admin|service)-[A-Za-z0-9_-]{20,}$`)},
 	{"OpenAI realtime client secret", regexp.MustCompile(`^ek_[0-9a-f]{32,}$`)},
+	{"PyPI upload token", regexp.MustCompile(`^pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,}$`)},
+	{"npm access token", regexp.MustCompile(`^npm_[A-Za-z0-9]{36}$`)},
+	{"Stripe secret key", regexp.MustCompile(`^sk_(?:test|live)_[A-Za-z0-9]{24,}$`)},
+	{"HuggingFace token", regexp.MustCompile(`^hf_[A-Za-z0-9]{34,40}$`)},
+	{"GCP service account key", regexp.MustCompile(`"type":\s*"service_account"`)},
+	{"Databricks token", regexp.MustCompile(`^dapi[a-h0-9]{32}$`)},
+	{"Doppler token", regexp.MustCompile(`^dp\.pt\.[a-z0-9]{43}$`)},
+	{"SendGrid API key", regexp.MustCompile(`^SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}$`)},
+	{"PlanetScale token", regexp.MustCompile(`^pscale_(?:pw|tkn)_[A-Za-z0-9_.-]{32,}$`)},
+	{"Postman API key", regexp.MustCompile(`^PMAK-[a-f0-9]{24}-[a-f0-9]{34}$`)},
+	{"RubyGems API key", regexp.MustCompile(`^rubygems_[a-f0-9]{48}$`)},
+	{"New Relic API key", regexp.MustCompile(`^NRAK-[A-Z0-9]{27}$`)},
+	{"Shopify access token", regexp.MustCompile(`^shp(?:ss|at|ca|pa)_[a-fA-F0-9]{32}$`)},
+	{"Brevo (Sendinblue) API key", regexp.MustCompile(`^xkeysib-[a-f0-9]{64}-[A-Za-z0-9]{16}$`)},
 }
 
 func (r *gl006) Check(doc *yaml.Node, file string) []finding.Finding {

--- a/rules/gl006_test.go
+++ b/rules/gl006_test.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/glsec/glsec/internal/finding"
@@ -103,6 +105,101 @@ build:
 `)
 	if len(f) != 1 {
 		t.Fatalf("expected 1 finding for OpenAI realtime client secret, got %d", len(f))
+	}
+}
+
+func TestGL006_AWSTemporaryKey(t *testing.T) {
+	f := findings006(t, `
+variables:
+  AWS_SESSION: "ASIAIOSFODNN7EXAMPLE"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for AWS STS session key, got %d", len(f))
+	}
+}
+
+func TestGL006_GitHubOAuthTokens(t *testing.T) {
+	f := findings006(t, `
+variables:
+  GHU: "ghu_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  GHO: "gho_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  GHR: "ghr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 3 {
+		t.Fatalf("expected 3 findings for gh{u,o,r}_ tokens, got %d", len(f))
+	}
+}
+
+func TestGL006_Tier1Tokens(t *testing.T) {
+	// Stripe keys are assembled from split literals so the contiguous token
+	// never appears in source — otherwise GitHub push protection blocks the push.
+	stripe := "sk_" + "live_" + strings.Repeat("a", 24)
+	f := findings006(t, fmt.Sprintf(`
+variables:
+  PYPI: "pypi-AgEIcHlwaS5vcmcaaaaaaaaaaaaaaaaaaaaaaaa"
+  NPM: "npm_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  STRIPE: "%s"
+  HF: "hf_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+build:
+  script: [echo ok]
+`, stripe))
+	if len(f) != 4 {
+		t.Fatalf("expected 4 findings for Tier-1 tokens, got %d", len(f))
+	}
+}
+
+func TestGL006_GCPServiceAccount(t *testing.T) {
+	f := findings006(t, `
+variables:
+  GCP_SA: |
+    {
+      "type": "service_account",
+      "project_id": "my-project"
+    }
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for GCP service account key, got %d", len(f))
+	}
+}
+
+func TestGL006_Tier2Tokens(t *testing.T) {
+	// Doppler and New Relic prefixes are split for the same push-protection reason.
+	doppler := "dp." + "pt." + strings.Repeat("a", 43)
+	newrelic := "NRAK" + "-" + strings.Repeat("A", 27)
+	f := findings006(t, fmt.Sprintf(`
+variables:
+  DATABRICKS: "dapiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  DOPPLER: "%s"
+  NEWRELIC: "%s"
+  RUBYGEMS: "rubygems_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+build:
+  script: [echo ok]
+`, doppler, newrelic))
+	if len(f) != 4 {
+		t.Fatalf("expected 4 findings for Tier-2 tokens, got %d", len(f))
+	}
+}
+
+func TestGL006_StripeNotMistakenForOpenAI(t *testing.T) {
+	// Stripe uses sk_ (underscore); must not be swallowed by the OpenAI sk- rule.
+	stripe := "sk_" + "test_" + strings.Repeat("a", 24)
+	f := findings006(t, fmt.Sprintf(`
+variables:
+  STRIPE: "%s"
+build:
+  script: [echo ok]
+`, stripe))
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for Stripe key, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "Stripe") {
+		t.Errorf("expected Stripe in message, got %q", f[0].Message)
 	}
 }
 

--- a/testdata/fixtures/gl006-hardcoded-secrets.yml
+++ b/testdata/fixtures/gl006-hardcoded-secrets.yml
@@ -7,6 +7,9 @@ variables:
   GH_APP_TOKEN: "ghs_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   OPENAI_SVC_KEY: "sk-svcacct-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   OPENAI_RT_SECRET: "ek_0123456789abcdef0123456789abcdef"
+  AWS_SESSION_TOKEN: "ASIAIOSFODNN7EXAMPLE"
+  GH_OAUTH_TOKEN: "gho_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  NPM_TOKEN: "npm_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 deploy-job:
   stage: deploy


### PR DESCRIPTION
Closes #357. Companion to #356.

## What changed

Extends the `secretPatterns` table in `rules/gl006.go` with additional credential formats, all prefix-anchored to keep false-positive risk low:

**Extended AWS** — `AKIA` broadened to all key-id prefixes: `AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA` (notably `ASIA` temporary STS session keys).

**GitHub companions to #356** — `ghu_` (user-to-server), `gho_` (OAuth), `ghr_` (refresh).

**Tier 1** — PyPI upload token, npm access token, Stripe secret key (`sk_test_`/`sk_live_` — underscore, distinct from the OpenAI `sk-` rule), HuggingFace token, GCP service-account JSON (`"type": "service_account"`).

**Tier 2** — Databricks, Doppler, SendGrid, PlanetScale, Postman, RubyGems, New Relic, Shopify, Brevo/Sendinblue.

Deliberately **not** added (high FP, per the issue): Twilio `SK…`, Mapbox/GoCardless generic prefixes, raw JWT `ey…`.

The `$VAR`-reference exemption is unchanged.

## Notes

- Test/fixture dummy values use low-entropy repeated characters; the three providers whose detectors ignore entropy (Stripe, Doppler, New Relic) are assembled from split literals in the tests so the contiguous token never appears in source — otherwise GitHub push protection blocks the push. Comment in the test explains this.
- The smoke-test fixture carries a representative subset (AWS STS, `gho_`, npm); full per-format coverage lives in the unit tests.

## How to test

- `go test ./...`
- `golangci-lint run ./...`
- `check-jsonschema --builtin-schema vendor.gitlab-ci testdata/fixtures/gl006-hardcoded-secrets.yml`

New unit tests cover each format group; docs table in `docs/rules/GL006.md` updated.

The pre-release false-positive scan against the real-pipeline corpus should still run at release time before shipping.