### PR TITLE
feat(suppress): optionally require a reason on inline suppressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ glsec --new-only --baseline main.json .gitlab-ci.yml  # diff against a saved JSO
 |------|---------|
 | 0 | No `error`-severity findings (warn-only findings exit 0 by default) |
 | 1 | One or more `error` findings; or any finding when `--strict` is set |
-| 2 | Usage error or file could not be parsed |
+| 2 | Usage error, file could not be parsed, or a suppression policy violation |
 
 Use `--strict` to treat `warn` findings as hard failures (exit 1). Use `--no-exit-codes` to always exit 0 regardless of findings (advisory/informational mode). All flags can also be set in `.glsec.yml`:
 
@@ -223,6 +223,19 @@ The same token works in the `.glsec-ignore` baseline, appended to a line:
 ```
 
 Entries without the token never expire, so existing ignore files keep working unchanged.
+
+To stop undocumented suppressions creeping in, require a reason:
+
+```sh
+glsec --require-ignore-reason .gitlab-ci.yml
+```
+
+```yaml
+# .glsec.yml
+require_ignore_reason: true
+```
+
+Any inline `# glsec:ignore` without a `-- reason` is then reported with its file and line, and glsec exits 2. Off by default, so existing suppressions keep working. The `.glsec-ignore` baseline is exempt because its format has no reason column. Note that enabling this disables the result cache: the check runs while findings are collected, so a cache hit would skip it.
 
 ## Rules
 

--- a/cmd/glsec/main.go
+++ b/cmd/glsec/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"time"
 
