### PR TITLE
feat(parser): lint GitLab CI/CD component templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ glsec --recursive .
 # also pick up CI configs with non-default names/paths during a recursive scan
 glsec --recursive --name '*.gitlab-ci.yml' --name 'ci/pipeline.yml' .
 
+# CI/CD Catalog component templates are detected automatically: a `spec:` header
+# followed by the template body. glsec lints the body and skips whole-pipeline
+# rules that a template fragment cannot satisfy.
+glsec templates/my-component.yml
+
 # aligned table view, easier to scan when there are many findings
 glsec --format table .gitlab-ci.yml
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -562,6 +562,9 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 		if !rules.EnabledFor(rule.ID(), gitlabVersion) {
 			continue
 		}
+		if doc.ComponentTemplate && !rules.AppliesToComponentTemplate(rule.ID()) {
+			continue
+		}
 		for _, f := range rule.Check(doc.Root, path) {
 			f = cfg.ApplySeverity(f)
 			if !cfg.AboveMinSeverity(f) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,7 +1,10 @@
 package parser
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -10,6 +13,11 @@ import (
 type Document struct {
 	Root *yaml.Node
 	File string
+	// ComponentTemplate reports whether the file is a GitLab CI/CD component
+	// template (a `spec:` document, then the template body). Root then points at
+	// the body. Such a file is a fragment, so rules that reason about a whole
+	// pipeline do not apply to it.
+	ComponentTemplate bool
 }
 
 func ParseFile(path string) (*Document, error) {
@@ -21,15 +29,51 @@ func ParseFile(path string) (*Document, error) {
 }
 
 func Parse(data []byte, file string) (*Document, error) {
-	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", file, err)
+	// Decode every document, not just the first: a CI/CD component template is a
+	// two-document stream (`spec:` inputs, then the template body).
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	var docs []*yaml.Node
+	for {
+		var n yaml.Node
+		err := dec.Decode(&n)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", file, err)
+		}
+		if n.Kind != 0 {
+			docs = append(docs, &n)
+		}
 	}
-	if root.Kind == 0 {
+	if len(docs) == 0 {
 		return nil, fmt.Errorf("%s: empty document", file)
 	}
-	ResolveReferences(&root)
-	return &Document{Root: &root, File: file}, nil
+
+	root := docs[0]
+	component := false
+	if len(docs) > 1 && hasSpecHeader(docs[0]) {
+		root = docs[1]
+		component = true
+	}
+	ResolveReferences(root)
+	return &Document{Root: root, File: file, ComponentTemplate: component}, nil
+}
+
+// hasSpecHeader reports whether a document is a component template's `spec:`
+// header. Only the key matters; its contents are input declarations, not CI
+// configuration, so there is nothing in them for the rules to check.
+func hasSpecHeader(doc *yaml.Node) bool {
+	mapping := Unwrap(doc)
+	if mapping.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == "spec" {
+			return true
+		}
+	}
+	return false
 }
 
 // MappingNode returns the top-level mapping node of the document.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -117,3 +117,50 @@ func TestEachJob_LineNumbers(t *testing.T) {
 		}
 	})
 }
+
+func TestParse_ComponentTemplate(t *testing.T) {
+	doc, err := Parse([]byte(`spec:
+  inputs:
+    version:
+      default: "1.0.0"
+---
+scan-job:
+  script: [echo hi]
+`), "template.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !doc.ComponentTemplate {
+		t.Error("expected the file to be detected as a component template")
+	}
+	m := doc.MappingNode()
+	if FindKey(m, "scan-job") == nil {
+		t.Error("expected the root to be the template body")
+	}
+	if FindKey(m, "spec") != nil {
+		t.Error("the spec header must not be the linted document")
+	}
+}
+
+func TestParse_PlainPipelineIsNotComponentTemplate(t *testing.T) {
+	doc, err := Parse([]byte("build:\n  script: [make]\n"), "ci.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if doc.ComponentTemplate {
+		t.Error("a single-document pipeline must not be treated as a component template")
+	}
+}
+
+func TestParse_MultiDocumentWithoutSpecUsesFirst(t *testing.T) {
+	doc, err := Parse([]byte("build:\n  script: [make]\n---\nother:\n  script: [x]\n"), "ci.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if doc.ComponentTemplate {
+		t.Error("multiple documents without a spec header are not a component template")
+	}
+	if FindKey(doc.MappingNode(), "build") == nil {
+		t.Error("expected the first document to be linted")
+	}
+}

