### PR TITLE
Add GL079: dependency confusion via pip --extra-index-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-78 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+79 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070, GL073 |
-| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075 |
+| Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075, GL079 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -54,6 +54,7 @@ Mutable references that allow silent substitution of images, templates, or packa
 | [GL069](rules/GL069.md) | `warn`  | Package signature/auth verification bypassed (`apt --allow-unauthenticated`, `[trusted=yes]`, `apk --allow-untrusted`) |
 | [GL072](rules/GL072.md) | `warn`  | `needs:project` cross-project artifact download with a mutable branch or variable `ref:` — the consumed artifacts can be poisoned |
 | [GL075](rules/GL075.md) | `warn`  | `include:` source (project / component / remote) not on the opt-in `allowed_include_sources` allowlist — provenance check complementing GL003's pinning |
+| [GL079](rules/GL079.md) | `warn`  | `pip install --extra-index-url` adds a public index alongside the default — highest version wins across indexes, enabling dependency confusion |
 
 ---
 

--- a/docs/rules/GL079.md
+++ b/docs/rules/GL079.md
@@ -1,0 +1,41 @@
+# GL079 — Dependency confusion via extra package index (`pip --extra-index-url`)
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)  
+
+## Risk
+
+Adding a public package index **alongside** a private one is the classic **dependency-confusion** foothold. `pip` resolves the **highest** version across *all* configured indexes, so an attacker who publishes a higher-versioned package of the same name on the public index (`pypi.org`) gets it pulled into the build instead of your private package.
+
+## What glsec checks
+
+GL079 flags a `pip install` (`pip`, `pip3`, or `python -m pip install`) that passes **`--extra-index-url`** in any `script:`, `before_script:`, `after_script:`, or `hooks:pre_get_sources_script` line:
+
+```yaml
+build:
+  script:
+    - pip install internal-lib --extra-index-url https://pypi.org/simple   # flagged
+```
+
+Commented lines (starting with `#`) are ignored.
+
+## Safe alternative
+
+Use a **single** trusted `--index-url` (not `--extra-index-url`) so resolution cannot fall through to a public index, and pin dependencies with hashes or a lockfile:
+
+```yaml
+build:
+  script:
+    - pip install --index-url https://pypi.internal.example.com/simple -r requirements.txt
+```
+
+For a private mirror that must proxy PyPI, configure the proxy on the index host so a single `--index-url` still resolves everything, rather than layering a second public index into the client.
+
+## Scope and false-positive risk
+
+`--extra-index-url` has legitimate uses, but its presence *is* the risk surface, so this is the higher-signal half of dependency-confusion detection. The npm/yarn/pnpm `--registry` variant (pointing back at the public registry while a scoped private registry is in use) is far more FP-prone — most projects legitimately use the public registry — and is intentionally **not** covered here.
+
+## Related rules
+
+- **GL042** flags `pip --trusted-host` (TLS-verification bypass) — a different flag and risk.
+- **GL022** flags missing version pins; **GL023** flags non-lockfile-strict installs.

--- a/rules/all.go
+++ b/rules/all.go
@@ -82,5 +82,6 @@ func All() []rule.Rule {
 		GL076,
 		GL077,
 		GL078,
+		GL079,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -80,6 +80,7 @@ var cweIDs = map[string]string{
 	"GL076": "CWE-653",
 	"GL077": "CWE-653",
 	"GL078": "CWE-1007",
+	"GL079": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl079.go
+++ b/rules/gl079.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl079 struct{}
+
+var GL079 = &gl079{}
+
+func (r *gl079) ID() string { return "GL079" }
+
+var (
+	// pipInstallRe matches a pip install invocation (pip, pip3, pip2, or
+	// `python -m pip install`).
+	pipInstallRe = regexp.MustCompile(`\bpip[0-9]*\s+install\b`)
+	// extraIndexRe matches pip's --extra-index-url flag, which adds a package
+	// index in addition to the default one.
+	extraIndexRe = regexp.MustCompile(`--extra-index-url(?:[=\s]|$)`)
+)
+
+func (r *gl079) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(line *yaml.Node, file, job string) {
+		v := line.Value
+		if strings.HasPrefix(strings.TrimSpace(v), "#") {
+			return
+		}
+		if !pipInstallRe.MatchString(v) || !extraIndexRe.MatchString(v) {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL079",
+			Severity: finding.Warn,
+			Job:      job,
+			Message:  "pip install with --extra-index-url adds a package index alongside the default — pip resolves the highest version across all indexes, so an attacker who publishes a higher-versioned package of the same name on the public index gets it pulled into the build (dependency confusion); use a single trusted --index-url plus hash-pinned requirements or a lockfile instead",
+			File:     file,
+			Line:     line.Line,
+			Col:      line.Column,
+		})
+	})
+	return findings
+}

