### PR TITLE
ci: drop literal token from secret scanning config, exclude gl006 test

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,9 +1,12 @@
-# glsec's GL006 and GL027 rules detect hardcoded secrets, so their test
-# fixtures contain deliberately fake tokens (for example AKIAIOSFODNN7EXAMPLE
-# and glpat-xxxxxxxxxxxxxxxxxxxx). Excluding the fixture directory keeps those
-# from raising alerts or blocking pushes via push protection.
+# glsec's GL006 and GL027 rules detect hardcoded secrets, so their fixtures and
+# unit tests contain deliberately fake tokens: placeholder strings and vendors'
+# own documentation example values. Excluding those paths keeps them from
+# raising alerts or blocking pushes via push protection.
 #
-# Scoped deliberately narrowly: only testdata/fixtures, not all of testdata/
-# and not docs/, so a real secret committed anywhere else is still caught.
+# Kept deliberately narrow, so a real secret committed anywhere else is still
+# caught. Only paths that have demonstrably triggered a detector are listed.
+#
+# This file must not itself contain literal token values.
 paths-ignore:
   - "testdata/fixtures/**"
+  - "rules/gl006_test.go"


### PR DESCRIPTION
Follow-up to the first secret scanning alert, which was a false positive.

## What was reported

One alert, "Amazon AWS Temporary Access Key ID", with two locations:

- `testdata/fixtures/gl006-hardcoded-secrets.yml` (already excluded)
- `rules/gl006_test.go` (not excluded, so the alert fired)

The value is `AKIAIOSFODNN7EXAMPLE`, AWS's own documentation example key.

## Why the test cannot simply change the value

`TestGL006_PlaceholderExample_NoFinding` asserts that glsec does **not** flag placeholder values. That exact string is the test subject: glsec's `placeholderMarkers` list skips any value containing `example`, `placeholder`, `changeme` and similar. Replacing the value would hollow out the test.

Worth noting that glsec gets this right where GitHub's detector does not: the rule deliberately ignores documentation placeholders, which is precisely the false positive class that fired here.

## Self-inflicted part

The previous version of `.github/secret_scanning.yml` quoted the literal token value in a comment, in a file that is not itself excluded. That turned the exclusion config into a potential trigger. Removed, and the file now carries a note not to repeat it.

## Changes

- literal token value removed from the config comment
- `rules/gl006_test.go` added to `paths-ignore`

## Scope discipline

Only paths that have **demonstrably** triggered a detector are listed. `docs/rules/GL006.md` also contains the same value but did not raise an alert, so it is deliberately not excluded; it can be added if that ever changes. Broadening to something like `rules/*_test.go` would create a wider blind spot than the evidence justifies.

The trade-off remains explicit: a real secret committed inside the excluded paths would go undetected. Both are synthetic-input paths by design, and keeping the list minimal keeps that blind spot small.

## Alert handling

Alert #1 was resolved as `used_in_tests` with a comment explaining the value's role, rather than dismissed as a generic false positive, since that classification is the accurate one.
