### PR TITLE
feat(suppress): support expiry dates on suppressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,33 @@ git checkout HEAD -- .gitlab-ci.yml
 glsec --new-only --baseline base.json .gitlab-ci.yml
 ```
 
+### Suppressions
+
+Silence a finding on a single line with an inline comment, optionally with a reason after `--`:
+
+```yaml
+build:
+  image: node:latest  # glsec:ignore GL001 -- base image is pinned by the platform
+```
+
+A suppression can also carry an **expiry date**, so accepted risk gets re-reviewed instead of becoming permanent:
+
+```yaml
+deploy:
+  script:
+    - ./deploy.sh  # glsec:ignore GL013 exp:2026-12-01 -- accepted until the migration lands
+```
+
+Once the date has passed the suppression stops applying, the finding is reported again, and glsec notes on stderr that the suppression expired, so a finding that reappears is traceable to the date rather than looking like a new violation. The expiry date itself is inclusive. A malformed date counts as expired, so a typo surfaces the finding rather than hiding it forever.
+
+The same token works in the `.glsec-ignore` baseline, appended to a line:
+
+```
+.gitlab-ci.yml:14 GL013 exp:2026-12-01
+```
+
+Entries without the token never expire, so existing ignore files keep working unchanged.
+
 ## Rules
 
 80 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/glsec/glsec/internal/baseline"
 	"github.com/glsec/glsec/internal/cache"
@@ -282,7 +283,7 @@ func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCoun
 		for i, d := range allDocs {
 			filePaths[i] = d.File
 		}
-		if key, kerr := cache.Key(resolvedVersion(), opt.versionStr, filePaths, opt.configPath, suppress.IgnoreFile, opt.cfg.ExcludePaths, opt.only, opt.skip); kerr == nil {
+		if key, kerr := cache.Key(resolvedVersion(), time.Now().Format("2006-01-02"), opt.versionStr, filePaths, opt.configPath, suppress.IgnoreFile, opt.cfg.ExcludePaths, opt.only, opt.skip); kerr == nil {
 			cacheKey = key
 			if entry, hit := cache.Load(cacheKey); hit {
 				return entry.Findings, entry.JobCount, true
@@ -550,6 +551,23 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 	if !skipIgnoreFile {
 		sm.Merge(suppress.LoadIgnoreFile(suppress.IgnoreFile, path))
 	}
+	now := time.Now()
+
+	// keep reports a finding unless an unexpired suppression covers it. An
+	// expired suppression is announced, so a finding that suddenly reappears is
+	// traceable to the date rather than looking like a new violation.
+	keep := func(f finding.Finding) bool {
+		if skipSuppress {
+			return true
+		}
+		if sm.IsSuppressed(f.Line, f.RuleID, now) {
+			return false
+		}
+		if sm.ExpiredAt(f.Line, f.RuleID, now) {
+			fmt.Fprintf(os.Stderr, "%s:%d: %s suppression has expired, reporting the finding again\n", path, f.Line, f.RuleID)
+		}
+		return true
+	}
 
 	var findings []finding.Finding
 	for _, rule := range rules.All() {
@@ -570,7 +588,7 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 			if !cfg.AboveMinSeverity(f) {
 				continue
 			}
-			if !skipSuppress && sm.IsSuppressed(f.Line, f.RuleID) {
+			if !keep(f) {
 				continue
 			}
 			findings = append(findings, f)
@@ -586,7 +604,7 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 			if !cfg.AboveMinSeverity(f) {
 				continue
 			}
-			if !skipSuppress && sm.IsSuppressed(f.Line, f.RuleID) {
+			if !keep(f) {
 				continue
 			}
 			findings = append(findings, f)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -37,10 +37,16 @@ func Dir() string {
 // Key computes a deterministic hex key from all inputs that affect scan results.
 // filePaths must include the main pipeline file and all discovered child pipeline files.
 // configPath and ignorePath are read from disk if they exist.
-func Key(version, gitlabVersion string, filePaths []string, configPath, ignorePath string, excludePatterns, only, skip []string) (string, error) {
+//
+// day is the current date as YYYY-MM-DD. It is part of the key because
+// suppressions can carry an expiry date: without it, a suppression that expired
+// overnight would keep hiding its finding until some file happened to change.
+// The cost is one cache miss per day.
+func Key(version, day, gitlabVersion string, filePaths []string, configPath, ignorePath string, excludePatterns, only, skip []string) (string, error) {
 	h := sha256.New()
 
 	_, _ = fmt.Fprintf(h, "version:%s\n", version)
+	_, _ = fmt.Fprintf(h, "day:%s\n", day)
 	_, _ = fmt.Fprintf(h, "gitlab-version:%s\n", gitlabVersion)
 
 	sorted := make([]string, len(excludePatterns))

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -65,11 +65,11 @@ func TestKey_Deterministic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	k1, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil, nil, nil)
+	k1, err := Key("v1.0.0", "2026-01-01", "16.0", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	k2, err := Key("v1.0.0", "16.0", []string{f}, "", "", nil, nil, nil)
+	k2, err := Key("v1.0.0", "2026-01-01", "16.0", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestKey_DiffersOnContentChange(t *testing.T) {
 	if err := os.WriteFile(f, []byte("stages: [build]"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	k1, err := Key("v1.0.0", "", []string{f}, "", "", nil, nil, nil)
+	k1, err := Key("v1.0.0", "2026-01-01", "", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestKey_DiffersOnContentChange(t *testing.T) {
 	if err := os.WriteFile(f, []byte("stages: [deploy]"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	k2, err := Key("v1.0.0", "", []string{f}, "", "", nil, nil, nil)
+	k2, err := Key("v1.0.0", "2026-01-01", "", []string{f}, "", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,17 +104,17 @@ func TestKey_DiffersOnContentChange(t *testing.T) {
 }
 
 func TestKey_DiffersOnVersion(t *testing.T) {
-	k1, _ := Key("v1.0.0", "", nil, "", "", nil, nil, nil)
-	k2, _ := Key("v1.0.1", "", nil, "", "", nil, nil, nil)
+	k1, _ := Key("v1.0.0", "2026-01-01", "", nil, "", "", nil, nil, nil)
+	k2, _ := Key("v1.0.1", "2026-01-01", "", nil, "", "", nil, nil, nil)
 	if k1 == k2 {
 		t.Error("key should differ on version change")
 	}
 }
 
 func TestKey_DiffersOnOnlySkip(t *testing.T) {
-	base, _ := Key("v1.0.0", "", nil, "", "", nil, nil, nil)
-	only, _ := Key("v1.0.0", "", nil, "", "", nil, []string{"GL001"}, nil)
-	skip, _ := Key("v1.0.0", "", nil, "", "", nil, nil, []string{"GL001"})
+	base, _ := Key("v1.0.0", "2026-01-01", "", nil, "", "", nil, nil, nil)
+	only, _ := Key("v1.0.0", "2026-01-01", "", nil, "", "", nil, []string{"GL001"}, nil)
+	skip, _ := Key("v1.0.0", "2026-01-01", "", nil, "", "", nil, nil, []string{"GL001"})
 	if base == only {
 		t.Error("key should differ when --only is set")
 	}
@@ -123,5 +123,13 @@ func TestKey_DiffersOnOnlySkip(t *testing.T) {
 	}
 	if only == skip {
 		t.Error("--only and --skip with the same ID should produce different keys")
+	}
+}
+
+func TestKeyChangesWithDay(t *testing.T) {
+	day1, _ := Key("v1.0.0", "2026-01-01", "", nil, "", "", nil, nil, nil)
+	day2, _ := Key("v1.0.0", "2026-01-02", "", nil, "", "", nil, nil, nil)
+	if day1 == day2 {
+		t.Error("the cache key must change between days, otherwise an expired suppression stays cached")
 	}
 }

--- a/internal/suppress/suppress.go
+++ b/internal/suppress/suppress.go
@@ -6,24 +6,56 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
+// dateLayout is the format accepted for suppression expiry dates.
+const dateLayout = "2006-01-02"
+
 // pattern matches:  # glsec:ignore GL001
 //
 //	# glsec:ignore GL001 -- approved, updated monthly
+//	# glsec:ignore GL001 exp:2026-12-01 -- accepted until the migration lands
 //	# glsec:ignore SC2086
-var pattern = regexp.MustCompile(`glsec:ignore\s+((?:GL|SC)\d+)(?:\s+--\s+(.+))?`)
+var pattern = regexp.MustCompile(
+	`glsec:ignore\s+((?:GL|SC)\d+)(?:\s+exp:(\d{4}-\d{2}-\d{2}))?(?:\s+--\s+(.+))?`,
+)
 
 // IgnoreFile is the default name of the baseline ignore file written by
 // --generate-ignore and read automatically on each run.
 const IgnoreFile = ".glsec-ignore"
 
+// Entry holds the metadata of a single suppression.
+type Entry struct {
+	Reason string // empty when no reason was given
+	// Expiry is an optional "YYYY-MM-DD" date. Once it has passed, the
+	// suppression stops applying and the finding is reported again. Empty means
+	// the suppression never expires.
+	Expiry string
+}
+
+// Expired reports whether the entry has an expiry date that has passed.
+// The expiry date itself is inclusive: a suppression dated 2026-12-01 still
+// applies throughout that day. A malformed date counts as expired, so a typo
+// surfaces the finding rather than silently suppressing it forever.
+func (e Entry) Expired(now time.Time) bool {
+	if e.Expiry == "" {
+		return false
+	}
+	if _, err := time.Parse(dateLayout, e.Expiry); err != nil {
+		return true
+	}
+	// ISO dates compare lexicographically in chronological order.
+	return now.Format(dateLayout) > e.Expiry
+}
+
 // Suppression records a single inline suppression parsed from a YAML comment.
 type Suppression struct {
 	RuleID string
 	Reason string // empty when no reason was given
+	Expiry string // empty when no expiry was given
 	Line   int
 }
 
@@ -41,16 +73,19 @@ func fromComment(comment string, line int) []Suppression {
 	for _, match := range pattern.FindAllStringSubmatch(comment, -1) {
 		s := Suppression{RuleID: match[1], Line: line}
 		if len(match) > 2 {
-			s.Reason = strings.TrimSpace(match[2])
+			s.Expiry = match[2]
+		}
+		if len(match) > 3 {
+			s.Reason = strings.TrimSpace(match[3])
 		}
 		out = append(out, s)
 	}
 	return out
 }
 
-// Map builds a lookup from (line → set of suppressed rule IDs) for an entire
-// YAML document tree. Call this once per document, then use IsSuppressed.
-type Map map[int]map[string]string // line → ruleID → reason
+// Map builds a lookup from (line → ruleID → entry) for an entire YAML document
+// tree. Call this once per document, then use IsSuppressed.
+type Map map[int]map[string]Entry
 
 // Build walks the node tree and collects all inline suppressions.
 func Build(root *yaml.Node) Map {
@@ -64,33 +99,61 @@ func walk(node *yaml.Node, m Map) {
 		return
 	}
 	for _, s := range fromComment(node.LineComment, node.Line) {
-		if m[s.Line] == nil {
-			m[s.Line] = make(map[string]string)
-		}
-		m[s.Line][s.RuleID] = s.Reason
+		m.set(s.Line, s.RuleID, Entry{Reason: s.Reason, Expiry: s.Expiry})
 	}
 	for _, child := range node.Content {
 		walk(child, m)
 	}
 }
 
-// IsSuppressed returns true when ruleID is suppressed on the given line.
-func (m Map) IsSuppressed(line int, ruleID string) bool {
-	if rules, ok := m[line]; ok {
-		_, suppressed := rules[ruleID]
-		return suppressed
+func (m Map) set(line int, ruleID string, e Entry) {
+	if m[line] == nil {
+		m[line] = make(map[string]Entry)
 	}
-	return false
+	m[line][ruleID] = e
+}
+
+func (m Map) lookup(line int, ruleID string) (Entry, bool) {
+	rules, ok := m[line]
+	if !ok {
+		return Entry{}, false
+	}
+	e, ok := rules[ruleID]
+	return e, ok
+}
+
+// IsSuppressed returns true when ruleID is suppressed on the given line and the
+// suppression has not expired as of now.
+func (m Map) IsSuppressed(line int, ruleID string, now time.Time) bool {
+	e, ok := m.lookup(line, ruleID)
+	return ok && !e.Expired(now)
+}
+
+// ExpiredAt reports whether a suppression exists for ruleID on the given line
+// but has expired, so the finding is reported again. Callers use this to
+// explain why a previously silenced finding reappeared.
+func (m Map) ExpiredAt(line int, ruleID string, now time.Time) bool {
+	e, ok := m.lookup(line, ruleID)
+	return ok && e.Expired(now)
+}
+
+// Entries returns every suppression in the map, keyed by line and rule ID.
+// Used to audit suppressions rather than to evaluate them.
+func (m Map) Entries() []Suppression {
+	var out []Suppression
+	for line, rules := range m {
+		for id, e := range rules {
+			out = append(out, Suppression{RuleID: id, Reason: e.Reason, Expiry: e.Expiry, Line: line})
+		}
+	}
+	return out
 }
 
 // Merge copies all entries from other into m.
 func (m Map) Merge(other Map) {
 	for line, rules := range other {
-		if m[line] == nil {
-			m[line] = make(map[string]string)
-		}
-		for id, reason := range rules {
-			m[line][id] = reason
+		for id, e := range rules {
+			m.set(line, id, e)
 		}
 	}
 }
@@ -98,6 +161,9 @@ func (m Map) Merge(other Map) {
 // LoadIgnoreFile reads a .glsec-ignore file and returns suppressions for the
 // given target file. Entries for other files are silently skipped.
 // Returns an empty map if the file does not exist.
+//
+// Line format: <file>:<line> <ruleID> [exp:YYYY-MM-DD]
+// The expiry token is optional, so files written by earlier versions still load.
 func LoadIgnoreFile(ignorePath, targetFile string) Map {
 	m := make(Map)
 	f, err := os.Open(ignorePath) //nolint:gosec
@@ -112,12 +178,17 @@ func LoadIgnoreFile(ignorePath, targetFile string) Map {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		// format: <file>:<linenum> <ruleID>
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) != 2 {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
 			continue
 		}
-		loc, ruleID := parts[0], strings.TrimSpace(parts[1])
+		loc, ruleID := fields[0], fields[1]
+		expiry := ""
+		for _, extra := range fields[2:] {
+			if rest, ok := strings.CutPrefix(extra, "exp:"); ok {
+				expiry = rest
+			}
+		}
 		lastColon := strings.LastIndex(loc, ":")
 		if lastColon < 0 {
 			continue
@@ -130,10 +201,7 @@ func LoadIgnoreFile(ignorePath, targetFile string) Map {
 		if filePath != targetFile {
 			continue
 		}
-		if m[lineNum] == nil {
-			m[lineNum] = make(map[string]string)
-		}
-		m[lineNum][ruleID] = ""
+		m.set(lineNum, ruleID, Entry{Expiry: expiry})
 	}
 	return m
 }

--- a/internal/suppress/suppress_test.go
+++ b/internal/suppress/suppress_test.go
@@ -3,9 +3,14 @@ package suppress
 import (
 	"os"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// testNow is a fixed reference date; entries without an expiry are
+// unaffected by it, so these tests stay deterministic.
+var testNow = time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
 
 func parseNode(t *testing.T, src string) *yaml.Node {
 	t.Helper()
@@ -66,10 +71,10 @@ build:
 	for line, rules := range m {
 		if _, ok := rules["GL001"]; ok {
 			found = true
-			if !m.IsSuppressed(line, "GL001") {
+			if !m.IsSuppressed(line, "GL001", testNow) {
 				t.Errorf("GL001 should be suppressed on line %d", line)
 			}
-			if m.IsSuppressed(line, "GL002") {
+			if m.IsSuppressed(line, "GL002", testNow) {
 				t.Errorf("GL002 should NOT be suppressed on line %d", line)
 			}
 		}
@@ -82,7 +87,7 @@ build:
 func TestBuild_EmptyDocument(t *testing.T) {
 	root := parseNode(t, "stages: [build]\n")
 	m := Build(root)
-	if m.IsSuppressed(1, "GL001") {
+	if m.IsSuppressed(1, "GL001", testNow) {
 		t.Error("nothing should be suppressed in a document without ignore comments")
 	}
 }
@@ -112,22 +117,22 @@ func TestFromComment_SCCodeWithReason(t *testing.T) {
 
 func TestIsSuppressed_MissingLine(t *testing.T) {
 	m := Map{}
-	if m.IsSuppressed(99, "GL001") {
+	if m.IsSuppressed(99, "GL001", testNow) {
 		t.Error("should not be suppressed on a line not in the map")
 	}
 }
 
 func TestMerge(t *testing.T) {
-	a := Map{1: {"GL001": "reason a"}}
-	b := Map{1: {"GL002": ""}, 2: {"GL003": ""}}
+	a := Map{1: {"GL001": Entry{Reason: "reason a"}}}
+	b := Map{1: {"GL002": Entry{}}, 2: {"GL003": Entry{}}}
 	a.Merge(b)
-	if !a.IsSuppressed(1, "GL001") {
+	if !a.IsSuppressed(1, "GL001", testNow) {
 		t.Error("GL001 on line 1 should still be suppressed after merge")
 	}
-	if !a.IsSuppressed(1, "GL002") {
+	if !a.IsSuppressed(1, "GL002", testNow) {
 		t.Error("GL002 on line 1 should be suppressed after merge")
 	}
-	if !a.IsSuppressed(2, "GL003") {
+	if !a.IsSuppressed(2, "GL003", testNow) {
 		t.Error("GL003 on line 2 should be suppressed after merge")
 	}
 }
@@ -144,14 +149,14 @@ func TestLoadIgnoreFile_Basic(t *testing.T) {
 	_ = f.Close()
 
 	m := LoadIgnoreFile(f.Name(), ".gitlab-ci.yml")
-	if !m.IsSuppressed(7, "GL001") {
+	if !m.IsSuppressed(7, "GL001", testNow) {
 		t.Error("GL001 on line 7 should be suppressed")
 	}
-	if !m.IsSuppressed(14, "GL002") {
+	if !m.IsSuppressed(14, "GL002", testNow) {
 		t.Error("GL002 on line 14 should be suppressed")
 	}
 	// Entry for other.yml should not appear for .gitlab-ci.yml
-	if m.IsSuppressed(3, "GL001") {
+	if m.IsSuppressed(3, "GL001", testNow) {
 		t.Error("GL001 on line 3 from other.yml should not be suppressed for .gitlab-ci.yml")
 	}
 }
@@ -160,5 +165,87 @@ func TestLoadIgnoreFile_Missing(t *testing.T) {
 	m := LoadIgnoreFile("/nonexistent/.glsec-ignore", ".gitlab-ci.yml")
 	if len(m) != 0 {
 		t.Error("expected empty map for missing ignore file")
+	}
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("bad test date %q: %v", s, err)
+	}
+	return ts
+}
+
+func TestExpiry_InlineParsing(t *testing.T) {
+	got := fromComment("# glsec:ignore GL001 exp:2026-12-01 -- accepted until the migration lands", 7)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 suppression, got %d", len(got))
+	}
+	if got[0].RuleID != "GL001" || got[0].Expiry != "2026-12-01" {
+		t.Errorf("rule/expiry = %q/%q", got[0].RuleID, got[0].Expiry)
+	}
+	if got[0].Reason != "accepted until the migration lands" {
+		t.Errorf("reason = %q", got[0].Reason)
+	}
+}
+
+func TestExpiry_Applies(t *testing.T) {
+	now := mustTime(t, "2026-06-15")
+	for _, tc := range []struct {
+		name       string
+		expiry     string
+		suppressed bool
+	}{
+		{"no expiry never expires", "", true},
+		{"future date still applies", "2026-12-01", true},
+		{"expiry day itself still applies", "2026-06-15", true},
+		{"past date no longer applies", "2026-06-14", false},
+		{"malformed date fails closed", "2026-13-45", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Map{}
+			m.set(4, "GL001", Entry{Expiry: tc.expiry})
+			if got := m.IsSuppressed(4, "GL001", now); got != tc.suppressed {
+				t.Errorf("IsSuppressed = %v, want %v", got, tc.suppressed)
+			}
+			// A suppression that no longer applies must be reported as expired,
+			// so the caller can explain why the finding came back.
+			if wantExpired := !tc.suppressed; m.ExpiredAt(4, "GL001", now) != wantExpired {
+				t.Errorf("ExpiredAt = %v, want %v", !wantExpired, wantExpired)
+			}
+		})
+	}
+}
+
+func TestExpiry_UnknownRuleIsNotExpired(t *testing.T) {
+	now := mustTime(t, "2026-06-15")
+	m := Map{}
+	if m.IsSuppressed(1, "GL999", now) || m.ExpiredAt(1, "GL999", now) {
+		t.Error("a rule with no suppression is neither suppressed nor expired")
+	}
+}
+
+func TestLoadIgnoreFile_Expiry(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/.glsec-ignore"
+	content := "# generated\n" +
+		".gitlab-ci.yml:4 GL001 exp:2026-12-01\n" +
+		".gitlab-ci.yml:9 GL002\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := LoadIgnoreFile(path, ".gitlab-ci.yml")
+
+	now := mustTime(t, "2026-06-15")
+	if !m.IsSuppressed(4, "GL001", now) {
+		t.Error("entry with a future expiry should still suppress")
+	}
+	if !m.IsSuppressed(9, "GL002", now) {
+		t.Error("entry without an expiry should suppress, keeping older ignore files working")
+	}
+	after := mustTime(t, "2027-01-01")
+	if m.IsSuppressed(4, "GL001", after) {
+		t.Error("entry should stop suppressing once its expiry has passed")
 	}
 }


### PR DESCRIPTION
Part of #398. This is the expiry half; the optional required-reason half follows in a separate PR, matching how the issue frames the two as independently shippable.

## What changed

Suppressions can now carry an expiry date, so accepted risk gets re-reviewed instead of quietly becoming permanent.

```yaml
deploy:
  script:
    - ./deploy.sh  # glsec:ignore GL013 exp:2026-12-01 -- accepted until the migration lands
