### PR TITLE
feat(output): add JUnit XML report format

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ glsec --format sarif .gitlab-ci.yml > gl.sarif
 # Code Climate output for GitLab Code Quality (inline MR findings, works on all tiers)
 glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json
 
+# JUnit output for the pipeline Tests tab / MR test widget (works on all tiers)
+glsec --format junit .gitlab-ci.yml > glsec-junit.xml
+
 # treat warn findings as hard failures (exit 1)
 glsec --strict .gitlab-ci.yml
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -60,7 +60,7 @@ func main() {
 		return
 	}
 
-	formatFlag := flag.String("format", "text", "output format: text, table, json, sarif, codeclimate")
+	formatFlag := flag.String("format", "text", "output format: text, table, json, sarif, codeclimate, junit")
 	configFlag := flag.String("config", config.DefaultFile, "path to .glsec.yml config file")
 	versionFlag := flag.Bool("version", false, "print version and exit")
 	gitlabVersionFlag := flag.String("gitlab-version", "", "target GitLab version, e.g. 16.0 (skips rules not available in that version)")
@@ -118,7 +118,7 @@ func main() {
 
 	format, ok := output.ParseFormat(*formatFlag)
 	if !ok {
-		fmt.Fprintf(os.Stderr, "unknown format %q — use text, table, json, sarif, or codeclimate\n", *formatFlag)
+		fmt.Fprintf(os.Stderr, "unknown format %q — use text, table, json, sarif, codeclimate, or junit\n", *formatFlag)
 		os.Exit(2)
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"strings"
@@ -21,11 +22,12 @@ const (
 	FormatSARIF       Format = "sarif"
 	FormatCodeClimate Format = "codeclimate"
 	FormatTable       Format = "table"
+	FormatJUnit       Format = "junit"
 )
 
 func ParseFormat(s string) (Format, bool) {
 	switch Format(s) {
-	case FormatText, FormatJSON, FormatSARIF, FormatCodeClimate, FormatTable:
+	case FormatText, FormatJSON, FormatSARIF, FormatCodeClimate, FormatTable, FormatJUnit:
 		return Format(s), true
 	default:
 		return "", false
@@ -43,6 +45,8 @@ func Write(w io.Writer, format Format, findings []finding.Finding, jobCount int,
 		return writeSARIF(w, findings, nil, nil, nil, nil, nil, nil)
 	case FormatCodeClimate:
 		return writeCodeClimate(w, findings)
+	case FormatJUnit:
+		return writeJUnit(w, findings)
 	case FormatTable:
 		return writeTable(w, findings, jobCount, isTTY)
 	default:
@@ -450,4 +454,81 @@ func writeCodeClimate(w io.Writer, findings []finding.Finding) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
+}
+
+type junitTestsuites struct {
+	XMLName  xml.Name         `xml:"testsuites"`
+	Name     string           `xml:"name,attr"`
+	Tests    int              `xml:"tests,attr"`
+	Failures int              `xml:"failures,attr"`
+	Suites   []junitTestsuite `xml:"testsuite"`
+}
+
+type junitTestsuite struct {
+	Name     string          `xml:"name,attr"`
+	Tests    int             `xml:"tests,attr"`
+	Failures int             `xml:"failures,attr"`
+	Cases    []junitTestcase `xml:"testcase"`
+}
+
+type junitTestcase struct {
+	Name      string        `xml:"name,attr"`
+	Classname string        `xml:"classname,attr"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Text    string `xml:",chardata"`
+}
+
+// writeJUnit renders findings as a JUnit XML report, consumed by GitLab's
+// pipeline Tests tab and MR test widget via artifacts:reports:junit (all tiers).
+// Each finding becomes one failing test case; a clean run emits a single
+// passing case so the widget is not empty.
+func writeJUnit(w io.Writer, findings []finding.Finding) error {
+	suite := junitTestsuite{Name: "glsec"}
+	if len(findings) == 0 {
+		suite.Tests = 1
+		suite.Cases = []junitTestcase{{Name: "glsec: no findings", Classname: "glsec"}}
+	} else {
+		for _, f := range findings {
+			loc := f.File
+			if f.Line > 0 {
+				loc = fmt.Sprintf("%s:%d", f.File, f.Line)
+			}
+			name := f.RuleID
+			if f.Job != "" {
+				name = fmt.Sprintf("%s in job %q", f.RuleID, f.Job)
+			}
+			suite.Cases = append(suite.Cases, junitTestcase{
+				Name:      name,
+				Classname: loc,
+				Failure: &junitFailure{
+					Message: f.Message,
+					Type:    string(f.Severity),
+					Text:    fmt.Sprintf("%s [%s] %s", f.RuleID, f.Severity, loc),
+				},
+			})
+		}
+		suite.Tests = len(findings)
+		suite.Failures = len(findings)
+	}
+	root := junitTestsuites{
+		Name:     "glsec",
+		Tests:    suite.Tests,
+		Failures: suite.Failures,
+		Suites:   []junitTestsuite{suite},
+	}
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(root); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\n")
+	return err
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"strings"
 	"testing"
 
@@ -214,6 +215,7 @@ func TestParseFormat(t *testing.T) {
 		{"json", FormatJSON, true},
 		{"sarif", FormatSARIF, true},
 		{"codeclimate", FormatCodeClimate, true},
+		{"junit", FormatJUnit, true},
 		{"xml", "", false},
 		{"", "", false},
 	} {
@@ -221,6 +223,50 @@ func TestParseFormat(t *testing.T) {
 		if ok != tc.ok || got != tc.want {
 			t.Errorf("ParseFormat(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
 		}
+	}
+}
+
+func TestWriteJUnit(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatJUnit, testFindingsWithJob, 3, false, false); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	var root junitTestsuites
+	if err := xml.Unmarshal(buf.Bytes(), &root); err != nil {
+		t.Fatalf("output is not valid XML: %v\n%s", err, buf.String())
+	}
+	if root.Tests != 3 || root.Failures != 3 {
+		t.Errorf("root tests/failures = %d/%d, want 3/3", root.Tests, root.Failures)
+	}
+	if len(root.Suites) != 1 || len(root.Suites[0].Cases) != 3 {
+		t.Fatalf("expected 1 suite with 3 cases, got %d suites", len(root.Suites))
+	}
+	c := root.Suites[0].Cases[0]
+	if c.Failure == nil {
+		t.Fatal("expected a failure element on the first case")
+	}
+	if !strings.Contains(c.Name, "GL024") || !strings.Contains(c.Name, "phpmd") {
+		t.Errorf("case name %q should mention the rule and job", c.Name)
+	}
+	if c.Classname != ".gitlab-ci.yml:52" {
+		t.Errorf("classname = %q, want .gitlab-ci.yml:52", c.Classname)
+	}
+}
+
+func TestWriteJUnit_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatJUnit, nil, 4, false, false); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	var root junitTestsuites
+	if err := xml.Unmarshal(buf.Bytes(), &root); err != nil {
+		t.Fatalf("output is not valid XML: %v", err)
+	}
+	if root.Failures != 0 {
+		t.Errorf("clean run should report 0 failures, got %d", root.Failures)
+	}
+	if len(root.Suites) != 1 || len(root.Suites[0].Cases) != 1 || root.Suites[0].Cases[0].Failure != nil {
+		t.Error("clean run should emit a single passing case")
 	}
 }
 


### PR DESCRIPTION
Closes #397.

## What changed

Adds a `junit` output format (`glsec --format junit`) that renders findings as a JUnit XML report.

- `internal/output/output.go`: new `FormatJUnit`, registered in `ParseFormat` and the `Write` dispatch, plus a `writeJUnit` renderer built on `encoding/xml` (so attribute and text content are escaped correctly).
- `cmd/glsec/main.go`: `junit` added to the `--format` help text and the unknown-format error.
- `README.md`: usage example.
- Tests for the populated and clean cases, plus a `ParseFormat` entry.

## Shape of the report

- One `<testsuite name="glsec">` inside `<testsuites>`.
- One `<testcase>` per finding, `classname` = `file:line`, `name` = rule id (and job when present), with a nested `<failure message="..." type="<severity>">`.
- `tests` and `failures` counts reflect the findings.
- A clean run emits a single passing test case so the GitLab widget is not empty.

Pipeline wire-up:

```yaml
glsec:
  script: glsec --format junit .gitlab-ci.yml > glsec-junit.xml
  artifacts:
    reports:
      junit: glsec-junit.xml
    when: always
```

## Why

Unlike the SAST report (Security widget, Ultimate only), JUnit renders in the pipeline Tests tab and the merge request test summary on every GitLab tier, surfacing each finding as a named failing test where a reviewer sees it without opening the job log. It is also a widely consumed generic CI format.

## How to test

Verified with Go 1.26:

- `go test ./...` passes, including new `TestWriteJUnit` (three findings become three failing cases with correct classname/name) and `TestWriteJUnit_Empty` (one passing case, zero failures)
- `golangci-lint run ./...` reports 0 issues
- end to end: `glsec --format junit <fixture>` emits well-formed XML that parses back cleanly, with proper entity escaping of quotes in messages and job names
