### PR TITLE
ci: attest release binary provenance (SLSA) on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write # keyless signing of the provenance via Sigstore
+  attestations: write # write the attestation to the GitHub attestations API
 
 jobs:
   release:
@@ -27,3 +29,10 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip


### PR DESCRIPTION
Part of #395 (release-binary half; the image half is #401). Once both are merged, #395 can be closed.

## What changed

Adds signed SLSA build provenance for the release artifacts in `release.yml`:

- adds `actions/attest-build-provenance` after the GoReleaser step to attest the built archives (`dist/*.tar.gz`, `dist/*.zip`)
- adds the two permissions this needs: `id-token: write` (keyless Sigstore signing via OIDC) and `attestations: write`

Signing is keyless through Sigstore, so there is no key to manage.

## Why

The release binaries currently have no provenance at all. This attaches a signed provenance attestation to each published archive, so anyone downloading a glsec release can confirm it was built by this repo's workflow from a specific commit rather than tampered with or repackaged.

This is the release-binary counterpart to the image provenance in #401. Together they cover both artifact streams glsec publishes (the ghcr image and the GitHub Release archives).

## How to verify (after the next tagged release)

Local static checks only for now, since the attestation is produced at release time in CI:

- `.github/workflows/release.yml` parses as valid YAML
- zizmor reports no findings on the workflow

Once a `v*` tag is released with this change, a downloaded archive can be verified by its digest:

```
gh attestation verify glsec_<version>_linux_amd64.tar.gz --owner glsec
```

and the attestations appear in the repository's Attestations tab.
