### PR TITLE
chore: prepare v1.9.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: glsec
 ```
@@ -312,13 +312,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.8.0
+    name: ghcr.io/glsec/glsec:1.9.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.8.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.9.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -326,7 +326,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.8.0"
+  GLSEC_VERSION: "1.9.0"
 
 glsec:
   stage: test
@@ -348,7 +348,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.8.0
+    name: ghcr.io/glsec/glsec:1.9.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -367,7 +367,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.8.0
+    name: ghcr.io/glsec/glsec:1.9.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
Bumps the pinned version examples in the README (pre-commit `rev`, image tags, `GLSEC_VERSION`) from `1.8.0` to `1.9.0` ahead of tagging **v1.9.0**.

## Release contents (since v1.8.0)

- #363 GL006: detect `ghs_` App tokens and hyphenated OpenAI key variants
- #364 GL006: add PyPI, npm, Stripe, HuggingFace, GCP, extended AWS and more token formats
- #365 GL006: require OpenAI watermark + placeholder allowlist (false-positive hardening)
- #366 New rules GL076 (`--security-opt …=unconfined`) and GL077 (`--ipc host`)

All backward-compatible → minor bump. Pre-release false-positive scan against 200 real public pipelines: **0 false positives** (GL076 produced 1 real true-positive project; GL077 and the new GL006 patterns produced no matches).

Tag `v1.9.0` will be pushed after this merges, triggering the goreleaser release workflow.