### PR TITLE
docs: record why release-archive SBOMs ship unattested

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Releases after v1.11.0 also attest `checksums.txt` itself, so the checksums file
 gh attestation verify checksums.txt --owner glsec
 ```
 
+**SBOMs**: the container image carries its SBOM as a signed attestation, listed by `cosign tree` above. The per-archive `.sbom.json` files are published as plain release assets rather than attestations, deliberately. Each contains four entries: glsec itself, its single dependency `gopkg.in/yaml.v3`, the Go standard library, and the archive's own digest. That is the same information `go.mod` already makes public, and the archive it describes is covered by provenance, so a swapped SBOM cannot make a tampered archive verify. If you need an SBOM you can trust end to end, use the image attestation or regenerate one from a verified archive with [syft](https://github.com/anchore/syft).
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
Closes #412.

The issue allowed either outcome: attest the per-archive SBOMs, or record a decision not to. This takes the second option, and documents the reasoning where users will actually encounter it.

## The evidence

I inspected a real v1.11.0 archive SBOM before deciding. It is SPDX 2.3 and contains exactly **four** entries:

```
github.com/glsec/glsec v1.11.0                 the module itself
gopkg.in/yaml.v3 v3.0.1                        the only third-party dependency
stdlib go1.26.0                                the Go standard library
glsec_1.11.0_linux_amd64.tar.gz  sha256:...    the archive and its digest
```

## Why not attest them

- the informational content is effectively what `go.mod` already publishes: one third-party dependency
- the archive the SBOM describes **is** covered by build provenance, so a swapped SBOM cannot make a tampered archive pass verification. The failure mode is "misleading inventory", not "undetected tampering"
- the image SBOM, which covers the same dependency graph plus the base image packages, is already a signed attestation
- attesting six per-archive SBOMs needs a matrix or loop in `release.yml`, which is the workflow where added complexity is least welcome

The cost lands in the most safety-critical workflow; the benefit is attesting a four-line document whose content is public.

## What changed

A paragraph in the README's "Verifying a release" section stating that the per-archive SBOMs are plain assets by choice, why that is sufficient, and what to do if you need an SBOM you can trust end to end: use the image attestation, or regenerate one from a verified archive with syft.

That last part matters. The decision is only defensible because a user who needs a trustworthy SBOM has a working path, and now the docs point at it.

## Revisit if

glsec grows a real dependency tree. The argument rests on the dependency set being one package, and it stops holding if that changes.
