### PR TITLE
ci: attest checksums.txt alongside release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
+          # checksums.txt is attested too: the install docs verify downloads
+          # against it, so it needs its own anchor, not just the archives.
           subject-path: |
             dist/*.tar.gz
             dist/*.zip
+            dist/checksums.txt


### PR DESCRIPTION
Closes #409.

## What changed

Adds `dist/checksums.txt` to the `subject-path` list of the release provenance attestation, so the checksums file gets its own attestation alongside the archives.

## Correction to the issue

The issue listed `subject-checksums: dist/checksums.txt` as the smallest option. That would **not** have closed the gap. Per the `actions/attest` documentation, `subject-checksums` creates attestation subjects for the artifacts **listed inside** the checksums file, using their names and digests. The checksums file itself is not attested by it; it only serves as a manifest. Since the archives were already covered by the existing globs, switching to `subject-checksums` would have changed the enumeration source without adding the missing anchor.

Adding the file to `subject-path` is what actually attests it.

## Why this matters

The archives were already attested, so `gh attestation verify <archive> --owner glsec` already worked. The gap was in the path the docs actually tell users to take: README install instructions and the plugin wrapper both verify a download **against `checksums.txt`**, and that file had nothing vouching for it. An attacker replacing the release assets could regenerate a matching checksums file and the documented check would still pass.

With this change a user can verify `checksums.txt` itself, then trust the digests inside it.

## How verified

- a full `goreleaser release --snapshot` confirms all seven subject files exist with exactly the expected names: `checksums.txt`, four `*.tar.gz`, two `*.zip`, so every glob in `subject-path` matches
- `release.yml` parses as valid YAML
- zizmor reports no findings

The attestation itself is only produced on a `v*` tag, so it is exercised at the next release. After that, `gh attestation verify checksums.txt --owner glsec` should succeed.

## Follow-up

#410 (verification docs) should document the checksums-anchored path now that it has an anchor, or point users at direct archive verification, whichever we prefer as the primary instruction.
