### PR TITLE
ci: sign image and add SBOMs (SLSA phase 2 + 3)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,3 +59,26 @@ jobs:
           subject-name: ghcr.io/glsec/glsec
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/glsec/glsec@$DIGEST"
+
+      - name: Generate image SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/glsec/glsec@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest image SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/glsec/glsec
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+      - name: Install syft (for SBOM generation)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,9 @@ checksum:
   name_template: checksums.txt
   algorithm: sha256
 
+sboms:
+  - artifacts: archive
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Closes #395. Builds on the provenance work already merged (#401 image, #402 releases) by adding container signing and SBOMs.

## What changed

**Image (`docker.yml`):**
- `cosign sign` (keyless) signs the pushed image, so it can be verified with `cosign verify` (the format Kubernetes admission policies such as Kyverno / policy-controller check).
- an SBOM is generated from the image with syft (`anchore/sbom-action`) and attached as a signed attestation via `actions/attest-sbom` (`push-to-registry`).

**Releases (`release.yml` + `.goreleaser.yml`):**
- syft is installed and GoReleaser now emits an SBOM per archive (`sboms:` block), uploaded as release assets.

All signing is keyless through Sigstore (the `id-token: write` / `attestations: write` permissions were already added in the provenance PRs), so there is still no key to manage.

## Scope note

Phase 2 (cosign signing) is applied to the **image only**. The release binaries are not separately signed with `cosign sign-blob`: that format is non-standard for release archives, and the binaries already carry a signed provenance attestation from #402 that verifies with `gh attestation verify`. cosign-`verify` interop matters for the container (admission control), not for downloaded binaries.

## How verified

- `goreleaser check` validates the config, and a full `goreleaser release --snapshot` with syft installed produced one SBOM per archive (6 files), so the release SBOM path works end to end locally.
- zizmor reports no findings on both workflows. It flagged a template-injection on the cosign digest expression, which is fixed by passing the digest through an env var instead of interpolating it into the run command.
- YAML parses for all three files.

The image signing and both attestations only run on a `v*` tag, so they are exercised at the next release. After that:

```
cosign verify ghcr.io/glsec/glsec:<tag> \
  --certificate-identity-regexp 'https://github.com/glsec/glsec/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
cosign tree ghcr.io/glsec/glsec:<tag>          # now lists signature + SBOM
gh attestation verify oci://ghcr.io/glsec/glsec:<tag> --owner glsec
```
