### PR TITLE
chore: bump version references to 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.10.0
+    rev: v1.11.0
     hooks:
       - id: glsec
 ```
@@ -315,13 +315,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.10.0
+    name: ghcr.io/glsec/glsec:1.11.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.10.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.11.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -329,7 +329,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.10.0"
+  GLSEC_VERSION: "1.11.0"
 
 glsec:
   stage: test
@@ -351,7 +351,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.10.0
+    name: ghcr.io/glsec/glsec:1.11.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -370,7 +370,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.10.0
+    name: ghcr.io/glsec/glsec:1.11.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true


### PR DESCRIPTION
Bumps the hardcoded image/version references in the README from 1.10.0 to 1.11.0 ahead of the v1.11.0 release.