### PR TITLE
ci: add hadolint and dockle Docker linting gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,31 @@ jobs:
           ignore-unfixed: true
           exit-code: "1"
 
+  hadolint:
+    name: Security (hadolint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Lint Dockerfile
+        run: docker run --rm -i hadolint/hadolint:v2.14.0 hadolint - < Dockerfile
+
+  dockle:
+    name: Security (dockle)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Build image
+        run: docker build -t glsec:ci .
+      - name: Lint image
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            goodwithtech/dockle:v0.4.15 --exit-code 1 --exit-level warn glsec:ci
+
   validate-fixtures:
     name: Validate GitLab CI fixtures
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -o glsec ./cmd/glsec
 
 FROM alpine:3.24
-RUN apk add --no-cache ca-certificates
 COPY --from=builder /build/glsec /usr/local/bin/glsec
+USER 65532:65532
 ENTRYPOINT ["glsec"]


### PR DESCRIPTION
## What changed

1. **Dockerfile hardening** (minimal, base-image-independent):
   - runs as a non-root user (`USER 65532:65532`)
   - drops the `ca-certificates` install: glsec makes no network or TLS calls (verified by grep over the source), so the certs were unused weight
2. **Two new CI jobs** alongside the Trivy image scan:
   - **Security (hadolint)** lints the `Dockerfile`
   - **Security (dockle)** builds the image and checks it against the CIS Docker Benchmark

Both jobs use official images pinned to a fixed version (`hadolint/hadolint:v2.14.0`, `goodwithtech/dockle:v0.4.15`) via `run:` steps, so no new `uses:` action is added and zizmor stays clean.

## Why

Trivy `scan-type: image` covers OS and library CVEs but does not lint the Dockerfile for misconfiguration nor check image hardening (root user, permissions). hadolint and dockle fill that gap.

The two findings these tools reported on the previous Dockerfile (hadolint `DL3018` unpinned `apk add`, dockle `CIS-DI-0001` root user) are fixed at the root here rather than suppressed, so both jobs pass as real blocking gates from the start.

This also brings the uncontroversial part of the hardening (non-root) onto `main` independently of the separate base-image discussion in #396.

## When they run

Same triggers as every other job in this workflow (`push` to `main` and `pull_request` to `main`), so exactly as often as the Trivy job.

## How to test

Verified locally:

- `docker build .` succeeds
- `docker run --rm <image> --version` runs, and `id` reports `uid=65532 gid=65532` (non-root confirmed)
- `docker run --rm <image> list` reports all 80 rules (the tool still works as non-root)
- hadolint exits 0 with no findings
- dockle exits 0 (only two INFO items remain: Content Trust and HEALTHCHECK)
- zizmor reports no findings on the updated workflow