### PR TITLE
GL006: reduce false positives — OpenAI watermark + placeholder allowlist

### DIFF
--- a/docs/rules/GL006.md
+++ b/docs/rules/GL006.md
@@ -20,9 +20,11 @@ glsec scans all `variables:` blocks (global, `default:`, and per-job) for scalar
 | GitHub App installation token | `ghs_…` (fixed-length and `ghs_<appid>_<jwt>` forms) |
 | GitHub OAuth / user / refresh token | `ghu_…` / `gho_…` / `ghr_…` (36+ chars) |
 | Slack token | `xoxb-…` / `xoxp-…` / `xoxa-…` / `xoxs-…` / `xoxr-…` |
-| OpenAI API key | `sk-…` (32+ alphanum chars) |
-| OpenAI project API key | `sk-proj-…` (80+ chars) |
-| OpenAI service/admin API key | `sk-svcacct-…` / `sk-admin-…` / `sk-service-…` |
+| Anthropic API key | `sk-ant-…` |
+| OpenRouter API key | `sk-or-v1-…` |
+| OpenAI API key | `sk-…` containing the `T3BlbkFJ` watermark |
+| OpenAI project API key | `sk-proj-…` containing the `T3BlbkFJ` watermark |
+| OpenAI service/admin API key | `sk-svcacct-…` / `sk-admin-…` / `sk-service-…` containing the `T3BlbkFJ` watermark |
 | OpenAI realtime client secret | `ek_…` (32+ hex chars) |
 | PyPI upload token | `pypi-AgEIcHlwaS5vcmc…` |
 | npm access token | `npm_…` (36 chars) |
@@ -39,7 +41,10 @@ glsec scans all `variables:` blocks (global, `default:`, and per-job) for scalar
 | Shopify access token | `shpss_…` / `shpat_…` / `shpca_…` / `shppa_…` |
 | Brevo (Sendinblue) API key | `xkeysib-…` |
 
-Values that are variable references (starting with `$`) are ignored.
+Values that are variable references (starting with `$`) are ignored. Obvious
+documentation placeholders are also skipped: a matched value is ignored when it
+contains `example`, `placeholder`, `changeme`, `redacted`, or `your-token-here`
+(case-insensitive) — for instance `AKIAIOSFODNN7EXAMPLE` or `glpat-your-token-here`.
 
 ## Trigger example
 

