### PR TITLE
security(deps): bump Go 1.24 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Last patch to Go 1.24 was in Feb 2026 (1.24.13) which is pretty aged, considering the ecosystem.

Bump Go to 1.25 which will use patch 1.25.13 from July 2026. Consider developing in 1.26 to stay more current and receive active security patching.