### PR TITLE
New rules: GL076 (--security-opt unconfined) and GL077 (--ipc host)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-75 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+77 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -162,7 +162,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074 |
-| Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063 |
+| Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063, GL076, GL077 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -129,6 +129,8 @@ Misconfigured CI settings that expand the attack surface or leak build context.
 | [GL058](rules/GL058.md) | `warn`  | `docker run --network host` removes network isolation from the runner host |
 | [GL060](rules/GL060.md) | `error`/`warn` | `docker run -v` mounts a sensitive host path (`/`, `/etc`, `/root`, `/proc`, `/sys`, …) breaking isolation |
 | [GL061](rules/GL061.md) | `warn`  | `docker run --pid host` shares the host PID namespace — container can see/signal all host processes |
+| [GL076](rules/GL076.md) | `warn`  | `docker run --security-opt seccomp=unconfined` / `apparmor=unconfined` disables kernel-level confinement — widens the escape surface without `--privileged` |
+| [GL077](rules/GL077.md) | `warn`  | `docker run --ipc host` shares the host IPC namespace — container can read host shared memory and signal host processes |
 | [GL063](rules/GL063.md) | `warn`  | `chmod` grants world-writable permissions (`777`, `a+w`, `o+w`) — TOCTOU risk on shared runners |
 
 ---

--- a/docs/rules/GL076.md
+++ b/docs/rules/GL076.md
@@ -1,0 +1,40 @@
+# GL076 — `docker run --security-opt seccomp=unconfined` / `apparmor=unconfined` in CI script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-653 – Improper Isolation or Compartmentalization](https://cwe.mitre.org/data/definitions/653.html)
+
+## Risk
+
+`--security-opt seccomp=unconfined` and `--security-opt apparmor=unconfined` disable the container's default seccomp or AppArmor profile. These profiles provide kernel-level confinement — seccomp filters the syscalls a container may issue, and AppArmor restricts file, capability, and network operations. Turning either off removes that restriction and widens the container-escape surface.
+
+This is **distinct from `--privileged` ([GL056](GL056.md))**: teams frequently reach for `--security-opt seccomp=unconfined` as the *lighter* alternative to full privilege (e.g. to run browsers, debuggers, or nested tooling), so a job can meaningfully weaken confinement while still passing GL056.
+
+## Trigger example
+
+```yaml
+test:
+  script:
+    - docker run --security-opt seccomp=unconfined myimage ./run.sh
+```
+
+Both `--security-opt seccomp=unconfined` and `--security-opt apparmor=unconfined` are detected, in space (`--security-opt seccomp=unconfined`) and `=` (`--security-opt=seccomp=unconfined`) forms.
+
+## Safe alternative
+
+Keep the default profile. If a specific syscall or behavior is genuinely required, supply a **scoped custom profile** that allows only what is needed rather than disabling confinement wholesale:
+
+```yaml
+test:
+  script:
+    - docker run --security-opt seccomp=./my-scoped-profile.json myimage ./run.sh
+```
+
+`--security-opt no-new-privileges` is a hardening option and is **not** flagged.
+
+## Notes
+
+- Severity is `warn`.
+- Related: [GL056](GL056.md) (`--privileged`), [GL057](GL057.md) (`--cap-add`), [GL077](GL077.md) (`--ipc host`).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL076`.

--- a/docs/rules/GL077.md
+++ b/docs/rules/GL077.md
@@ -1,0 +1,38 @@
+# GL077 — `docker run --ipc host` in CI script
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-7 – Insecure System Configuration](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-07-Insecure-System-Configuration)  
+**CWE:** [CWE-653 – Improper Isolation or Compartmentalization](https://cwe.mitre.org/data/definitions/653.html)
+
+## Risk
+
+`docker run --ipc host` makes the container share the host's IPC (inter-process communication) namespace. The container can then read and write the host's System V / POSIX shared memory segments and message queues, and signal host processes. On a shared runner this exposes the memory of other CI jobs and the runner agent, and provides another route to affect the host.
+
+It is the missing sibling of the namespace-sharing flags glsec already flags: [GL058](GL058.md) (`--network host`) and [GL061](GL061.md) (`--pid host`).
+
+## Trigger example
+
+```yaml
+test:
+  script:
+    - docker run --ipc host myimage ./run.sh
+```
+
+Both `--ipc host` and `--ipc=host` are detected.
+
+## Safe alternative
+
+Omit `--ipc` (the default is a private IPC namespace). If shared memory must be shared with another container — for example a sibling in the same job — scope it to that container rather than the host:
+
+```yaml
+test:
+  script:
+    - docker run --ipc container:abc123 myimage ./run.sh
+```
+
+## Notes
+
+- Severity is `warn`.
+- Related: [GL058](GL058.md) (`--network host`), [GL061](GL061.md) (`--pid host`), [GL076](GL076.md) (`--security-opt …=unconfined`).
+- Script-line rule; assumes POSIX shell (see the README *Shell assumptions* note).
+- Suppress per-file with `.glsec-ignore` or inline `# glsec:ignore GL077`.