--- a/rules/component.go
+++ b/rules/component.go
@@ -1,0 +1,20 @@
+package rules
+
+// wholePipelineRules reason about a pipeline as a whole, so they cannot be
+// evaluated against a CI/CD component template. A template is a fragment: the
+// consuming pipeline supplies the surrounding configuration.
+//
+// Kept deliberately small. Rules that merely *read* a top-level key when it is
+// present (GL043, GL074, GL080) degrade correctly on a fragment and stay
+// enabled; only rules that fire on its absence belong here.
+var wholePipelineRules = map[string]bool{
+	// GL053 flags a missing top-level workflow: block. A component template
+	// never has one, so it would fire on every template ever written.
+	"GL053": true,
+}
+
+// AppliesToComponentTemplate reports whether a rule is meaningful when the file
+// under analysis is a CI/CD component template rather than a full pipeline.
+func AppliesToComponentTemplate(id string) bool {
+	return !wholePipelineRules[id]
+}

--- a/rules/component_test.go
+++ b/rules/component_test.go
@@ -1,0 +1,14 @@
+package rules
+
+import "testing"
+
+func TestAppliesToComponentTemplate(t *testing.T) {
+	if AppliesToComponentTemplate("GL053") {
+		t.Error("GL053 checks for an absent top-level workflow: block, so it cannot apply to a fragment")
+	}
+	for _, id := range []string{"GL001", "GL002", "GL043", "GL074", "GL080"} {
+		if !AppliesToComponentTemplate(id) {
+			t.Errorf("%s should still apply to component templates", id)
+		}
+	}
+}


### PR DESCRIPTION
Closes #408.

## What changed

glsec can now lint GitLab CI/CD Catalog component templates. Previously it rejected them outright with `not a valid GitLab CI file: no recognisable GitLab CI content` (exit 2).

**Cause**: `yaml.Unmarshal` decodes only the first document of a stream. A component template is two documents, `spec:` inputs then the template body, so glsec only ever saw the `spec:` header, found no jobs, and bailed.

**Fix**, three small pieces:

- `internal/parser`: decode every document with `yaml.NewDecoder`. If there is more than one and the first carries a `spec:` key, lint the second and set `Document.ComponentTemplate`.
- `rules/component.go`: a small set of rules that reason about a whole pipeline and therefore cannot apply to a fragment.
- `cmd/glsec`: skip those rules when the document is a component template.

## Only GL053 is skipped

A template is a fragment, so it has no top-level `workflow:` block by design. GL053 fires on that absence and would flag every component template ever written.

The other three rules that touch `workflow:` (GL043, GL074, GL080) only read it when present and degrade correctly on a fragment, so they stay enabled. Being surgical here matters: broadly disabling rules for templates would quietly stop checking things that do apply, such as a component shipping an unpinned image.

## Verified against the real templates

Checked against the actual published templates from `gitlab.com/glsec-io/glsec`, not just synthetic fixtures:

- before: both rejected with exit 2
- after: both lint cleanly with no findings
- a plain single-document pipeline still reports GL053, confirming the skip is scoped to templates and did not weaken normal linting

Plus unit tests for template detection, a plain pipeline, a multi-document file *without* a `spec:` header (first document still wins, so existing behaviour is unchanged), and the rule-applicability helper.

`go test ./...` passes and `golangci-lint` reports 0 issues.

## One debugging note worth recording

While verifying, the fix appeared not to work: GL053 kept appearing after the change. The cause was the result cache returning findings computed by the previous binary, since the cache key does not change between two builds of the same commit. Re-running with `--no-cache` showed the correct behaviour. Worth knowing when testing rule changes locally.
