### PR TITLE
chore: align go.mod to Go 1.26 to match Docker builder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/glsec/glsec
 
-go 1.25.0
+go 1.26.0
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## What changed

Bumps the `go` directive in `go.mod` from `1.25.0` to `1.26.0`.

## Why

The build environment and the Docker build were on different Go minor versions:

- `go.mod` declared `go 1.25.0`
- the Dockerfile builder uses `golang:1.26-alpine` (bumped in #390)
- CI reads the toolchain from `go.mod` via `go-version-file`, so it was building and testing on 1.25 while the released image was built on 1.26

Aligning `go.mod` to `1.26.0` makes all three (local, CI, Docker) use the same Go minor version.

The directive is set to the minor floor `1.26.0` rather than a pinned patch. The "always latest patch" behaviour comes from the `golang:1.26-alpine` tag plus the weekly rebuild, so both the builder and CI pick up the newest 1.26 patch automatically without over-pinning the module.

## How to test

Verified with Go 1.26.5 (in a `golang:1.26` container, since the aligned module requires 1.26):

- `go build ./...` passes
- `go vet ./...` passes
- `go test -race ./...` passes across all packages
- `golangci-lint run ./...` reports 0 issues
- `docker build .` succeeds and the resulting binary runs

Closes #394
