### PR TITLE
Add GL078: invisible / bidirectional Unicode characters (Trojan Source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-77 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+78 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070, GL073 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063, GL076, GL077 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -73,6 +73,7 @@ User-controlled inputs and unversioned component references that allow malicious
 | [GL053](rules/GL053.md) | `warn`  | Missing or unrestricted `workflow:rules` — pipelines run for every event, including untrusted fork merge requests |
 | [GL065](rules/GL065.md) | `warn`  | `image:`/`services:` from a registry not in the opt-in `allowed_registries` allowlist |
 | [GL067](rules/GL067.md) | `warn`  | `SECURE_ANALYZERS_PREFIX` (or `*_ANALYZER_IMAGE`) repoints managed security scanners off `registry.gitlab.com` |
+| [GL078](rules/GL078.md) | `warn`  | Invisible / bidirectional Unicode control characters (Trojan Source) — rendered file can differ from what runs |
 
 ---
 

--- a/docs/rules/GL078.md
+++ b/docs/rules/GL078.md
@@ -1,0 +1,47 @@
+# GL078 — Invisible / bidirectional Unicode characters (Trojan Source)
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)  
+
+## Risk
+
+`.gitlab-ci.yml` files can carry **invisible or bidirectional Unicode control characters** that make the rendered text differ from what is actually parsed and executed — the "Trojan Source" class ([CVE-2021-42574](https://nvd.nist.gov/vuln/detail/CVE-2021-42574)). A `script:` line can look benign in a reviewer's editor while running something else, or hide payload via zero-width characters that survive copy-paste.
+
+## What glsec checks
+
+GL078 scans the **raw bytes** of the file (not the parsed YAML tree, where these characters are invisible) and flags any occurrence of:
+
+**Bidirectional control characters** (reordering attacks):
+
+| Range | Characters |
+|-------|-----------|
+| `U+202A`–`U+202E` | LRE, RLE, PDF, LRO, RLO |
+| `U+2066`–`U+2069` | LRI, RLI, FSI, PDI |
+| `U+061C` | Arabic letter mark |
+
+**Zero-width / invisible characters** (hidden-payload / homoglyph smuggling):
+
+| Code point | Character |
+|------------|-----------|
+| `U+200B`–`U+200D` | Zero-width space / non-joiner / joiner |
+| `U+2060` | Word joiner |
+| `U+FEFF` | Zero-width no-break space / BOM |
+| `U+00AD` | Soft hyphen |
+
+A single **leading** `U+FEFF` byte-order mark is allowed so BOM-prefixed files are not flagged; any later `U+FEFF` is reported.
+
+## Trigger example
+
+A line that renders as a harmless comment but reorders under a `U+202E` (RLO) override, or a `script:` value with an embedded `U+200B`, produces a finding pointing at the line and column of the offending code point:
+
+```
+GL078 warn: invisible/bidirectional Unicode character U+202E (RIGHT-TO-LEFT OVERRIDE) at column 18 …
+```
+
+## Safe alternative
+
+Remove the control character. CI configuration never needs bidirectional or zero-width formatting; keep `.gitlab-ci.yml` to plain ASCII (plus ordinary accented text where genuinely required).
+
+## False-positive risk
+
+Very low — these code points essentially never appear legitimately in a CI configuration.

--- a/rules/all.go
+++ b/rules/all.go
@@ -81,5 +81,6 @@ func All() []rule.Rule {
 		GL075,
 		GL076,
 		GL077,
+		GL078,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -79,6 +79,7 @@ var cweIDs = map[string]string{
 	"GL075": "CWE-829",
 	"GL076": "CWE-653",
 	"GL077": "CWE-653",
+	"GL078": "CWE-1007",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -104,6 +105,7 @@ var cweNames = map[string]string{
 	"CWE-552":  "Files or Directories Accessible to External Parties",
 	"CWE-732":  "Incorrect Permission Assignment for Critical Resource",
 	"CWE-1104": "Use of Unmaintained Third-Party Components",
+	"CWE-1007": "Insufficient Visual Distinction of Homoglyphs Presented to User",
 }
 
 // CWEID returns the CWE identifier for a rule, e.g. "CWE-798".

--- a/rules/gl078.go
+++ b/rules/gl078.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl078 struct{}
+
+var GL078 = &gl078{}
+
+func (r *gl078) ID() string { return "GL078" }
+
+// dangerousRunes are Unicode code points that make rendered text differ from
+// what is actually parsed/executed — the "Trojan Source" class (CVE-2021-42574).
+// Bidirectional controls reorder a line; zero-width and invisible characters
+// hide or smuggle payload. None of these appear legitimately in a CI config.
+var dangerousRunes = map[rune]string{
+	// Bidirectional control characters (reordering attacks).
+	0x202A: "LEFT-TO-RIGHT EMBEDDING",
+	0x202B: "RIGHT-TO-LEFT EMBEDDING",
+	0x202C: "POP DIRECTIONAL FORMATTING",
+	0x202D: "LEFT-TO-RIGHT OVERRIDE",
+	0x202E: "RIGHT-TO-LEFT OVERRIDE",
+	0x2066: "LEFT-TO-RIGHT ISOLATE",
+	0x2067: "RIGHT-TO-LEFT ISOLATE",
+	0x2068: "FIRST STRONG ISOLATE",
+	0x2069: "POP DIRECTIONAL ISOLATE",
+	0x061C: "ARABIC LETTER MARK",
+	// Zero-width / invisible characters (hidden-payload / homoglyph smuggling).
+	0x200B: "ZERO WIDTH SPACE",
+	0x200C: "ZERO WIDTH NON-JOINER",
+	0x200D: "ZERO WIDTH JOINER",
+	0x2060: "WORD JOINER",
+	0xFEFF: "ZERO WIDTH NO-BREAK SPACE (BOM)",
+	0x00AD: "SOFT HYPHEN",
+}
+
+// Check scans the raw file bytes (not the parsed YAML tree) because these
+// control characters are invisible in the node values a tree walk would see.
+func (r *gl078) Check(_ *yaml.Node, file string) []finding.Finding {
+	data, err := os.ReadFile(file) //nolint:gosec // G304: scanning the file glsec was asked to lint
+	if err != nil {
+		return nil
+	}
+
+	var findings []finding.Finding
+	line, col := 1, 1
+	for i, ch := range string(data) {
+		switch ch {
+		case '\n':
+			line++
+			col = 1
+			continue
+		// A single leading BOM is legitimate; ignore it but flag any later U+FEFF.
+		case 0xFEFF:
+			if i == 0 {
+				continue
+			}
+		}
+		if name, ok := dangerousRunes[ch]; ok {
+			findings = append(findings, finding.Finding{
+				RuleID:   "GL078",
+				Severity: finding.Warn,
+				Message: fmt.Sprintf(
+					"invisible/bidirectional Unicode character U+%04X (%s) at column %d — the rendered file can differ from what runs (Trojan Source, CVE-2021-42574); remove it",
+					ch, name, col,
+				),
+				File: file,
+				Line: line,
+				Col:  col,
+			})
+		}
+		col++
+	}
+	return findings
+}

--- a/rules/gl078_test.go
+++ b/rules/gl078_test.go
@@ -1,0 +1,96 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+)
+
+// findings078 writes content to a temp file and runs GL078 against it, since the
+// rule scans raw file bytes by path rather than the parsed YAML tree. The
+// control characters under test are written as \u escapes so this source file
+// itself stays clean (and does not trip GL078-style scanners).
+func findings078(t *testing.T, content string) []finding.Finding {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gitlab-ci.yml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return GL078.Check(nil, path)
+}
+
+func TestGL078_ZeroWidthSpace(t *testing.T) {
+	f := findings078(t, "build:\n  script:\n    - echo \"hi\u200bthere\"\n")
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for zero-width space, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+	if f[0].Line != 3 {
+		t.Errorf("expected finding on line 3, got %d", f[0].Line)
+	}
+}
+
+func TestGL078_RLOOverride(t *testing.T) {
+	f := findings078(t, "build:\n  script:\n    - echo \"admin\u202eresu\"\n")
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for RLO override, got %d", len(f))
+	}
+}
+
+func TestGL078_MultipleChars(t *testing.T) {
+	f := findings078(t, "build:\n  script:\n    - echo \"a\u200bb\"\n    - echo \"c\u2066d\u2069e\"\n")
+	if len(f) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(f))
+	}
+}
+
+func TestGL078_SoftHyphenAndWordJoiner(t *testing.T) {
+	f := findings078(t, "build:\n  script:\n    - echo \"x\u00ady\u2060z\"\n")
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(f))
+	}
+}
+
+func TestGL078_LeadingBOMAllowed(t *testing.T) {
+	f := findings078(t, "\ufeffbuild:\n  script:\n    - echo ok\n")
+	if len(f) != 0 {
+		t.Fatalf("expected no finding for a single leading BOM, got %d", len(f))
+	}
+}
+
+func TestGL078_NonLeadingBOMFlagged(t *testing.T) {
+	f := findings078(t, "build:\n  script:\n    - echo \"a\ufeffb\"\n")
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for a non-leading BOM, got %d", len(f))
+	}
+}
+
+func TestGL078_CleanFile(t *testing.T) {
+	f := findings078(t, "build:\n  script:\n    - echo \"perfectly normal\"\n    - make test\n")
+	if len(f) != 0 {
+		t.Errorf("expected no findings for a clean file, got %d", len(f))
+	}
+}
+
+func TestGL078_Column(t *testing.T) {
+	f := findings078(t, "build:\n  script:\n    - echo \"\u200bx\"\n")
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	// Line 3 is 4 spaces + `- echo "` (8 chars) so the quote is at column 12 and
+	// the zero-width space immediately after it sits at column 13.
+	if f[0].Col != 13 {
+		t.Errorf("expected column 13, got %d", f[0].Col)
+	}
+}
+
+func TestGL078_MissingFile(t *testing.T) {
+	if f := GL078.Check(nil, filepath.Join(t.TempDir(), "does-not-exist.yml")); f != nil {
+		t.Errorf("expected nil for unreadable file, got %d findings", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -80,6 +80,7 @@ var owaspCategories = map[string][]string{
 	"GL075": {"CICD-SEC-3"},
 	"GL076": {"CICD-SEC-7"},
 	"GL077": {"CICD-SEC-7"},
+	"GL078": {"CICD-SEC-4"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl078-trojan-source.yml
+++ b/testdata/fixtures/gl078-trojan-source.yml
@@ -1,0 +1,4 @@
+build:
+  script:
+    - echo "hello​world"
+    - echo "admin‮resu"


### PR DESCRIPTION
Closes #374

## What changed
New rule **GL078** flagging invisible or bidirectional Unicode control characters in `.gitlab-ci.yml` — the "Trojan Source" class ([CVE-2021-42574](https://nvd.nist.gov/vuln/detail/CVE-2021-42574)), where the rendered text differs from what is parsed and executed.

Detected code points:
- **Bidi controls:** `U+202A`–`U+202E`, `U+2066`–`U+2069`, `U+061C`
- **Zero-width / invisible:** `U+200B`–`U+200D`, `U+2060`, `U+FEFF`, `U+00AD`

A single **leading** `U+FEFF` BOM is allowed; any later occurrence is flagged. Severity `warn`.

## Design
Unlike the tree-walking rules, GL078 scans the **raw file bytes** (via the `file` path already passed to every rule) — these characters are invisible in the parsed node values. Reports line, column, and the offending code point (`U+XXXX`).

- OWASP: CICD-SEC-4 (Poisoned Pipeline Execution)
- CWE-1007 (added to `cwe.go`)

## FP risk
Very low — these code points essentially never appear legitimately in a CI configuration.

## How to test
- Fixture `testdata/fixtures/gl078-trojan-source.yml` embeds a `U+200B` and a `U+202E` in `script:` lines → two findings.
- `go test ./rules/ -run TestGL078` covers each character class, the leading-BOM allowance, non-leading BOM, clean files, column reporting, and unreadable files. Control chars in the test are written as `\u` escapes so the test source stays clean.
- `go test ./...`, `golangci-lint run ./...`, `check-jsonschema` all green.

## Files
- `rules/gl078.go`, `rules/gl078_test.go`
- `rules/all.go`, `rules/owasp.go`, `rules/cwe.go`
- `docs/rules/GL078.md`, `docs/rules.md`, `README.md`
- `testdata/fixtures/gl078-trojan-source.yml`