### PR TITLE
ci: attest image build provenance (SLSA) on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # keyless signing of the provenance via Sigstore
+  attestations: write # write the attestation to the GitHub attestations API
 
 jobs:
   docker:
@@ -40,6 +42,7 @@ jobs:
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        id: build
         with:
           context: .
           push: true
@@ -49,3 +52,10 @@ jobs:
             DATE=${{ steps.date.outputs.date }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/glsec/glsec
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Part of #395 (image half; the release-binary half will follow in a separate PR).

## What changed

Adds signed SLSA build provenance for the container image in `docker.yml`:

- gives the `build-push-action` step an `id` so its pushed digest is available
- adds `actions/attest-build-provenance` to generate and sign a provenance attestation for the pushed image, and pushes it to the registry as a referrer
- adds the two permissions this needs: `id-token: write` (keyless Sigstore signing via OIDC) and `attestations: write`

No key management is involved: signing is keyless through Sigstore, so there is no public or private key to publish or protect.

## Why

Today the image on `ghcr.io/glsec/glsec` only carries the default unsigned BuildKit provenance, which is not verifiable to us. This adds a provenance attestation signed by GitHub's OIDC identity, so anyone can confirm the image was built by this repo's workflow from a specific commit. For a supply-chain security tool this is the hygiene we should model.

## How to verify (after the next tagged release)

Local static checks only for now, since the attestation is produced at release time in CI:

- `.github/workflows/docker.yml` parses as valid YAML
- zizmor reports no findings on the workflow

Once a `v*` tag is released with this change, the attestation can be verified against the image:

```
gh attestation verify oci://ghcr.io/glsec/glsec:<tag> --owner glsec
cosign tree ghcr.io/glsec/glsec:<tag>
```

and it will show up in the repository's Attestations tab. Before this change those commands return nothing.
