### PR TITLE
GL080: cut false positives from the pre-release corpus scan

### DIFF
--- a/docs/rules/GL080.md
+++ b/docs/rules/GL080.md
@@ -11,9 +11,14 @@ A privileged job with **no pipeline-source guard at all** runs on every pipeline
 
 GL080 flags a job when **all** of the following hold:
 
-1. **The job is sensitive** — its `stage:` or name is deploy/publish/release-like, or it declares an `environment:`.
+1. **The job is sensitive** — it declares a named `environment:` (other than an `action: stop` teardown), or its name/stage matches a narrow deploy keyword (`deploy`, `rollout`, `release`, `publish`, `provision`). Build/test/package jobs are excluded even when their name contains a deploy word (e.g. `windows-release-build`, `docdist`).
 2. **The job has no effective guard** — either no `rules:` / `only:` / `except:` at all, **or** a `rules:` block whose items carry no `if:` / `changes:` / `exists:` condition (e.g. only `when: always` / `when: on_success`), so the gate imposes no restriction.
 3. **No restricting `workflow:rules`** — the top-level `workflow:rules` does not carry an `if:` condition that would already gate which pipeline sources run.
+
+To avoid false positives on guards glsec cannot resolve, GL080 **skips**:
+
+- **Hidden jobs** (names starting with `.`) — templates GitLab never runs.
+- **Jobs that inherit config** via `extends:` or a YAML merge (`<<:`) — their guard may come from a base. A condition merged **into a `rules:` item** via `<<:` also counts as an effective guard.
 
 ## Trigger example
 

--- a/rules/gl080.go
+++ b/rules/gl080.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
 	"github.com/glsec/glsec/internal/parser"
@@ -26,7 +27,17 @@ func (r *gl080) Check(doc *yaml.Node, file string) []finding.Finding {
 
 	var findings []finding.Finding
 	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
-		if !IsDeployLikeJob(name.Value, job) {
+		// Hidden jobs (names starting with ".") are templates GitLab never runs.
+		if strings.HasPrefix(name.Value, ".") {
+			return
+		}
+		// A job that pulls config in via extends: or a YAML merge (<<:) may
+		// inherit its guard from a base glsec does not resolve — skip it rather
+		// than report a guard that is present but invisible here.
+		if inheritsConfig(job) {
+			return
+		}
+		if !gl080Sensitive(name.Value, job) {
 			return
 		}
 		// The production-environment-without-rules case is already covered by
@@ -49,6 +60,69 @@ func (r *gl080) Check(doc *yaml.Node, file string) []finding.Finding {
 		})
 	})
 	return findings