--- a/rules/gl079_test.go
+++ b/rules/gl079_test.go
@@ -1,0 +1,110 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings079(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL079.Check(doc.Root, "test.yml")
+}
+
+func TestGL079_ExtraIndexURL(t *testing.T) {
+	f := findings079(t, `
+build:
+  script:
+    - pip install foo --extra-index-url https://pypi.org/simple
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL079_ExtraIndexURLEquals(t *testing.T) {
+	f := findings079(t, `
+build:
+  script:
+    - pip3 install foo --extra-index-url=https://pypi.org/simple
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for --extra-index-url=, got %d", len(f))
+	}
+}
+
+func TestGL079_PythonMPip(t *testing.T) {
+	f := findings079(t, `
+build:
+  script:
+    - python -m pip install foo --extra-index-url https://pypi.org/simple
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for python -m pip, got %d", len(f))
+	}
+}
+
+func TestGL079_BeforeScript(t *testing.T) {
+	f := findings079(t, `
+build:
+  before_script:
+    - pip install foo --extra-index-url https://pypi.org/simple
+  script:
+    - make
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in before_script, got %d", len(f))
+	}
+}
+
+func TestGL079_SingleIndexURL_NoFinding(t *testing.T) {
+	f := findings079(t, `
+build:
+  script:
+    - pip install --index-url https://pypi.internal.example.com/simple -r requirements.txt
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a single --index-url, got %d", len(f))
+	}
+}
+
+func TestGL079_PlainInstall_NoFinding(t *testing.T) {
+	f := findings079(t, `
+build:
+  script:
+    - pip install foo -r requirements.txt
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a plain pip install, got %d", len(f))
+	}
+}
+
+func TestGL079_CommentedLine_NoFinding(t *testing.T) {
+	f := findings079(t, `
+build:
+  script:
+    - "# pip install foo --extra-index-url https://pypi.org/simple"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a commented line, got %d", len(f))
+	}
+}
+
+func TestGL079_NotPip_NoFinding(t *testing.T) {
+	f := findings079(t, `
+build:
+  script:
+    - echo "docs mention --extra-index-url as a flag"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when there is no pip install, got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -81,6 +81,7 @@ var owaspCategories = map[string][]string{
 	"GL076": {"CICD-SEC-7"},
 	"GL077": {"CICD-SEC-7"},
 	"GL078": {"CICD-SEC-4"},
+	"GL079": {"CICD-SEC-3"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl079-dependency-confusion.yml
+++ b/testdata/fixtures/gl079-dependency-confusion.yml
@@ -1,0 +1,15 @@
+stages:
+  - build
+
+install-deps:
+  stage: build
+  image: python:3.12
+  script:
+    - pip install internal-lib --extra-index-url https://pypi.org/simple
+    - python -m pip install foo --extra-index-url=https://pypi.org/simple
+
+safe-install:
+  stage: build
+  image: python:3.12
+  script:
+    - pip install --index-url https://pypi.internal.example.com/simple -r requirements.txt


### PR DESCRIPTION
Closes #375

## What changed
New rule **GL079** flagging `pip install … --extra-index-url` in any script section (`script:`, `before_script:`, `after_script:`, `hooks:pre_get_sources_script`).

Adding a public package index alongside a private one is the classic **dependency-confusion** foothold: pip resolves the highest version across *all* configured indexes, so an attacker who publishes a higher-versioned package of the same name on the public index gets it pulled into the build.

Matches `pip`, `pip3`, and `python -m pip install`, with either `--extra-index-url URL` or `--extra-index-url=URL`. Commented lines are ignored. Severity `warn`.

- OWASP: CICD-SEC-3 (Dependency Chain Abuse)
- CWE-829 (Inclusion of Functionality from Untrusted Control Sphere)

## Scope
Per the issue, this ships the **confident half** only — pip `--extra-index-url`. The npm/yarn/pnpm `--registry` variant is far more FP-prone (most projects legitimately use the public registry) and is intentionally left out; noted as such in the rule doc.

## How to test
- Fixture `testdata/fixtures/gl079-dependency-confusion.yml`: two flagged lines (`--extra-index-url` and `--extra-index-url=`), plus a `safe-install` job using a single `--index-url` that must not fire.
- `go test ./rules/ -run TestGL079` covers the equals form, `python -m pip`, `before_script`, and negative cases (single `--index-url`, plain install, commented line, non-pip line mentioning the flag).
- `go test ./...`, `golangci-lint run ./...`, `check-jsonschema` all green.

## Files
- `rules/gl079.go`, `rules/gl079_test.go`
- `rules/all.go`, `rules/owasp.go`, `rules/cwe.go`
- `docs/rules/GL079.md`, `docs/rules.md`, `README.md`
- `testdata/fixtures/gl079-dependency-confusion.yml`