### PR TITLE
build(docker): add OCI image labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,21 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 FROM alpine:3.24
 COPY --from=builder /build/glsec /usr/local/bin/glsec
+
+# ARGs do not cross build stages, so re-declare them here for the LABELs
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
+ARG GH=https://github.com/glsec/glsec
+LABEL org.opencontainers.image.title="glsec" \
+      org.opencontainers.image.description="Security linter for GitLab CI (.gitlab-ci.yml) files" \
+      org.opencontainers.image.url="${GH}" \
+      org.opencontainers.image.source="${GH}" \
+      org.opencontainers.image.documentation="${GH}/blob/main/README.md" \
+      org.opencontainers.image.vendor="glsec" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.created="${DATE}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${COMMIT}"
 USER 65532:65532
 ENTRYPOINT ["glsec"]


### PR DESCRIPTION
Adopts the OCI image labels from #396 onto the current Alpine-based image.

## What changed

Adds standard `org.opencontainers.image.*` annotations (title, description, source, url, documentation, vendor, licenses, created, version, revision) to the final stage of the `Dockerfile`. The build args are re-declared in the final stage because `ARG`s do not cross build stages.

## Why

Labels make the published image self-describing (source repo, license, version, commit) for anyone inspecting it with `docker inspect` or a registry UI. This is the uncontroversial, dependency-free part of #396.

Note: `docker.yml` already injects OCI labels at release time via `docker/metadata-action`, which take precedence for the release build. These Dockerfile labels provide the same baseline for every other build (local `docker build`, the CI image-scan jobs), so nothing conflicts.

## How verified

Built with `--build-arg VERSION=1.10.0 --build-arg COMMIT=abc1234 --build-arg DATE=...`:

- all ten labels are present and the version/revision/created values are populated from the build args
- the image runs and reports the injected version, still as non-root (`uid 65532`)
- hadolint reports no findings
- dockle passes (only the two informational items remain)

## Relation to #396

The colleague's #396 proposed switching the base images to Docker Hardened Images (dhi.io) plus non-root, digest pinning, a cert stage, and these labels. Non-root landed already in #400, and glsec makes no network calls so the cert stage is unnecessary. We are keeping the public Alpine base rather than dhi.io (which needs an authenticated pull, so fork-PR CI and local builds would need a Docker login) and taking the labels here. Full reasoning goes in a comment on #396.