+}
+
+// gl080DeployKeywords are the narrow set of job/stage name fragments that
+// reliably indicate a deployment or external publish. Broader terms used
+// elsewhere (push, upload, dist, ship, migrate) matched too many build/cache
+// jobs in real pipelines, so they are intentionally excluded here.
+var gl080DeployKeywords = []string{"deploy", "rollout", "release", "publish", "provision"}
+
+// gl080NotDeployKeywords mark jobs that only build, test, or package artifacts —
+// e.g. a "release build" or "docdist" is not a deployment. They veto a keyword
+// match so "windows-release-build" or "coverage-review" is not flagged.
+var gl080NotDeployKeywords = []string{
+	"build", "compile", "test", "lint", "cache", "coverage",
+	"check", "package", "bundle", "prepare", "validate", "audit",
+	"scan", "review", "dist",
+}
+
+// gl080Sensitive reports whether a job deploys or publishes to an external
+// target. An environment: (other than a teardown/stop job) is the strongest
+// signal; otherwise a narrow deploy keyword in the job or stage name, unless a
+// build/test/package keyword vetoes it.
+func gl080Sensitive(name string, job *yaml.Node) bool {
+	if env := parser.FindKey(job, "environment"); env != nil && !envActionStop(env) && extractEnvName(env) != "" {
+		return true
+	}
+	hay := strings.ToLower(name) + " " + jobStageName(job)
+	for _, neg := range gl080NotDeployKeywords {
+		if strings.Contains(hay, neg) {
+			return false
+		}
+	}
+	for _, kw := range gl080DeployKeywords {
+		if strings.Contains(hay, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// inheritsConfig reports whether a job draws configuration from a base via
+// extends: or a YAML merge key (<<:), which glsec does not resolve.
+func inheritsConfig(job *yaml.Node) bool {
+	return parser.FindKey(job, "extends") != nil || parser.FindKey(job, "<<") != nil
+}
+
+func jobStageName(job *yaml.Node) string {
+	if s := parser.FindKey(job, "stage"); s != nil && s.Kind == yaml.ScalarNode {
+		return strings.ToLower(s.Value)
+	}
+	return ""
+}
+
+// envActionStop reports whether an environment: block is a teardown job
+// (environment:action: stop), which tears an environment down rather than
+// deploying to it and carries little source-guard risk.
+func envActionStop(env *yaml.Node) bool {
+	if env.Kind != yaml.MappingNode {
+		return false
+	}
+	if a := parser.FindKey(env, "action"); a != nil && a.Kind == yaml.ScalarNode {
+		return a.Value == "stop"
+	}
+	return false
 }
 
 type guardState int
@@ -89,9 +163,12 @@ func jobGuardState(job *yaml.Node) guardState {
 		if item.Kind != yaml.MappingNode {
 			continue
 		}
+		// A rules item may pull its condition in from an anchor via a YAML merge
+		// (<<:), which glsec does not resolve — treat that as a real condition.
 		if parser.FindKey(item, "if") != nil ||
 			parser.FindKey(item, "changes") != nil ||
-			parser.FindKey(item, "exists") != nil {
+			parser.FindKey(item, "exists") != nil ||
+			parser.FindKey(item, "<<") != nil {
 			return guardEffective
 		}
 	}

--- a/rules/gl080_test.go
+++ b/rules/gl080_test.go
@@ -146,6 +146,107 @@ deploy-prod:
 	}
 }
 
+func TestGL080_HiddenJobSkipped(t *testing.T) {
+	f := findings080(t, `
+.deploy_template:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a hidden (.-prefixed) template job, got %d", len(f))
+	}
+}
+
+func TestGL080_ExtendsSkipped(t *testing.T) {
+	f := findings080(t, `
+deploy-prod:
+  extends: .deploy_base
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a job using extends: (guard may be inherited), got %d", len(f))
+	}
+}
+
+func TestGL080_MergeKeySkipped(t *testing.T) {
+	f := findings080(t, `
+.base: &base
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "push"'
+
+deploy-prod:
+  <<: *base
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a job using a <<: merge (guard may be inherited), got %d", len(f))
+	}
+}
+
+func TestGL080_MergeInsideRulesItemEffective(t *testing.T) {
+	f := findings080(t, `
+.if-main: &if-main
+  if: '$CI_COMMIT_BRANCH == "main"'
+
+deploy-prod:
+  stage: deploy
+  rules:
+    - <<: *if-main
+      variables:
+        X: "1"
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when a rules item merges its condition via <<:, got %d", len(f))
+	}
+}
+
+func TestGL080_EmptyEnvironmentNotSensitive(t *testing.T) {
+	f := findings080(t, `
+run-tests:
+  stage: test
+  environment:
+  script:
+    - make test
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for an empty environment: on a test job, got %d", len(f))
+	}
+}
+
+func TestGL080_EnvironmentStopNotSensitive(t *testing.T) {
+	f := findings080(t, `
+stop-review:
+  stage: deploy
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    action: stop
+  script:
+    - ./teardown.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for an environment teardown (action: stop) job, got %d", len(f))
+	}
+}
+
+func TestGL080_ReleaseBuildNotFlagged(t *testing.T) {
+	f := findings080(t, `
+windows-release-build:
+  stage: build
+  script:
+    - cmake --build . --config Release
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a release *build* job, got %d", len(f))
+	}
+}
+
 func TestGL080_MultipleJobs(t *testing.T) {
 	f := findings080(t, `
 build-app:


### PR DESCRIPTION
Hardens GL080 (merged in #381, not yet released) after the pre-release false-positive scan against 200 real public GitLab pipelines. Raw GL080 fired on **104/200** files, almost all false positives; after this change it fires on **7/200**, nearly all true or defensible.

## Root causes found in the corpus
1. **Hidden/template jobs** (`.`-prefixed, 24 hits) — GitLab never runs them.
2. **Guards behind `extends:` / YAML merge (`<<:`)** — e.g. `buildFdroidReleaseApk` has `<<: *only-release`, `kitmaker_*_deploy` has `<<: *..._only`; glsec doesn't resolve these, so the guard is invisible and the job looked unguarded. Also a condition merged **into a `rules:` item** via `<<:` (gitlab-com `pages`).
3. **Loose name matching** — `windows-release-build` / `docdist` / `ruby-push-cache` matched `release`/`dist`/`push` although they only build/cache.
4. **Empty `environment:`** on a test job counted as a deployment target.

## Changes
- Skip hidden jobs (name starts with `.`).
- Skip jobs that inherit config via `extends:` or `<<:` (guard may be inherited); treat a `<<:` inside a `rules:` item as an effective condition.
- Narrow the deploy keyword set to `deploy`/`rollout`/`release`/`publish`/`provision`, vetoed by build/test/package/… keywords.
- Require a **named** `environment:` and skip `action: stop` teardown jobs.

## Remaining 7 findings (all defensible)
deploy_all, deploy_artifacts, pages, deploy-job, `nanuchi deploy` (SSH deploy to a prod host, no guard — clear TP), soapbox `review` (review-app deploy), wasm_artifacts. All are genuinely unguarded jobs in deploy stages / with an environment.

## Tests
New cases: hidden-job skip, `extends:` skip, `<<:` skip, `<<:`-inside-rules-item effective, empty-environment not sensitive, `action: stop` not sensitive, release-*build* not flagged. `go test ./...` and `golangci-lint run ./rules/` green.

## Notes
Validated in-process against the corpus (the local Go build cache in this environment was unreliable; the source is authoritative and CI builds clean).