### PR TITLE
ci: correct govulncheck-action version pin comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
 
   zizmor:
     name: Security (zizmor)


### PR DESCRIPTION
## What changed
Corrects the version comment on the `golang/govulncheck-action` hash pin in `.github/workflows/ci.yml` from `# v1` to `# v1.0.4` — the commit `b625fbe0…` is tagged `v1.0.4`.

## Why
zizmor v1.26.1 (installed fresh on every CI run) now flags this as a `ref-version-mismatch` (medium), which fails the `Security (zizmor)` job on every PR. main last ran green on 2026-07-09 with an older zizmor; the newer version surfaced the mismatch. This is a repo-wide, pre-existing issue unrelated to any rule change and blocks all open PRs.

## How to test
`Security (zizmor)` job passes on this branch. No behavior change — only a comment.