@@ -71,6 +72,7 @@ func main() {
 	noIgnoresFlag := flag.Bool("no-ignores", false, "audit mode: bypass all glsec suppressions (inline # glsec:ignore directives and the .glsec-ignore baseline) for this run; report every finding")
 	newOnlyFlag := flag.Bool("new-only", false, "report (and fail) only on findings absent from the baseline; defaults to the .glsec-ignore baseline unless --baseline is given")
 	baselineFlag := flag.String("baseline", "", "path to a baseline to diff against in --new-only mode: a glsec JSON snapshot (--format json) or a .glsec-ignore file (implies --new-only)")
+	requireReasonFlag := flag.Bool("require-ignore-reason", false, "treat an inline # glsec:ignore without a \"-- reason\" as a policy violation (exit 2)")
 	noCacheFlag := flag.Bool("no-cache", false, "disable result cache for this run")
 	clearCacheFlag := flag.Bool("clear-cache", false, "remove all cached results and exit")
 	noColorFlag := flag.Bool("no-color", false, "disable colored output")
@@ -136,6 +138,9 @@ func main() {
 	if *noExitCodesFlag {
 		cfg.NoExitCodes = true
 	}
+	if *requireReasonFlag {
+		cfg.RequireIgnoreReason = true
+	}
 	cfg.ExcludePaths = append(cfg.ExcludePaths, excludeArgs...)
 
 	if len(onlyArgs) > 0 {
@@ -179,7 +184,10 @@ func main() {
 	colorEnabled := color.IsEnabled(*noColorFlag, os.Stdout)
 	stdoutIsTTY := color.IsTerminal(os.Stdout)
 	newOnly := *newOnlyFlag || *baselineFlag != ""
-	useCache := !*noCacheFlag && !*generateIgnoreFlag && !*noIgnoresFlag && !newOnly
+	// The reason check runs while collecting findings, so a cache hit would skip
+	// it and silently drop the per-suppression messages. Opt-in policy, so paying
+	// with a cold scan is the right trade.
+	useCache := !*noCacheFlag && !*generateIgnoreFlag && !*noIgnoresFlag && !newOnly && !cfg.RequireIgnoreReason
 
 	scanOpts := scanOptions{
 		cfg:            cfg,
@@ -196,18 +204,20 @@ func main() {
 
 	var allFindings []finding.Finding
 	totalJobCount := 0
+	totalUnjustified := 0
 	hadError := false
 	for _, file := range targets {
 		if matchesExclude(file, cfg.ExcludePaths) {
 			continue
 		}
-		findings, jobCount, ok := scanRoot(file, scanOpts)
+		findings, jobCount, unjustified, ok := scanRoot(file, scanOpts)
 		if !ok {
 			hadError = true
 			continue
 		}
 		allFindings = append(allFindings, findings...)
 		totalJobCount += jobCount
+		totalUnjustified += unjustified
 	}
 
 	if *generateIgnoreFlag {
@@ -231,6 +241,10 @@ func main() {
 	if hadError {
 		os.Exit(2)
 	}
+	if totalUnjustified > 0 {
+		fmt.Fprintf(os.Stderr, "%d suppression(s) without a reason; require_ignore_reason is enabled\n", totalUnjustified)
+		os.Exit(2)
+	}
 	os.Exit(exitCode(allFindings, cfg))
 }
 
@@ -250,11 +264,11 @@ type scanOptions struct {
 // scanRoot parses one root pipeline file (and its child pipelines), runs the
 // rules, and returns the findings and job count. ok is false if the file could
 // not be parsed or validated; the error has already been reported to stderr.
-func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCount int, ok bool) {
+func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCount, unjustified int, ok bool) {
 	doc, err := parser.ParseFile(file)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
 
 	warns, valErr := validate.File(file, doc)
@@ -263,7 +277,7 @@ func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCoun
 	}
 	if valErr != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", valErr)
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
 
 	seen := map[string]bool{}
@@ -286,21 +300,23 @@ func scanRoot(file string, opt scanOptions) (findings []finding.Finding, jobCoun
 		if key, kerr := cache.Key(resolvedVersion(), time.Now().Format("2006-01-02"), opt.versionStr, filePaths, opt.configPath, suppress.IgnoreFile, opt.cfg.ExcludePaths, opt.only, opt.skip); kerr == nil {
 			cacheKey = key
 			if entry, hit := cache.Load(cacheKey); hit {
-				return entry.Findings, entry.JobCount, true
+				return entry.Findings, entry.JobCount, 0, true
 			}
 		}
 	}
 
 	skipSuppress := opt.generateIgnore || opt.noIgnores
 	for _, d := range allDocs {
-		findings = append(findings, collectFindings(d, d.File, opt.cfg, opt.gitlabVersion, skipSuppress, opt.newOnly)...)
+		f, u := collectFindings(d, d.File, opt.cfg, opt.gitlabVersion, skipSuppress, opt.newOnly)
+		findings = append(findings, f...)
+		unjustified += u
 	}
 
 	if opt.useCache && cacheKey != "" {
 		cache.Store(cacheKey, &cache.Entry{Findings: findings, JobCount: jobCount})
 	}
 
-	return findings, jobCount, true
+	return findings, jobCount, unjustified, true
 }
 
 // writeOutput renders findings in the requested format.
@@ -546,8 +562,14 @@ func collectDocuments(doc *parser.Document, path string, excludePaths []string, 
 // skipIgnoreFile drops the .glsec-ignore line suppression (but keeps inline
 // directives) so --new-only can diff the full backlog against the baseline by
 // fingerprint instead of by exact line.
-func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, skipSuppress, skipIgnoreFile bool) []finding.Finding {
+func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitlabVersion gitlabver.Version, skipSuppress, skipIgnoreFile bool) ([]finding.Finding, int) {
 	sm := suppress.Build(doc.Root)
+	// Checked against the inline map only: the .glsec-ignore baseline has no
+	// reason column, so requiring one there would be unsatisfiable.
+	unjustified := 0
+	if cfg.RequireIgnoreReason && !skipSuppress {
+		unjustified = reportUnjustified(sm, path)
+	}
 	if !skipIgnoreFile {
 		sm.Merge(suppress.LoadIgnoreFile(suppress.IgnoreFile, path))
 	}
@@ -611,7 +633,28 @@ func collectFindings(doc *parser.Document, path string, cfg *config.Config, gitl
 		}
 	}
 
-	return findings
+	return findings, unjustified
+}
+
+// reportUnjustified prints every inline suppression that carries no reason and
+// returns how many there were.
+func reportUnjustified(sm suppress.Map, path string) int {
+	entries := sm.Entries()
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Line != entries[j].Line {
+			return entries[i].Line < entries[j].Line
+		}
+		return entries[i].RuleID < entries[j].RuleID
+	})
+	n := 0
+	for _, e := range entries {
+		if e.Reason != "" {
+			continue
+		}
+		n++
+		fmt.Fprintf(os.Stderr, "%s:%d: %s is suppressed without a reason; add \"-- why\" to the glsec:ignore comment\n", path, e.Line, e.RuleID)
+	}
+	return n
 }
 
 // filterNewOnly keeps only findings absent from the baseline. baselinePath is

--- a/cmd/glsec/no_ignores_test.go
+++ b/cmd/glsec/no_ignores_test.go
@@ -19,7 +19,8 @@ func hasGL001(t *testing.T, content string, skipSuppress bool) bool {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	for _, f := range collectFindings(doc, "test.yml", config.Default(), gitlabver.Version{}, skipSuppress, false) {
+	found, _ := collectFindings(doc, "test.yml", config.Default(), gitlabver.Version{}, skipSuppress, false)
+	for _, f := range found {
 		if f.RuleID == "GL001" {
 			return true
 		}
@@ -52,5 +53,44 @@ func TestCollectFindings_NoIgnoresBypassesBaseline(t *testing.T) {
 	}
 	if !hasGL001(t, plainYAML, true) {
 		t.Fatal("expected GL001 reported with --no-ignores despite baseline, but it was suppressed")
+	}
+}
+
+func TestCollectFindings_RequireIgnoreReason(t *testing.T) {
+	src := `
+build:
+  image: node:latest  # glsec:ignore GL001
+  script:
+    - make
+`
+	doc, err := parser.Parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	cfg := config.Default()
+	_, unjustified := collectFindings(doc, "test.yml", cfg, gitlabver.Version{}, false, false)
+	if unjustified != 0 {
+		t.Errorf("policy off: expected 0 violations, got %d", unjustified)
+	}
+
+	cfg.RequireIgnoreReason = true
+	_, unjustified = collectFindings(doc, "test.yml", cfg, gitlabver.Version{}, false, false)
+	if unjustified != 1 {
+		t.Errorf("policy on: expected 1 violation for the reasonless suppression, got %d", unjustified)
+	}
+
+	// A suppression carrying a reason satisfies the policy.
+	withReason, err := parser.Parse([]byte(`
+build:
+  image: node:latest  # glsec:ignore GL001 -- pinned by the platform team
+  script:
+    - make
+`), "test.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, n := collectFindings(withReason, "test.yml", cfg, gitlabver.Version{}, false, false); n != 0 {
+		t.Errorf("a suppression with a reason must not be a violation, got %d", n)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,10 @@ type Config struct {
 	AllowedIncludeSources []string `yaml:"allowed_include_sources"`
 	// ShellCheck holds optional ShellCheck integration settings.
 	ShellCheck ShellCheckConfig `yaml:"shellcheck"`
+	// RequireIgnoreReason makes an inline `# glsec:ignore` without a `-- reason`
+	// a policy violation. Off by default, so existing suppressions keep working.
+	// The .glsec-ignore baseline has no reason column and is not affected.
+	RequireIgnoreReason bool `yaml:"require_ignore_reason"`
 	// Strict makes warn findings count as errors for exit-code purposes.
 	Strict bool `yaml:"strict"`
 	// NoExitCodes makes glsec always exit 0 on successful execution,
@@ -172,6 +176,7 @@ var allowedTopLevelKeys = map[string]bool{
 	"owasp":                   true,
 	"owasp_exclude":           true,
 	"shellcheck":              true,
+	"require_ignore_reason":   true,
 }
 
 func checkUnknownKeys(mapping *yaml.Node, path string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -301,3 +301,21 @@ owasp:
 		t.Error("expected error for invalid OWASP category")
 	}
 }
+
+func TestRequireIgnoreReason(t *testing.T) {
+	cfg, err := parse([]byte("require_ignore_reason: true\n"), ".glsec.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !cfg.RequireIgnoreReason {
+		t.Error("require_ignore_reason should be parsed from the config file")
+	}
+	// Absent means off, so existing configs keep their behaviour.
+	def, err := parse([]byte("strict: true\n"), ".glsec.yml")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if def.RequireIgnoreReason {
+		t.Error("require_ignore_reason must default to false")
+	}
+}


### PR DESCRIPTION
Closes #398. This is the required-reason half; it is **stacked on #424** (the expiry half) and should merge after it. The diff shown here is only this change once #424 lands.

## What changed

An opt-in policy: an inline `# glsec:ignore` without a `-- reason` becomes a violation.

```sh
glsec --require-ignore-reason .gitlab-ci.yml
```

```yaml
# .glsec.yml
require_ignore_reason: true
```

Each offending suppression is reported with its file and line, followed by a summary, and glsec exits 2.

## Design decisions

**Off by default.** Existing suppressions keep working untouched.

**Inline only.** The `.glsec-ignore` baseline has no reason column, so requiring one there would be unsatisfiable. The check runs against the inline map before the baseline is merged in.

**Exit 2, not 1.** Exit 1 means "findings were reported". An unjustified suppression is not a finding about the pipeline, it is a policy violation in how the file is written, which sits closer to the existing exit-2 cases. The README's exit code table is updated to say so rather than leaving 2 described as parse errors only.

## Why this disables the cache

Worth calling out, because it is the kind of thing that would otherwise quietly not work.

The check runs while findings are collected. On a cache hit that code never executes, so both the count and the per-suppression messages would vanish, and the policy would appear to pass. Rather than caching the count (which would still lose the messages telling you *which* suppressions to fix), enabling the policy now disables the result cache, alongside the existing exceptions for `--generate-ignore`, `--no-ignores`, and `--new-only`.

The trade is a cold scan for users who opt in, which seemed clearly better than a check that silently stops running.

## How verified

End to end with a real binary:

| run | result |
|---|---|
| no flag, suppression without reason | exit 0, suppressed as before |
| `--require-ignore-reason`, no reason | exit 2, reports `file:2: GL001 is suppressed without a reason` plus a summary |
| `--require-ignore-reason`, with reason | exit 0 |

Unit tests cover the config key parsing and defaulting to off, and `collectFindings` returning 0 violations with the policy off, 1 with it on, and 0 when the suppression carries a reason.

`go test ./...` passes and `golangci-lint` reports 0 issues.
