### PR TITLE
ci: require a green CI run before releasing or publishing the image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,16 +5,42 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write # keyless signing of the provenance via Sigstore
-  attestations: write # write the attestation to the GitHub attestations API
+# Default-deny at the workflow level; each job grants only what it needs.
+permissions: {}
 
 jobs:
+  # Tags can point at any commit, so require that CI actually passed for it
+  # before publishing. Fails closed: no completed CI run means no image push.
+  gate:
+    name: Require green CI
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Require a successful CI run for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          conclusion=$(gh api \
+            "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&status=completed" \
+            --jq '.workflow_runs[0].conclusion // "none"')
+          echo "CI conclusion for $SHA: $conclusion"
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::Image publish blocked: CI for $SHA concluded '$conclusion', expected 'success'. Wait for CI to finish, then re-run this workflow."
+            exit 1
+          fi
+
   docker:
     name: Build and push Docker image
+    needs: gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      packages: write # push the image to ghcr
+      id-token: write # keyless signing of the provenance via Sigstore
+      attestations: write # write the attestation to the GitHub attestations API
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,41 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write # keyless signing of the provenance via Sigstore
-  attestations: write # write the attestation to the GitHub attestations API
+# Default-deny at the workflow level; each job grants only what it needs.
+permissions: {}
 
 jobs:
+  # Tags can point at any commit, so require that CI actually passed for it
+  # before publishing. Fails closed: no completed CI run means no release.
+  gate:
+    name: Require green CI
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Require a successful CI run for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          conclusion=$(gh api \
+            "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&status=completed" \
+            --jq '.workflow_runs[0].conclusion // "none"')
+          echo "CI conclusion for $SHA: $conclusion"
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::Release blocked: CI for $SHA concluded '$conclusion', expected 'success'. Wait for CI to finish, then re-run this workflow."
+            exit 1
+          fi
+
   release:
     name: Release
+    needs: gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub release
+      id-token: write # keyless signing of the provenance via Sigstore
+      attestations: write # write the attestation to the GitHub attestations API
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Closes #411.

## What changed

Both release workflows now start with a `gate` job that requires a successful CI run for the tagged commit, and the publishing job `needs: gate`.

- `release.yml`: gate before the GoReleaser job
- `docker.yml`: gate before the image build and push

The gate queries the CI workflow's runs for `github.sha` and fails unless the newest completed run concluded `success`. It **fails closed**: a commit with no completed CI run (a tag on an arbitrary commit, or CI still running) does not release.

## Why both workflows

Both trigger on the same `v*` tags and publish independently. Gating only one would let the image publish while the binary release is blocked, leaving the two halves of a release out of sync.

## Permissions restructure (required, not incidental)

Adding a second job to each workflow surfaced a real issue: the workflow-level `contents: write` / `id-token: write` / `attestations: write` grants applied to *every* job, including a gate job that only needs `actions: read`. zizmor flagged this as `excessive-permissions` (6 high findings).

Fixed properly rather than suppressed:

- workflow level is now `permissions: {}` (default-deny)
- the gate job grants `actions: read`
- the publishing jobs grant exactly what they use, with a comment per line

This is a genuine hardening improvement that the gate change forced into the open.

## How verified

The gate query was tested live against real commits before committing:

- `1e27bd9` (current `main`, CI green) returns `success`, so the gate passes
- the repository's initial commit, which never ran CI, returns `none`, so the gate blocks

Also:

- both workflows parse as valid YAML
- zizmor reports no findings and exits 0 (it reported 6 high findings before the permissions restructure)

The gate only executes on a `v*` tag, so it is exercised end to end at the next release.

## Operational note

If a tag is pushed while CI is still running, the gate fails closed with a clear message. The fix is to wait for CI and re-run the blocked workflow from the Actions tab, rather than deleting and re-pushing the tag.
