### PR TITLE
ci: scan the Docker image with Trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,24 @@ jobs:
       - name: Run zizmor
         run: zizmor --gh-token "${{ secrets.GITHUB_TOKEN }}" .github/workflows/
 
+  trivy:
+    name: Security (Trivy image)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Build image
+        run: docker build -t glsec:ci .
+      - name: Scan image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: glsec:ci
+          scan-type: image
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
   validate-fixtures:
     name: Validate GitLab CI fixtures
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add a `Security (Trivy image)` job to CI that builds the Docker image and scans it with Trivy, failing on **fixable** HIGH/CRITICAL vulnerabilities.

## Why

We publish `ghcr.io/glsec/glsec`, but nothing scanned the final image's OS packages (Alpine, busybox, ca-certificates) — `gosec`/`govulncheck` only cover our Go code and Go dependencies, not the image layers. This job closes that gap.

It also gives the **Dockerfile PR-time coverage** it lacked: `docker.yml` only builds the image on release tags, so a broken Dockerfile previously wouldn't surface until a release. This job now builds it on every PR.

Scan is scoped to keep it low-noise:
- `severity: HIGH,CRITICAL` — ignore Low/Medium
- `ignore-unfixed: true` — only fail on vulnerabilities that actually have a fix available, so unpatched upstream base-image CVEs don't block merges

## How to test

Verified locally against the current image (`golang:1.25-alpine` builder + `alpine:3.21` runtime):

```
Report Summary
  glsec:ci (alpine 3.21.7)  alpine    0 vulnerabilities
  usr/local/bin/glsec       gobinary  0 vulnerabilities
```

Trivy exit 0, and `zizmor` reports no findings on the updated workflow. The action is SHA-pinned (`v0.36.0`) to match the repo convention.