### PR TITLE
ci: exclude test fixtures from secret scanning

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,9 @@
+# glsec's GL006 and GL027 rules detect hardcoded secrets, so their test
+# fixtures contain deliberately fake tokens (for example AKIAIOSFODNN7EXAMPLE
+# and glpat-xxxxxxxxxxxxxxxxxxxx). Excluding the fixture directory keeps those
+# from raising alerts or blocking pushes via push protection.
+#
+# Scoped deliberately narrowly: only testdata/fixtures, not all of testdata/
+# and not docs/, so a real secret committed anywhere else is still caught.
+paths-ignore:
+  - "testdata/fixtures/**"


### PR DESCRIPTION
Prepares the repository for enabling secret scanning and push protection, which are currently disabled.

## Why this is needed first

glsec's GL006 and GL027 rules detect hardcoded secrets, so their fixtures contain deliberately fake tokens. Enabling push protection without an exclusion could block pushes that touch those files.

## The actual exposure is small

Six files in the repository contain secret-shaped strings, and the values are benign:

- `AKIAIOSFODNN7EXAMPLE`, which is AWS's own documentation example key and is commonly allowlisted by detectors
- `glpat-xxxxxxxxxxxxxxxxxxxx`, placeholder x characters with no valid checksum
- no real PEM block anywhere; `docs/rules/GL006.md` only describes the header pattern in a table

Many provider detectors require a structurally valid token, so these likely never fire. This config is insurance rather than a fix for an observed problem.

## Scope

`paths-ignore` covers **both** alerts and push protection, per GitHub's documentation, so this addresses the blocking concern and not just alert noise.

Scoped deliberately to `testdata/fixtures/**` only:

- not all of `testdata/`, and not `docs/`, so a real secret committed anywhere else is still caught
- the trade-off is explicit: a genuinely leaked secret placed inside the fixtures directory would go undetected. For a directory whose entire purpose is synthetic test input, that seems acceptable, and narrowing the scope keeps the blind spot as small as possible

## After merging

Enable secret scanning and push protection in repository settings. Landing this config first means neither can disrupt anything.
