### PR TITLE
GL002: treat author-controlled identity variables as untrusted

### DIFF
--- a/docs/rules/GL002.md
+++ b/docs/rules/GL002.md
@@ -21,6 +21,11 @@ Several GitLab CI predefined variables are populated from user-supplied data: br
 | `CI_MERGE_REQUEST_TITLE` | MR title |
 | `CI_MERGE_REQUEST_DESCRIPTION` | MR description |
 | `CI_PIPELINE_NAME` | Pipeline name set by the caller when triggering via API |
+| `CI_COMMIT_AUTHOR` | Commit author `Name <email>`, set verbatim from the commit |
+| `GITLAB_USER_NAME` | Account display name, free-text and user-editable |
+| `GITLAB_USER_EMAIL` | Account email, user-editable |
+
+In a fork merge-request pipeline the identity variables (`CI_COMMIT_AUTHOR`, `GITLAB_USER_NAME`, `GITLAB_USER_EMAIL`) reflect the external MR author and are attacker-controlled. `GITLAB_USER_LOGIN` is intentionally **not** flagged — its username charset excludes shell metacharacters.
 
 ## Trigger example
 

--- a/rules/gl002.go
+++ b/rules/gl002.go
@@ -29,6 +29,14 @@ var userControlledVars = []string{
 	"CI_MERGE_REQUEST_TITLE",
 	"CI_MERGE_REQUEST_DESCRIPTION",
 	"CI_PIPELINE_NAME",
+	// Identity variables controlled directly by an untrusted contributor via
+	// the commit or their own account profile. In fork MR pipelines these
+	// reflect the external MR author. CI_COMMIT_AUTHOR is "Name <email>" taken
+	// verbatim from the commit; GITLAB_USER_NAME/EMAIL are user-editable.
+	// GITLAB_USER_LOGIN is deliberately excluded — its charset is restricted.
+	"CI_COMMIT_AUTHOR",
+	"GITLAB_USER_NAME",
+	"GITLAB_USER_EMAIL",
 }
 
 // userVarRe matches any user-controlled variable reference ($VAR or ${VAR})

--- a/rules/gl002_test.go
+++ b/rules/gl002_test.go
@@ -141,6 +141,50 @@ build:
 	}
 }
 
+func TestGL002_CommitAuthor(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo hi $CI_COMMIT_AUTHOR
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_COMMIT_AUTHOR, got %d", len(f))
+	}
+}
+
+func TestGL002_GitlabUserName(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - ./greet.sh $GITLAB_USER_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for GITLAB_USER_NAME, got %d", len(f))
+	}
+}
+
+func TestGL002_GitlabUserEmail(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - ./mail.sh $GITLAB_USER_EMAIL
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for GITLAB_USER_EMAIL, got %d", len(f))
+	}
+}
+
+func TestGL002_GitlabUserLoginNotFlagged(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo $GITLAB_USER_LOGIN
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no findings for GITLAB_USER_LOGIN (restricted charset), got %d", len(f))
+	}
+}
+
 func TestGL002_SafeVariable(t *testing.T) {
 	f := findings002(t, `
 build:

--- a/testdata/fixtures/gl002-variable-injection.yml
+++ b/testdata/fixtures/gl002-variable-injection.yml
@@ -16,3 +16,11 @@ deploy-job:
     - echo $CI_COMMIT_MESSAGE
   script:
     - ./deploy.sh $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME
+
+greet-job:
+  stage: test
+  image: alpine:3.19
+  script:
+    - echo hi $CI_COMMIT_AUTHOR
+    - ./greet.sh $GITLAB_USER_NAME
+    - ./mail.sh $GITLAB_USER_EMAIL


### PR DESCRIPTION
Closes #371

## What changed
Adds three author-controlled identity variables to the GL002 untrusted-variable set in `rules/gl002.go`:

- `CI_COMMIT_AUTHOR` — `Name <email>` taken verbatim from the commit, fully attacker-set via `git config`.
- `GITLAB_USER_NAME` — account display name, free-text and user-editable.
- `GITLAB_USER_EMAIL` — user-editable.

`GITLAB_USER_LOGIN` is deliberately left out — its username charset excludes shell metacharacters, so it carries low injection value and high FP risk.

## Why
In a fork merge-request pipeline these variables reflect the external MR author, so an unquoted use like `echo hi $CI_COMMIT_AUTHOR` is injectable — the same vulnerability class as the already-covered `CI_COMMIT_MESSAGE` / `CI_MERGE_REQUEST_TITLE`.

## How to test
- `go test ./rules/ -run TestGL002` — new cases cover each added variable firing plus `GITLAB_USER_LOGIN` staying silent.
- Fixture `testdata/fixtures/gl002-variable-injection.yml` gains a `greet-job` exercising all three unquoted.
- Full suite: `go test ./...`, `golangci-lint run ./...`, schema-valid fixture.

## Files
- `rules/gl002.go` — extend `userControlledVars`
- `rules/gl002_test.go` — 4 new cases
- `testdata/fixtures/gl002-variable-injection.yml` — new job
- `docs/rules/GL002.md` — variable table + note