### PR TITLE
GL006: add anchored secret-token formats

### DIFF
--- a/docs/rules/GL006.md
+++ b/docs/rules/GL006.md
@@ -40,6 +40,21 @@ glsec scans all `variables:` blocks (global, `default:`, and per-job) for scalar
 | New Relic API key | `NRAK-…` |
 | Shopify access token | `shpss_…` / `shpat_…` / `shpca_…` / `shppa_…` |
 | Brevo (Sendinblue) API key | `xkeysib-…` |
+| age secret key | `AGE-SECRET-KEY-1…` |
+| Clojars deploy token | `CLOJARS_…` (60 chars) |
+| Dynatrace token | `dt0c01.<24>.<64>` |
+| Duffel API token | `duffel_test_…` / `duffel_live_…` |
+| Frame.io token | `fio-u-…` (64 chars) |
+| Terraform Cloud token | `…atlasv1.…` |
+| Linear API key | `lin_api_…` (40 chars) |
+| New Relic browser key | `NRJS-…` (19 hex chars) |
+| Pulumi access token | `pul-…` (40 hex chars) |
+| Shippo API token | `shippo_live_…` / `shippo_test_…` |
+| Slack webhook URL | `https://hooks.slack.com/services/…` |
+| Alibaba access key ID | `LTAI…` |
+| Private Packagist token | `packagist_…` |
+| Adobe client secret | `p8e-…` (32 chars) |
+| Flutterwave secret key | `FLWSECK_TEST-…` / `FLWPUBK_TEST-…` |
 
 Values that are variable references (starting with `$`) are ignored. Obvious
 documentation placeholders are also skipped: a matched value is ignored when it

--- a/rules/gl006.go
+++ b/rules/gl006.go
@@ -63,6 +63,21 @@ var secretPatterns = []secretPattern{
 	{"New Relic API key", regexp.MustCompile(`^NRAK-[A-Z0-9]{27}$`)},
 	{"Shopify access token", regexp.MustCompile(`^shp(?:ss|at|ca|pa)_[a-fA-F0-9]{32}$`)},
 	{"Brevo (Sendinblue) API key", regexp.MustCompile(`^xkeysib-[a-f0-9]{64}-[A-Za-z0-9]{16}$`)},
+	{"age secret key", regexp.MustCompile(`^AGE-SECRET-KEY-1[0-9A-Z]{50,}$`)},
+	{"Clojars deploy token", regexp.MustCompile(`^CLOJARS_[a-z0-9]{60}$`)},
+	{"Dynatrace token", regexp.MustCompile(`^dt0c01\.[A-Z0-9]{24}\.[A-Z0-9]{64}$`)},
+	{"Duffel API token", regexp.MustCompile(`^duffel_(?:test|live)_[A-Za-z0-9_-]{40,}$`)},
+	{"Frame.io token", regexp.MustCompile(`^fio-u-[A-Za-z0-9_-]{64}$`)},
+	{"Terraform Cloud token", regexp.MustCompile(`[A-Za-z0-9]{14}\.atlasv1\.[A-Za-z0-9_-]{60,}`)},
+	{"Linear API key", regexp.MustCompile(`^lin_api_[A-Za-z0-9]{40}$`)},
+	{"New Relic browser key", regexp.MustCompile(`^NRJS-[a-f0-9]{19}$`)},
+	{"Pulumi access token", regexp.MustCompile(`^pul-[a-f0-9]{40}$`)},
+	{"Shippo API token", regexp.MustCompile(`^shippo_(?:live|test)_[a-f0-9]{40}$`)},
+	{"Slack webhook URL", regexp.MustCompile(`^https://hooks\.slack\.com/services/T[A-Za-z0-9_]+/B[A-Za-z0-9_]+/[A-Za-z0-9_]{20,}$`)},
+	{"Alibaba access key ID", regexp.MustCompile(`^LTAI[A-Za-z0-9]{20}$`)},
+	{"Private Packagist token", regexp.MustCompile(`^packagist_[a-z]{3}_[a-f0-9]{68}$`)},
+	{"Adobe client secret", regexp.MustCompile(`^p8e-[a-z0-9]{32}$`)},
+	{"Flutterwave secret key", regexp.MustCompile(`^FLW(?:PUBK|SECK)_TEST-[a-h0-9]{32}-X$`)},
 }
 
 func (r *gl006) Check(doc *yaml.Node, file string) []finding.Finding {

--- a/rules/gl006_test.go
+++ b/rules/gl006_test.go
@@ -298,6 +298,50 @@ build:
 	}
 }
 