--- a/rules/all.go
+++ b/rules/all.go
@@ -79,5 +79,7 @@ func All() []rule.Rule {
 		GL073,
 		GL074,
 		GL075,
+		GL076,
+		GL077,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -77,6 +77,8 @@ var cweIDs = map[string]string{
 	"GL073": "CWE-538",
 	"GL074": "CWE-691",
 	"GL075": "CWE-829",
+	"GL076": "CWE-653",
+	"GL077": "CWE-653",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl076.go
+++ b/rules/gl076.go
@@ -1,0 +1,49 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl076 struct{}
+
+var GL076 = &gl076{}
+
+func (r *gl076) ID() string { return "GL076" }
+
+// unconfinedRe captures a --security-opt flag that disables the seccomp or
+// AppArmor profile (space or = separated between flag and value).
+var unconfinedRe = regexp.MustCompile(`--security-opt[=\s]+(seccomp|apparmor)=unconfined`)
+
+func (r *gl076) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerRunRe.MatchString(v) {
+			return
+		}
+		for _, m := range unconfinedRe.FindAllStringSubmatch(v, -1) {
+			profile := strings.ToLower(m[1])
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL076",
+				Severity: finding.Warn,
+				Job:      job,
+				Message: fmt.Sprintf(
+					"docker run --security-opt %s=unconfined disables the container's %s confinement, removing kernel-level syscall/behavior restrictions — this widens the container-escape surface without needing --privileged; keep the default profile or supply a scoped custom one",
+					profile, profile,
+				),
+				File: file,
+				Line: line.Line,
+				Col:  line.Column,
+			})
+		}
+	})
+	return findings
+}

