### PR TITLE
docs: document how to verify a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,42 @@ curl -sSL https://github.com/glsec/glsec/releases/latest/download/glsec_linux_am
 
 Homebrew coming soon.
 
+## Verifying a release
+
+Every release is signed and carries build provenance, so you can confirm an artifact really came from this repository's workflow before trusting it. Signing is keyless through [Sigstore](https://www.sigstore.dev/), so there is no public key to fetch or rotate.
+
+**Release binaries** carry a SLSA provenance attestation. Verify a downloaded archive with the [GitHub CLI](https://cli.github.com/):
+
+```sh
+gh attestation verify glsec_1.11.0_linux_amd64.tar.gz --owner glsec
+```
+
+**The container image** is signed with [cosign](https://github.com/sigstore/cosign) and carries provenance plus an SBOM attestation:
+
+```sh
+cosign verify ghcr.io/glsec/glsec:1.11.0 \
+  --certificate-identity-regexp 'https://github.com/glsec/glsec/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# list everything attached to the image (signature, provenance, SBOM)
+cosign tree ghcr.io/glsec/glsec:1.11.0
+```
+
+The two `--certificate-*` flags are what bind the signature to this repository's GitHub Actions workflow. Without them `cosign verify` accepts a signature from any identity, which defeats the point.
+
+**Checksums** are published as `checksums.txt` next to the archives:
+
+```sh
+curl -sSLO https://github.com/glsec/glsec/releases/download/v1.11.0/checksums.txt
+sha256sum -c checksums.txt --ignore-missing
+```
+
+Releases after v1.11.0 also attest `checksums.txt` itself, so the checksums file can be verified first and the digests it lists then trusted:
+
+```sh
+gh attestation verify checksums.txt --owner glsec
+```
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
Closes #410.

## What changed

Adds a "Verifying a release" section to the README, placed directly after "Install" so the flow reads download then verify. It covers all three artifact types:

- **release binaries**: `gh attestation verify <archive> --owner glsec`
- **container image**: `cosign verify` with the identity flags, plus `cosign tree` to list what is attached
- **checksums**: `sha256sum -c checksums.txt --ignore-missing`

It also explains *why* the two `--certificate-*` flags matter, since without them `cosign verify` accepts a signature from any identity, which is the mistake this kind of documentation usually invites.

## Verified before documenting

Every command was checked against the real v1.11.0 release rather than written from memory:

- `cosign verify ghcr.io/glsec/glsec:1.11.0` with the documented flags exits 0 and reports the certificate verified against the trusted CA and the transparency log entry
- the linux/amd64 archive from v1.11.0 was downloaded and its digest queried against the attestations API: one attestation exists, predicate type `https://slsa.dev/provenance/v1`, so `gh attestation verify` works for it
- `sha256sum -c checksums.txt --ignore-missing` was tested both ways: it reports OK for the genuine archive, and FAILED with exit 1 after appending a single byte, so it actually detects tampering

## One accuracy note

`checksums.txt` for v1.11.0 is **not** attested. That was confirmed directly: its digest returns 404 from the attestations API. The attestation for it landed in #415, which merged after v1.11.0 shipped.

The section therefore documents the checksums attestation as applying to "releases after v1.11.0" rather than presenting a command that would fail today. The wording resolves itself once the next release ships, without naming a specific future version.

## Version numbers

The examples use concrete versions (`1.11.0`) rather than placeholders, matching the existing README convention. They are covered by the version bump that already happens as part of cutting a release.