+func TestGL006_AnchoredFormatsExtra(t *testing.T) {
+	// Values are assembled from split literals + strings.Repeat so no contiguous
+	// token ever appears in source — otherwise GitHub push protection blocks the
+	// push (fixtures cannot split literals, so these formats live in unit tests).
+	a := func(n int) string { return strings.Repeat("a", n) }
+	cases := map[string]struct {
+		value string
+		label string
+	}{
+		"age":         {"AGE-SECRET-KEY-1" + strings.Repeat("A", 58), "age secret key"},
+		"clojars":     {"CLOJARS_" + a(60), "Clojars deploy token"},
+		"dynatrace":   {"dt0c01." + strings.Repeat("A", 24) + "." + strings.Repeat("B", 64), "Dynatrace token"},
+		"duffel":      {"duffel_" + "test_" + a(43), "Duffel API token"},
+		"frameio":     {"fio-u-" + a(64), "Frame.io token"},
+		"terraform":   {a(14) + ".atlasv1." + strings.Repeat("b", 70), "Terraform Cloud token"},
+		"linear":      {"lin_" + "api_" + a(40), "Linear API key"},
+		"nrjs":        {"NRJS-" + a(19), "New Relic browser key"},
+		"pulumi":      {"pul-" + a(40), "Pulumi access token"},
+		"shippo":      {"shippo_" + "live_" + a(40), "Shippo API token"},
+		"slack":       {"https://hooks.slack.com/services/T" + strings.Repeat("A", 9) + "/B" + strings.Repeat("A", 9) + "/" + a(24), "Slack webhook URL"},
+		"alibaba":     {"LTAI" + a(20), "Alibaba access key ID"},
+		"packagist":   {"packagist_" + "uip_" + a(68), "Private Packagist token"},
+		"adobe":       {"p8e-" + a(32), "Adobe client secret"},
+		"flutterwave": {"FLW" + "SECK_TEST-" + a(32) + "-X", "Flutterwave secret key"},
+	}
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			f := findings006(t, fmt.Sprintf(`
+variables:
+  TOKEN: "%s"
+build:
+  script: [echo ok]
+`, tc.value))
+			if len(f) != 1 {
+				t.Fatalf("expected 1 finding for %s, got %d", name, len(f))
+			}
+			if !strings.Contains(f[0].Message, tc.label) {
+				t.Errorf("expected %q in message, got %q", tc.label, f[0].Message)
+			}
+		})
+	}
+}
+
 func TestGL006_PlaceholderExample_NoFinding(t *testing.T) {
 	f := findings006(t, `
 variables:


### PR DESCRIPTION
Closes #372

## What changed
Extends `secretPatterns` in `rules/gl006.go` with 15 additional anchored / specific-prefix token formats:

age, Clojars, Dynatrace, Duffel, Frame.io, Terraform Cloud (`…atlasv1.…`), Linear, New Relic browser key (`NRJS-`), Pulumi, Shippo, Slack webhook URL, Alibaba access key ID, Private Packagist, Adobe client secret, Flutterwave.

Each pattern is anchored to a specific prefix/structure, so false-positive risk is minimal. Deliberately **not** added (per the issue): generic JWT, Twilio `SK[hex]{32}`, Mapbox `pk.`, generic 40-char AWS secret, Maven `<password>`, and other generic `<vendor>.*<hex>` magnets.

## Why
GL006 already covers a broad set of provider tokens; these were the remaining well-known formats that are cheap to match with high signal.

## Testing notes
- New unit test `TestGL006_AnchoredFormatsExtra` exercises all 15 formats (one sub-test each), asserting a single finding with the correct provider label.
- Values are assembled from split literals so no contiguous secret appears in source — otherwise GitHub push protection blocks the push. For the same reason these formats are covered by unit tests rather than a YAML fixture (fixtures cannot split literals); the existing `gl006-hardcoded-secrets.yml` still satisfies the rule-consistency fixture check.
- `go test ./...`, `golangci-lint run ./...`, `check-jsonschema` all green.

## Files
- `rules/gl006.go` — 15 new patterns
- `rules/gl006_test.go` — `TestGL006_AnchoredFormatsExtra`
- `docs/rules/GL006.md` — pattern table rows