--- a/rules/gl006.go
+++ b/rules/gl006.go
@@ -37,9 +37,17 @@ var secretPatterns = []secretPattern{
 	{"GitHub App installation token", regexp.MustCompile(`^ghs_[A-Za-z0-9_.-]{36,}$`)},
 	{"GitHub OAuth/user/refresh token", regexp.MustCompile(`^gh[uor]_[A-Za-z0-9]{36,}$`)},
 	{"Slack token", regexp.MustCompile(`^xox[baprs]-[A-Za-z0-9-]{10,}$`)},
-	{"OpenAI API key", regexp.MustCompile(`^sk-[A-Za-z0-9]{32,}$`)},
-	{"OpenAI project API key", regexp.MustCompile(`^sk-proj-[A-Za-z0-9_-]{80,}$`)},
-	{"OpenAI service/admin API key", regexp.MustCompile(`^sk-(?:svcacct|admin|service)-[A-Za-z0-9_-]{20,}$`)},
+	// Anthropic and OpenRouter reuse the sk- prefix but carry no OpenAI
+	// watermark; match them by their specific prefixes so they are labelled
+	// correctly instead of being reported as OpenAI keys.
+	{"Anthropic API key", regexp.MustCompile(`^sk-ant-[A-Za-z0-9_-]{20,}$`)},
+	{"OpenRouter API key", regexp.MustCompile(`^sk-or-v1-[A-Za-z0-9]{20,}$`)},
+	// Modern OpenAI keys embed the fixed watermark T3BlbkFJ (base64 of "OpenAI")
+	// between two random segments. Requiring it cuts false positives from
+	// arbitrary sk-… strings and avoids mislabelling other vendors' keys.
+	{"OpenAI project API key", regexp.MustCompile(`^sk-proj-[A-Za-z0-9_-]{8,}T3BlbkFJ[A-Za-z0-9_-]{8,}$`)},
+	{"OpenAI service/admin API key", regexp.MustCompile(`^sk-(?:svcacct|admin|service)-[A-Za-z0-9_-]{8,}T3BlbkFJ[A-Za-z0-9_-]{8,}$`)},
+	{"OpenAI API key", regexp.MustCompile(`^sk-[A-Za-z0-9]{8,}T3BlbkFJ[A-Za-z0-9]{8,}$`)},
 	{"OpenAI realtime client secret", regexp.MustCompile(`^ek_[0-9a-f]{32,}$`)},
 	{"PyPI upload token", regexp.MustCompile(`^pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,}$`)},
 	{"npm access token", regexp.MustCompile(`^npm_[A-Za-z0-9]{36}$`)},
@@ -106,9 +114,25 @@ func checkVariablesNode(node *yaml.Node, file string) []finding.Finding {
 	return findings
 }
 
+// placeholderMarkers are substrings (matched case-insensitively) that mark a
+// value as an obvious documentation/template placeholder rather than a real
+// secret, e.g. "glpat-EXAMPLE…" or "AKIA…EXAMPLE…". A matched value containing
+// one of these is skipped to avoid firing on example configs.
+var placeholderMarkers = []string{"example", "placeholder", "changeme", "redacted", "your-token-here", "your_token_here"}
+
+func looksLikePlaceholder(v string) bool {
+	lower := strings.ToLower(v)
+	for _, m := range placeholderMarkers {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	return false
+}
+
 func checkSecretValue(node *yaml.Node, varName, file string) *finding.Finding {
 	v := node.Value
-	if v == "" || strings.HasPrefix(v, "$") {
+	if v == "" || strings.HasPrefix(v, "$") || looksLikePlaceholder(v) {
 		return nil
 	}
 	for _, pat := range secretPatterns {

--- a/rules/gl006_test.go
+++ b/rules/gl006_test.go
@@ -34,12 +34,15 @@ build:
 }
 
 func TestGL006_AWSAccessKey(t *testing.T) {
-	f := findings006(t, `
+	// Split literal so the contiguous key never appears in source (push protection);
+	// a non-"example" value so the placeholder allowlist does not suppress it.
+	key := "AKIA" + strings.Repeat("Q", 16)
+	f := findings006(t, fmt.Sprintf(`
 variables:
-  AWS_SECRET: "AKIAIOSFODNN7EXAMPLE"
+  AWS_SECRET: "%s"
 build:
   script: [echo ok]
-`)
+`, key))
 	if len(f) != 1 {
 		t.Fatalf("expected 1 finding for AWS key, got %d", len(f))
 	}
@@ -83,14 +86,20 @@ build:
 }
 
 func TestGL006_OpenAIServiceAdminKey(t *testing.T) {
-	f := findings006(t, `
+	// wm is the OpenAI watermark, split so the marker is not contiguous in source.
+	wm := "T3Blbk" + "FJ"
+	body := strings.Repeat("a", 12)
+	svc := "sk-svcacct-" + body + wm + body
+	admin := "sk-admin-" + body + wm + body
+	service := "sk-service-myapp-" + body + wm + body
+	f := findings006(t, fmt.Sprintf(`
 variables:
-  SVC: "sk-svcacct-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  ADMIN: "sk-admin-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  SERVICE: "sk-service-myapp-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  SVC: "%s"
+  ADMIN: "%s"
+  SERVICE: "%s"
 build:
   script: [echo ok]
-`)
+`, svc, admin, service))
 	if len(f) != 3 {
 		t.Fatalf("expected 3 findings for OpenAI service/admin keys, got %d", len(f))
 	}
@@ -109,12 +118,13 @@ build:
 }
 
 func TestGL006_AWSTemporaryKey(t *testing.T) {
-	f := findings006(t, `
+	key := "ASIA" + strings.Repeat("Q", 16)
+	f := findings006(t, fmt.Sprintf(`
 variables:
-  AWS_SESSION: "ASIAIOSFODNN7EXAMPLE"
+  AWS_SESSION: "%s"
 build:
   script: [echo ok]
-`)
+`, key))
 	if len(f) != 1 {
 		t.Fatalf("expected 1 finding for AWS STS session key, got %d", len(f))
 	}
@@ -216,14 +226,89 @@ build:
 }
 
 func TestGL006_OpenAIProjectKey(t *testing.T) {
+	wm := "T3Blbk" + "FJ"
+	key := "sk-proj-" + strings.Repeat("a", 40) + wm + strings.Repeat("a", 40)
+	f := findings006(t, fmt.Sprintf(`
+variables:
+  OPENAI_KEY: "%s"
+build:
+  script: [echo ok]
+`, key))
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for OpenAI project API key, got %d", len(f))
+	}
+}
+
+func TestGL006_OpenAIKeyRequiresWatermark(t *testing.T) {
+	wm := "T3Blbk" + "FJ"
+	withMark := "sk-" + strings.Repeat("a", 20) + wm + strings.Repeat("a", 20)
+	f := findings006(t, fmt.Sprintf(`
+variables:
+  OPENAI_KEY: "%s"
+build:
+  script: [echo ok]
+`, withMark))
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for watermarked OpenAI key, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "OpenAI") {
+		t.Errorf("expected OpenAI in message, got %q", f[0].Message)
+	}
+
+	// Same shape without the watermark must not be reported as an OpenAI key.
+	noMark := "sk-" + strings.Repeat("a", 44)
+	f = findings006(t, fmt.Sprintf(`
+variables:
+  NOT_OPENAI: "%s"
+build:
+  script: [echo ok]
+`, noMark))
+	if len(f) != 0 {
+		t.Fatalf("expected no finding for sk- value without watermark, got %d", len(f))
+	}
+}
+
+func TestGL006_AnthropicKeyNotOpenAI(t *testing.T) {
 	f := findings006(t, `
 variables:
-  OPENAI_KEY: "sk-proj-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  ANTHROPIC_KEY: "sk-ant-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 build:
   script: [echo ok]
 `)
 	if len(f) != 1 {
-		t.Fatalf("expected 1 finding for OpenAI project API key, got %d", len(f))
+		t.Fatalf("expected 1 finding for Anthropic key, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "Anthropic") {
+		t.Errorf("expected Anthropic in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL006_OpenRouterKeyNotOpenAI(t *testing.T) {
+	f := findings006(t, `
+variables:
+  OPENROUTER_KEY: "sk-or-v1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for OpenRouter key, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "OpenRouter") {
+		t.Errorf("expected OpenRouter in message, got %q", f[0].Message)
+	}
+}
+
+func TestGL006_PlaceholderExample_NoFinding(t *testing.T) {
+	f := findings006(t, `
+variables:
+  AWS_SECRET: "AKIAIOSFODNN7EXAMPLE"
+  GL_PAT: "glpat-EXAMPLEEXAMPLEEXAMPLE12"
+  PLACEHOLDER: "glpat-your-token-here-000000"
+build:
+  script: [echo ok]
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for placeholder values, got %d", len(f))
 	}
 }
 
@@ -291,13 +376,14 @@ build:
 }
 
 func TestGL006_MultipleSecrets(t *testing.T) {
-	f := findings006(t, `
+	aws := "AKIA" + strings.Repeat("Q", 16)
+	f := findings006(t, fmt.Sprintf(`
 variables:
   PAT: "glpat-xxxxxxxxxxxxxxxxxxxx"
-  AWS: "AKIAIOSFODNN7EXAMPLE"
+  AWS: "%s"
 build:
   script: [echo ok]
-`)
+`, aws))
 	if len(f) != 2 {
 		t.Fatalf("expected 2 findings, got %d", len(f))
 	}

--- a/testdata/fixtures/gl006-hardcoded-secrets.yml
+++ b/testdata/fixtures/gl006-hardcoded-secrets.yml
@@ -2,12 +2,9 @@ stages:
   - deploy
 
 variables:
-  AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
   DEPLOY_TOKEN: "glpat-xxxxxxxxxxxxxxxxxxxx"
   GH_APP_TOKEN: "ghs_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  OPENAI_SVC_KEY: "sk-svcacct-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   OPENAI_RT_SECRET: "ek_0123456789abcdef0123456789abcdef"
-  AWS_SESSION_TOKEN: "ASIAIOSFODNN7EXAMPLE"
   GH_OAUTH_TOKEN: "gho_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   NPM_TOKEN: "npm_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 


### PR DESCRIPTION
Closes #358.

## What changed

Two false-positive hardening changes to GL006's secret detection.

### 1. Discriminate OpenAI keys by their embedded watermark

Modern OpenAI keys carry a fixed marker `T3BlbkFJ` (base64 of "OpenAI") between their two random segments. The OpenAI patterns now require it:

- `OpenAI API key` → `^sk-[A-Za-z0-9]{8,}T3BlbkFJ[A-Za-z0-9]{8,}$`
- `OpenAI project API key` → `^sk-proj-…T3BlbkFJ…$`
- `OpenAI service/admin API key` → `^sk-(svcacct|admin|service)-…T3BlbkFJ…$`

This cuts the FP surface (arbitrary 32+ char `sk-…` strings no longer match) and stops sibling vendors from being mislabelled as OpenAI. Anthropic (`sk-ant-…`) and OpenRouter (`sk-or-v1-…`) are now matched by their own prefixes and reported under their correct names. The realtime `ek_…` secret is unchanged.

### 2. Placeholder / example allowlist

A matched value is skipped when it looks like a documentation placeholder — contains `example`, `placeholder`, `changeme`, `redacted`, or `your-token-here` (case-insensitive). This stops GL006 firing on docs/template configs (e.g. `AKIAIOSFODNN7EXAMPLE`, `glpat-your-token-here`) without weakening real detection.

## Test / fixture adjustments

- The AWS positive tests previously used `AKIAIOSFODNN7EXAMPLE`, which is now (correctly) suppressed as a placeholder — they were switched to non-example values built via split literals.
- OpenAI test values now embed the watermark (split in source so the marker isn't contiguous — otherwise GitHub push protection blocks the push).
- New tests: watermark-required (with/without), Anthropic/OpenRouter not-as-OpenAI, and a placeholder-suppression case.
- The smoke-test fixture dropped the now-suppressed `…EXAMPLE` AWS values and the watermark-less svcacct key; remaining firing entries keep the rule covered.

## How to test

- `go test ./...`
- `golangci-lint run ./...`
- `check-jsonschema --builtin-schema vendor.gitlab-ci testdata/fixtures/gl006-hardcoded-secrets.yml`

Docs table in `docs/rules/GL006.md` updated with the watermark requirement, the Anthropic/OpenRouter rows, and the placeholder-allowlist note.

Note: requiring the watermark means legacy pre-2023 OpenAI keys (no watermark) are no longer matched — an intentional trade-off for the FP reduction. The pre-release FP scan against the real-pipeline corpus should still run at release time.