### PR TITLE
Add GL080: sensitive job with no pipeline-source guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 
 ## Rules
 
-79 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+80 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -161,7 +161,7 @@ glsec --new-only --baseline base.json .gitlab-ci.yml
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075, GL079 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
-| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074 |
+| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074, GL080 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063, GL076, GL077 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -107,6 +107,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL071](rules/GL071.md) | `warn`  | Manual approval gate before a production deploy without `allow_failure: false` — optional by default, so the pipeline can deploy without it being triggered |
 | [GL074](rules/GL074.md) | `warn`  | Tautological (always-true) `rules:if` condition — the gate is a no-op and the job runs in every context it was meant to restrict |
 | [GL055](rules/GL055.md) | `warn`  | `DOCKER_HOST` points at the host Docker socket (`/var/run/docker.sock`) — full control of the runner's Docker daemon |
+| [GL080](rules/GL080.md) | `warn`  | Sensitive/deploy job with no pipeline-source guard (no `rules:`/`only:` or a `rules:` with no `if:`) — runs on every source including fork MRs |
 
 ---
 

--- a/docs/rules/GL080.md
+++ b/docs/rules/GL080.md
@@ -1,0 +1,57 @@
+# GL080 — Sensitive job with no pipeline-source guard
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)  
+
+## Risk
+
+A privileged job with **no pipeline-source guard at all** runs on every pipeline source — including **fork merge requests**, where an external contributor controls the code. Without a `rules:if` that inspects `$CI_PIPELINE_SOURCE` (or an equivalent restriction), a deploy/publish/release job is an absent flow-control gate: untrusted contributors can trigger it.
+
+## What glsec checks
+
+GL080 flags a job when **all** of the following hold:
+
+1. **The job is sensitive** — its `stage:` or name is deploy/publish/release-like, or it declares an `environment:`.
+2. **The job has no effective guard** — either no `rules:` / `only:` / `except:` at all, **or** a `rules:` block whose items carry no `if:` / `changes:` / `exists:` condition (e.g. only `when: always` / `when: on_success`), so the gate imposes no restriction.
+3. **No restricting `workflow:rules`** — the top-level `workflow:rules` does not carry an `if:` condition that would already gate which pipeline sources run.
+
+## Trigger example
+
+```yaml
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh          # no rules: — runs on fork MR pipelines too
+
+publish:
+  stage: deploy
+  rules:
+    - when: on_success     # no if: — imposes no source restriction
+  script:
+    - ./publish.sh
+```
+
+## Safe alternative
+
+Gate the job on the pipeline source (and, for deploys, restrict to the intended branches):
+
+```yaml
+deploy-prod:
+  stage: deploy
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "main"'
+  script:
+    - ./deploy.sh
+```
+
+A restricting top-level `workflow:rules` gates every job, in which case GL080 does not fire.
+
+## Relationship to other rules
+
+- **GL013** flags a production-environment deploy job with no `rules:`/`only:`. GL080 **defers** to GL013 for that exact case and covers the gaps: jobs sensitive by *stage/name* (not `environment:`), and jobs whose `rules:` block exists but imposes no condition.
+- **GL074** flags a tautological (always-true) `rules:if`. GL080 covers the *missing/ineffective* gate — no `if:` at all — rather than an always-true one.
+- **GL053** flags a missing or unrestricted top-level `workflow:rules` at the pipeline level.
+
+## False-positive note
+
+Not every deploy-stage job without `rules:` is exploitable — many legitimately rely on a restricting `workflow:rules` (which GL080 already accounts for) or on branch-scoped runners. Review each finding in context.

