### PR TITLE
chore: bump doc version examples to 1.10.0 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: glsec
 ```
@@ -312,13 +312,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.9.0
+    name: ghcr.io/glsec/glsec:1.10.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.9.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.10.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -326,7 +326,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.9.0"
+  GLSEC_VERSION: "1.10.0"
 
 glsec:
   stage: test
@@ -348,7 +348,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.9.0
+    name: ghcr.io/glsec/glsec:1.10.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -367,7 +367,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.9.0
+    name: ghcr.io/glsec/glsec:1.10.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
Bumps the version examples in `README.md` from `1.9.0` to `1.10.0` ahead of the v1.10.0 release (mirrors #367).

## v1.10.0 highlights
- **GL002**: treat author-controlled identity vars (`CI_COMMIT_AUTHOR`, `GITLAB_USER_NAME/EMAIL`) as untrusted (#376)
- **GL006**: 15 new anchored secret-token formats (#377)
- **GL078** (new): invisible / bidirectional Unicode characters — Trojan Source (#379)
- **GL079** (new): dependency confusion via `pip --extra-index-url` (#380)
- **GL080** (new): sensitive job with no pipeline-source guard (#381), FP-hardened against a 200-pipeline corpus (#382)

80 rules total. Pre-release false-positive scan run against 200 real public GitLab pipelines: GL078/GL079/GL006 clean, GL002 true positives, GL080 reduced from 104→7 findings.