```

and in the baseline file:

```
.gitlab-ci.yml:14 GL013 exp:2026-12-01
```

Once the date has passed the suppression stops applying and the finding is reported again, with a stderr note explaining that the suppression expired. Without that note a reappearing finding looks like a new violation.

## Design decisions worth flagging

**The expiry day is inclusive.** A suppression dated 2026-12-01 still applies throughout that day.

**A malformed date counts as expired.** `exp:2026-13-45` matches the syntax but is not a real date. Treating it as "never expires" would fail open on a typo, so it fails closed and the finding surfaces.

**`now` is a parameter, not a call to `time.Now()` inside the package.** `IsSuppressed` and `ExpiredAt` take the time, which keeps the suppress package deterministic under test. Only `cmd/glsec` reads the clock.

**Backward compatible.** Entries without the token never expire, so existing `.glsec-ignore` files and inline comments behave exactly as before. `LoadIgnoreFile` now parses by fields and ignores unknown trailing tokens.

## The cache had to change too

This is the non-obvious part. Scan results are cached, and the key covers the tool version, config, and file contents, but not the date. A suppression that expired overnight would therefore keep hiding its finding until some file happened to change, which defeats the feature entirely.

`cache.Key` now takes the current day and includes it in the hash. The cost is one cache miss per day.

## How verified

End to end with a real binary, three variants of the same violation:

| suppression | result |
|---|---|
| `exp:2020-01-01` (past) | GL001 reported, plus the expiry note |
| `exp:2099-01-01` (future) | suppressed |
| no expiry | suppressed |

Unit tests cover inline parsing with expiry and reason together, the inclusive boundary (expiry day itself still suppresses), the fail-closed malformed date, ignore-file entries with and without the token, and a cache key that differs between two days.

`go test ./...` passes and `golangci-lint` reports 0 issues.