--- a/rules/all.go
+++ b/rules/all.go
@@ -83,5 +83,6 @@ func All() []rule.Rule {
 		GL077,
 		GL078,
 		GL079,
+		GL080,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -81,6 +81,7 @@ var cweIDs = map[string]string{
 	"GL077": "CWE-653",
 	"GL078": "CWE-1007",
 	"GL079": "CWE-829",
+	"GL080": "CWE-691",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl080.go
+++ b/rules/gl080.go
@@ -1,0 +1,131 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl080 struct{}
+
+var GL080 = &gl080{}
+
+func (r *gl080) ID() string { return "GL080" }
+
+func (r *gl080) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+
+	// A restricting top-level workflow:rules gates every job's pipeline source,
+	// so no job needs its own guard. Suppress conservatively: any workflow:rules
+	// carrying an if: condition is treated as restricting the source.
+	if workflowRestrictsSource(mapping) {
+		return nil
+	}
+
+	var findings []finding.Finding
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		if !IsDeployLikeJob(name.Value, job) {
+			return
+		}
+		// The production-environment-without-rules case is already covered by
+		// GL013; skip it here to avoid a duplicate finding.
+		if gl013Owns(job) {
+			return
+		}
+		state := jobGuardState(job)
+		if state == guardEffective {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL080",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message:  gl080Message(name.Value, state),
+			File:     file,
+			Line:     name.Line,
+			Col:      name.Column,
+		})
+	})
+	return findings
+}
+
+type guardState int
+
+const (
+	guardAbsent      guardState = iota // no rules:/only:/except: at all
+	guardIneffective                   // rules: present but no if:/changes:/exists: condition
+	guardEffective                     // has a real restriction
+)
+
+func gl080Message(job string, state guardState) string {
+	if state == guardIneffective {
+		return fmt.Sprintf(
+			"sensitive job %q has a rules: block with no if:/changes:/exists: condition — the gate imposes no restriction, so the job runs on every pipeline source including fork merge requests; add a rules:if that checks $CI_PIPELINE_SOURCE",
+			job,
+		)
+	}
+	return fmt.Sprintf(
+		"sensitive job %q has no rules:/only:/except: guard — it runs on every pipeline source including fork merge requests; add a rules:if that checks $CI_PIPELINE_SOURCE",
+		job,
+	)
+}
+
+// jobGuardState classifies a job's execution guard. only:/except: (legacy) and
+// any rules item carrying an if:/changes:/exists: condition count as effective.
+func jobGuardState(job *yaml.Node) guardState {
+	if parser.FindKey(job, "only") != nil || parser.FindKey(job, "except") != nil {
+		return guardEffective
+	}
+	rules := parser.FindKey(job, "rules")
+	if rules == nil {
+		return guardAbsent
+	}
+	if rules.Kind != yaml.SequenceNode {
+		return guardEffective
+	}
+	for _, item := range rules.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		if parser.FindKey(item, "if") != nil ||
+			parser.FindKey(item, "changes") != nil ||
+			parser.FindKey(item, "exists") != nil {
+			return guardEffective
+		}
+	}
+	return guardIneffective
+}
+
+// gl013Owns reports whether GL013 already flags this job (a production-like
+// environment with no rules:/only: restriction), so GL080 can defer to it.
+func gl013Owns(job *yaml.Node) bool {
+	env := parser.FindKey(job, "environment")
+	if env == nil {
+		return false
+	}
+	envName := extractEnvName(env)
+	tier := extractDeploymentTier(env)
+	prod := (envName != "" && isProdEnv(envName)) || isProdTier(tier)
+	return prod && !hasExecutionRestriction(job)
+}
+
+// workflowRestrictsSource reports whether top-level workflow:rules carries any
+// if: condition — treated as restricting which pipeline sources run at all.
+func workflowRestrictsSource(mapping *yaml.Node) bool {
+	wf := parser.FindKey(mapping, "workflow")
+	if wf == nil {
+		return false
+	}
+	rules := parser.FindKey(wf, "rules")
+	if rules == nil || rules.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, item := range rules.Content {
+		if item.Kind == yaml.MappingNode && parser.FindKey(item, "if") != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/rules/gl080_test.go
+++ b/rules/gl080_test.go
@@ -1,0 +1,171 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings080(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL080.Check(doc.Root, "test.yml")
+}
+
+func TestGL080_DeployNoGuard(t *testing.T) {
+	f := findings080(t, `
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL080_IneffectiveRules(t *testing.T) {
+	f := findings080(t, `
+publish:
+  stage: deploy
+  rules:
+    - when: on_success
+  script:
+    - ./publish.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for rules with no if:, got %d", len(f))
+	}
+}
+
+func TestGL080_EffectiveIfRule_NoFinding(t *testing.T) {
+	f := findings080(t, `
+deploy:
+  stage: deploy
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a rules:if guard, got %d", len(f))
+	}
+}
+
+func TestGL080_ChangesRule_NoFinding(t *testing.T) {
+	f := findings080(t, `
+deploy:
+  stage: deploy
+  rules:
+    - changes:
+        - src/**/*
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a rules:changes condition, got %d", len(f))
+	}
+}
+
+func TestGL080_OnlyClause_NoFinding(t *testing.T) {
+	f := findings080(t, `
+deploy:
+  stage: deploy
+  only:
+    - main
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for an only: clause, got %d", len(f))
+	}
+}
+
+func TestGL080_NonSensitiveJob_NoFinding(t *testing.T) {
+	f := findings080(t, `
+run-tests:
+  stage: test
+  script:
+    - make test
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a non-sensitive job, got %d", len(f))
+	}
+}
+
+func TestGL080_EnvironmentMakesSensitive(t *testing.T) {
+	f := findings080(t, `
+ship-it:
+  stage: build
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+  script:
+    - ./ship.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for an environment job with no guard, got %d", len(f))
+	}
+}
+
+func TestGL080_WorkflowRulesSuppress(t *testing.T) {
+	f := findings080(t, `
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when workflow:rules restricts the source, got %d", len(f))
+	}
+}
+
+func TestGL080_DefersToGL013(t *testing.T) {
+	// Production environment with no rules: is GL013's case — GL080 must not
+	// also fire on it.
+	f := findings080(t, `
+deploy-prod:
+  stage: deploy
+  environment:
+    name: production
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected GL080 to defer to GL013 for prod env + no rules, got %d", len(f))
+	}
+}
+
+func TestGL080_MultipleJobs(t *testing.T) {
+	f := findings080(t, `
+build-app:
+  stage: build
+  script:
+    - make
+
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh
+
+publish:
+  stage: deploy
+  rules:
+    - when: always
+  script:
+    - ./publish.sh
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (deploy-prod + publish), got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -82,6 +82,7 @@ var owaspCategories = map[string][]string{
 	"GL077": {"CICD-SEC-7"},
 	"GL078": {"CICD-SEC-4"},
 	"GL079": {"CICD-SEC-3"},
+	"GL080": {"CICD-SEC-1"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl080-missing-source-guard.yml
+++ b/testdata/fixtures/gl080-missing-source-guard.yml
@@ -1,0 +1,27 @@
+stages:
+  - build
+  - deploy
+
+build-app:
+  stage: build
+  script:
+    - make build
+
+deploy-prod:
+  stage: deploy
+  script:
+    - ./deploy.sh production
+
+publish-artifacts:
+  stage: deploy
+  rules:
+    - when: on_success
+  script:
+    - ./publish.sh
+
+deploy-guarded:
+  stage: deploy
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+  script:
+    - ./deploy.sh


### PR DESCRIPTION
Closes #373

## What changed
New rule **GL080** flagging a sensitive job (deploy/publish/release-like stage or name, or one declaring an `environment:`) that runs on **every pipeline source** — including fork merge requests — because it has no effective flow-control gate.

A job is flagged only when **all** hold:
1. **Sensitive** — via `IsDeployLikeJob` (deploy-like stage/name, or an `environment:`).
2. **No effective guard** — no `rules:`/`only:`/`except:` at all, **or** a `rules:` block whose items carry no `if:`/`changes:`/`exists:` condition (e.g. only `when: always`/`when: on_success`).
3. **No restricting `workflow:rules`** — the top-level `workflow:rules` carries no `if:` (conservative: any `workflow:rules` `if:` suppresses the rule).

Severity `warn`. OWASP CICD-SEC-1 (Insufficient Flow Control), CWE-691.

## Kept narrow to avoid overlap / false positives
- **Defers to GL013**: the production-environment + no-`rules:` case is GL013's; GL080 skips it (`gl013Owns`) so there is no duplicate finding. GL080 covers the gaps GL013 misses — jobs sensitive by *stage/name* rather than `environment:`, and jobs whose `rules:` exists but imposes no condition.
- **Complements GL074** (tautological always-true `if:`) — GL080 is the *missing/ineffective* gate instead.
- A restricting `workflow:rules` suppresses the rule entirely.

## FP caveat
Per the issue, this is the higher-signal but still FP-sensitive area. It ships **default-enabled** (per maintainer decision) in the narrow form above; the `docs/rules/GL080.md` "False-positive note" tells users to review findings in context. Recommend a pass against the real-pipeline corpus before the next release, consistent with the usual pre-release FP scan.

## How to test
Verified with the binary against the fixture — exactly two findings (`deploy-prod` absent guard, `publish-artifacts` ineffective `rules:`), `deploy-guarded` with a `rules:if` correctly silent.

- Fixture `testdata/fixtures/gl080-missing-source-guard.yml`
- `go test ./rules/ -run TestGL080` covers: absent guard, ineffective `rules:`, effective `if:`/`changes:`, `only:`, non-sensitive job, `environment` sensitivity, `workflow:rules` suppression, GL013 deferral, multi-job.
- `go test ./...`, `golangci-lint run ./...`, `check-jsonschema` all green.

## Files
- `rules/gl080.go`, `rules/gl080_test.go`
- `rules/all.go`, `rules/owasp.go`, `rules/cwe.go`
- `docs/rules/GL080.md`, `docs/rules.md`, `README.md`
- `testdata/fixtures/gl080-missing-source-guard.yml`