### PR TITLE
ci: add a 7 day Dependabot cooldown for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,31 @@
 version: 2
+
+# cooldown holds back a version update until the release has been out for a
+# while, which is the window in which a compromised release is usually caught
+# and pulled. GitHub's built-in default is 3 days, so 7 is the first value that
+# changes anything. Security updates are exempt from cooldown, so CVE fixes are
+# not delayed by it.
 updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Part of #413.

## What changed

Adds `cooldown: default-days: 7` to all three ecosystem entries (`gomod`, `github-actions`, `docker`) in `.github/dependabot.yml`, plus a short comment recording why the value is 7 and not something smaller.

## Why 7 and not 3

GitHub applies a **built-in cooldown of 3 days** when none is configured, confirmed in the Dependabot options reference. Setting `default-days: 3` would therefore change nothing. 7 is the first value that actually holds anything back, and it is where comparable projects have landed.

## Why the cost is low

Per the same reference, cooldown applies to **version updates only, not security updates**, so CVE fixes are not delayed by it.

That exemption is the whole reason this is cheap, which leads to the one open dependency below.

## Open dependency: this should not merge alone

**Dependabot security updates are currently disabled for this repository.** With them off, the exemption above buys nothing: version updates get held back 7 days and there is no security-update path running alongside to deliver urgent fixes faster. Merging the cooldown on its own would make patching slightly slower without the compensating mechanism.

Enable Dependabot security updates (Settings, Code security) before or together with merging this. The second acceptance criterion on #413 covers exactly this, which is why this PR says "Part of" rather than "Closes".

## How verified

- placement confirmed against the Dependabot options reference: `cooldown` is a key inside each `updates:` entry, not top level
- `.github/dependabot.yml` parses, and all three ecosystem entries carry `cooldown: {default-days: 7}`