--- a/rules/gl076_test.go
+++ b/rules/gl076_test.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings076(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL076.Check(doc.Root, "test.yml")
+}
+
+func TestGL076_SeccompUnconfined(t *testing.T) {
+	f := findings076(t, `
+test:
+  script:
+    - docker run --security-opt seccomp=unconfined myimage ./run.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL076" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+}
+
+func TestGL076_ApparmorUnconfined(t *testing.T) {
+	f := findings076(t, `
+test:
+  script:
+    - docker run --security-opt apparmor=unconfined myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for apparmor=unconfined, got %d", len(f))
+	}
+}
+
+func TestGL076_EqualsForm(t *testing.T) {
+	f := findings076(t, `
+test:
+  script:
+    - docker run --security-opt=seccomp=unconfined myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --security-opt=seccomp=unconfined, got %d", len(f))
+	}
+}
+
+func TestGL076_NoNewPrivilegesNotFlagged(t *testing.T) {
+	f := findings076(t, `
+test:
+  script:
+    - docker run --security-opt no-new-privileges myimage
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for no-new-privileges, got %d", len(f))
+	}
+}
+
+func TestGL076_NoSecurityOpt(t *testing.T) {
+	f := findings076(t, `
+test:
+  script:
+    - docker run myimage ./run.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without --security-opt, got %d", len(f))
+	}
+}
+
+func TestGL076_NoDockerRun(t *testing.T) {
+	f := findings076(t, `
+test:
+  script:
+    - echo "avoid --security-opt seccomp=unconfined"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without docker run, got %d", len(f))
+	}
+}
+
+func TestGL076_CommentNotFlagged(t *testing.T) {
+	f := findings076(t, `
+test:
+  script:
+    - "# docker run --security-opt seccomp=unconfined is discouraged"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/gl077.go
+++ b/rules/gl077.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl077 struct{}
+
+var GL077 = &gl077{}
+
+func (r *gl077) ID() string { return "GL077" }
+
+// ipcHostRe matches --ipc host / --ipc=host.
+var ipcHostRe = regexp.MustCompile(`--ipc[=\s]+host(?:\s|$)`)
+
+func (r *gl077) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !dockerRunRe.MatchString(v) || !ipcHostRe.MatchString(v) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL077",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "docker run --ipc host shares the host IPC namespace — the container can read the host's shared memory and POSIX message queues and signal host processes; omit --ipc or scope it with --ipc container:<id>",
+			File:     file,
+			Line:     line.Line,
+			Col:      line.Column,
+		})
+	})
+	return findings
+}

--- a/rules/gl077_test.go
+++ b/rules/gl077_test.go
@@ -1,0 +1,86 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings077(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL077.Check(doc.Root, "test.yml")
+}
+
+func TestGL077_IpcHost(t *testing.T) {
+	f := findings077(t, `
+test:
+  script:
+    - docker run --ipc host myimage ./run.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn || f[0].RuleID != "GL077" {
+		t.Errorf("unexpected finding: %+v", f[0])
+	}
+}
+
+func TestGL077_IpcHostEqualsForm(t *testing.T) {
+	f := findings077(t, `
+test:
+  script:
+    - docker run --ipc=host myimage
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --ipc=host, got %d", len(f))
+	}
+}
+
+func TestGL077_IpcContainerNotFlagged(t *testing.T) {
+	f := findings077(t, `
+test:
+  script:
+    - docker run --ipc container:abc123 myimage
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for --ipc container:, got %d", len(f))
+	}
+}
+
+func TestGL077_NoIpcFlag(t *testing.T) {
+	f := findings077(t, `
+test:
+  script:
+    - docker run myimage ./run.sh
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without --ipc, got %d", len(f))
+	}
+}
+
+func TestGL077_NoDockerRun(t *testing.T) {
+	f := findings077(t, `
+test:
+  script:
+    - echo "use --ipc host for shared memory"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings without docker run, got %d", len(f))
+	}
+}
+
+func TestGL077_CommentNotFlagged(t *testing.T) {
+	f := findings077(t, `
+test:
+  script:
+    - "# docker run --ipc host is discouraged"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no findings for commented line, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -78,6 +78,8 @@ var owaspCategories = map[string][]string{
 	"GL073": {"CICD-SEC-6"},
 	"GL074": {"CICD-SEC-1"},
 	"GL075": {"CICD-SEC-3"},
+	"GL076": {"CICD-SEC-7"},
+	"GL077": {"CICD-SEC-7"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl076-security-opt-unconfined.yml
+++ b/testdata/fixtures/gl076-security-opt-unconfined.yml
@@ -1,0 +1,7 @@
+# docker run --security-opt seccomp=unconfined disables kernel-level confinement.
+test:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker run --security-opt seccomp=unconfined myimage ./run.sh

--- a/testdata/fixtures/gl077-ipc-host.yml
+++ b/testdata/fixtures/gl077-ipc-host.yml
@@ -1,0 +1,7 @@
+# docker run --ipc host shares the host IPC namespace with the container.
+test:
+  image: docker:26.0
+  services:
+    - docker:26.0-dind
+  script:
+    - docker run --ipc host myimage ./run.sh


### PR DESCRIPTION
Closes #359.

## What changed

Two new `docker run` hardening rules that complete glsec's container-escape-surface coverage, following the existing GL05x family (one rule per flag family).

### GL076 — `--security-opt seccomp=unconfined` / `apparmor=unconfined` (`warn`)

Disabling the seccomp or AppArmor profile removes kernel-level syscall/behavior confinement. This is **distinct from `--privileged` (GL056)**: teams reach for `--security-opt seccomp=unconfined` as the *lighter* alternative to full privilege, so a job can widen the escape surface while still passing GL056 — this closes that bypass. `--security-opt no-new-privileges` (a hardening option) is not flagged.

### GL077 — `--ipc host` (`warn`)

Sharing the host IPC namespace lets the container read host shared memory / message queues and signal host processes. It's the missing sibling of the namespace-sharing family already covered by GL058 (`--network host`) and GL061 (`--pid host`); the detection is a near-clone of GL061.

The optional `--sysctl` idea from the issue was **not** included — it's more FP-prone and less common in CI, per the issue's own note.

## Mapping

Both: OWASP **CICD-SEC-7** (Insecure System Configuration), **CWE-653** (Improper Isolation or Compartmentalization) — consistent with GL058/GL061.

## Files touched

`rules/gl076.go`, `rules/gl077.go` (+ `_test.go`), `rules/all.go`, `rules/owasp.go`, `rules/cwe.go`, `docs/rules/GL076.md`, `docs/rules/GL077.md`, `docs/rules.md`, `README.md` (count 75 → 77, category list), `testdata/fixtures/gl076-*.yml`, `testdata/fixtures/gl077-*.yml`.

## How to test

- `go test ./...`
- `golangci-lint run ./...`
- `check-jsonschema --builtin-schema vendor.gitlab-ci testdata/fixtures/gl07{6,7}-*.yml`
- Verified end-to-end: `go run ./cmd/glsec` on both fixtures emits GL076 / GL077 with the expected messages.

Both rules gate on the existing `dockerRunRe`, skip commented lines, and detect space and `=` flag forms. The pre-release FP scan against the real-pipeline corpus should still run at release time.