### PR TITLE
chore: bump Go to 1.25 and watch Docker base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Dev environment
 
-**Requirements:** Go 1.21+
+**Requirements:** Go 1.25+
 
 ```sh
 git clone https://github.com/glsec/glsec.git

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ERROR  .gitlab-ci.yml:3   GL003  project include "company/templates" missing "re
 
 ## Install
 
-**Go install (requires Go 1.21+):**
+**Go install (requires Go 1.25+):**
 
 ```sh
 go install github.com/glsec/glsec@latest

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/glsec/glsec
 
-go 1.24.3
+go 1.25.0
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## What

- **`go.mod`**: bump the `go` directive `1.24.3` → `1.25.0`, aligning the module's minimum Go with the Docker builder (`golang:1.25-alpine`, bumped in #385).
- **Docs**: `README.md` and `CONTRIBUTING.md` said "Go 1.21+", which was already stale (go.mod required 1.24.3). Updated both to "Go 1.25+".
- **Dependabot**: add the `docker` ecosystem so the Dockerfile base images (`golang:*-alpine`, `alpine:*`) get automated update PRs. They were previously watched by nothing — the recent Alpine/Go bumps (#384/#385) had to come in manually.

## Why

The `go` directive is the minimum language/feature level, set to `1.25.0` (not the latest patch `1.25.13` — the directive is a floor, not a pin; the current patch is picked by the builder/CI toolchain at build time). Aligning it with the already-bumped builder keeps source builds, CI (`go-version-file: go.mod`), and the release image consistent. Adding the Docker ecosystem to Dependabot closes the gap that made those base-image bumps a manual, easy-to-miss task — note that the zizmor CI job only scans `.github/workflows/`, not the Dockerfile.

The Go *version* itself needs no dedicated new check: `govulncheck` already fails CI reactively if the Go version in use carries a stdlib vulnerability.

## How to test

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green locally (the `1.25.0` directive auto-selects the go1.25 toolchain via `GOTOOLCHAIN=auto`).
- Dependabot config is picked up on merge to `main`; the new `docker` block watches both `FROM` lines in the Dockerfile.