### PR TITLE
feat(output): show source-line context in text output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@
 ```
 $ glsec .gitlab-ci.yml
 
-ERROR  .gitlab-ci.yml:7   GL001  image "node:latest" uses mutable tag "latest" — pin to a specific version or digest
-WARN   .gitlab-ci.yml:14  GL002  variable $CI_COMMIT_REF_NAME in script is user-controlled and unquoted — wrap in double quotes
-ERROR  .gitlab-ci.yml:3   GL003  project include "company/templates" missing "ref" — defaults to HEAD of default branch (mutable)
+error[GL001]: image "node:latest" uses mutable tag "latest" — pin to a specific version or digest
+  --> .gitlab-ci.yml:7:10 (job: build)
+  |
+7 |   image: node:latest
+  |          ^
+
+warn[GL002]: unquoted user-controlled variable $CI_COMMIT_REF_NAME in script — value is set by commit authors and may contain shell metacharacters
+  --> .gitlab-ci.yml:14:7 (job: build)
+   |
+14 |     - echo $CI_COMMIT_REF_NAME
+   |       ^
 ```
+
+Use `--format table` for a compact one-line-per-finding view when there are many findings.
 
 ## Why glsec?
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -7,6 +7,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -85,29 +87,19 @@ func writeTable(w io.Writer, findings []finding.Finding, jobCount int, isTTY boo
 	return tw.Flush()
 }
 
+// writeText renders findings as compiler-style diagnostics: a header carrying
+// severity, rule and message, the location, then the offending source line with
+// a caret at the recorded column. When the source cannot be read the header is
+// still printed, so output never depends on the file still being there.
 func writeText(w io.Writer, findings []finding.Finding, jobCount int, col, isTTY bool) error {
-	for _, f := range findings {
-		sev := strings.ToUpper(string(f.Severity))
-		switch f.Severity {
-		case finding.Error:
-			sev = color.Red(sev, col)
-		case finding.Warn:
-			sev = color.Yellow(sev, col)
+	src := newSourceCache()
+	for i, f := range findings {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
 		}
-		ruleID := color.Bold(f.RuleID, col)
-		location := color.Bold(fmt.Sprintf("%s:%d", f.File, f.Line), col)
-
-		var err error
-		if f.Job != "" {
-			_, err = fmt.Fprintf(w, "%-6s %s  %s  [%s]  %s\n",
-				sev, location, ruleID, f.Job, f.Message,
-			)
-		} else {
-			_, err = fmt.Fprintf(w, "%-6s %s  %s  %s\n",
-				sev, location, ruleID, f.Message,
-			)
-		}
-		if err != nil {
+		if err := writeDiagnostic(w, f, src, col); err != nil {
 			return err
 		}
 	}
@@ -119,6 +111,70 @@ func writeText(w io.Writer, findings []finding.Finding, jobCount int, col, isTTY
 		return err
 	}
 	return nil
+}
+
+// writeDiagnostic renders one finding. The source block is best-effort: a
+// missing file, an out-of-range line or a zero column each degrade to printing
+// less, never to an error.
+func writeDiagnostic(w io.Writer, f finding.Finding, src *sourceCache, colorOn bool) error {
+	sev := string(f.Severity)
+	switch f.Severity {
+	case finding.Error:
+		sev = color.Red(sev, colorOn)
+	case finding.Warn:
+		sev = color.Yellow(sev, colorOn)
+	}
+	if _, err := fmt.Fprintf(w, "%s[%s]: %s\n", sev, color.Bold(f.RuleID, colorOn), f.Message); err != nil {
+		return err
+	}
+
+	loc := fmt.Sprintf("%s:%d", f.File, f.Line)
+	if f.Col > 0 {
+		loc += ":" + strconv.Itoa(f.Col)
+	}
+	if f.Job != "" {
+		loc += " (job: " + f.Job + ")"
+	}
+	if _, err := fmt.Fprintf(w, "  --> %s\n", color.Bold(loc, colorOn)); err != nil {
+		return err
+	}
+
+	line, ok := src.line(f.File, f.Line)
+	if !ok {
+		return nil
+	}
+	num := strconv.Itoa(f.Line)
+	pad := strings.Repeat(" ", len(num))
+	if _, err := fmt.Fprintf(w, "%s |\n%s | %s\n", pad, num, line); err != nil {
+		return err
+	}
+	if f.Col > 0 {
+		if _, err := fmt.Fprintf(w, "%s | %s^\n", pad, strings.Repeat(" ", f.Col-1)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sourceCache reads files lazily so several findings in one file cost a single
+// read. A file that cannot be read is remembered as absent rather than retried.
+type sourceCache struct{ files map[string][]string }
+
+func newSourceCache() *sourceCache { return &sourceCache{files: make(map[string][]string)} }
+
+func (c *sourceCache) line(path string, n int) (string, bool) {
+	lines, cached := c.files[path]
+	if !cached {
+		data, err := os.ReadFile(path) //nolint:gosec // reads the file that was just scanned
+		if err == nil {
+			lines = strings.Split(string(data), "\n")
+		}
+		c.files[path] = lines
+	}
+	if n < 1 || n > len(lines) {
+		return "", false
+	}
+	return strings.TrimRight(lines[n-1], "\r"), true
 }
 
 type jsonFinding struct {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"os"
 	"strings"
 	"testing"
 
@@ -27,14 +28,17 @@ func TestWriteText(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := buf.String()
-	if !strings.Contains(got, "ERROR") || !strings.Contains(got, "WARN") {
-		t.Errorf("missing severity labels: %q", got)
+	// Compiler-style header: severity[rule]: message
+	if !strings.Contains(got, "error[GL001]:") || !strings.Contains(got, "warn[GL002]:") {
+		t.Errorf("missing severity[rule] headers: %q", got)
 	}
-	if !strings.Contains(got, "GL001") || !strings.Contains(got, "GL002") {
-		t.Errorf("missing rule IDs: %q", got)
+	if !strings.Contains(got, "--> ci.yml:4") {
+		t.Errorf("missing location line: %q", got)
 	}
-	if !strings.Contains(got, "ci.yml:4") {
-		t.Errorf("missing file:line: %q", got)
+	// ci.yml does not exist on disk, so the source block is skipped rather than
+	// erroring. The header must still be there.
+	if strings.Contains(got, " | ") {
+		t.Errorf("no source block expected for a missing file: %q", got)
 	}
 }
 
@@ -128,17 +132,12 @@ func TestWriteText_WithJob(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := buf.String()
-	if !strings.Contains(got, "[phpmd]") {
-		t.Errorf("expected [phpmd] in output: %q", got)
+	if !strings.Contains(got, "(job: phpmd)") || !strings.Contains(got, "(job: e2e)") {
+		t.Errorf("expected job names on the location line: %q", got)
 	}
-	if !strings.Contains(got, "[e2e]") {
-		t.Errorf("expected [e2e] in output: %q", got)
-	}
-	// Finding without a job should not contain brackets around a job name.
-	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
-	last := lines[len(lines)-1]
-	if strings.Contains(last, "[") && strings.Contains(last, "]") {
-		t.Errorf("finding without job should not render brackets, got: %q", last)
+	// The third finding has no job, so exactly two location lines carry one.
+	if n := strings.Count(got, "(job: "); n != 2 {
+		t.Errorf("expected 2 job annotations, got %d: %q", n, got)
 	}
 }
 
@@ -555,5 +554,66 @@ func TestWriteSARIF_WithASVS(t *testing.T) {
 	}
 	if len(run.Taxonomies) != 1 || run.Taxonomies[0].Name != "OWASP ASVS" || run.Taxonomies[0].Version != "4.0.3" {
 		t.Fatalf("expected OWASP ASVS 4.0.3 taxonomy, got %+v", run.Taxonomies)
+	}
+}
+
+func TestWriteText_SourceContext(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/.gitlab-ci.yml"
+	content := "build:\n  image: node:latest\n  script: [make]\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f := []finding.Finding{{
+		RuleID: "GL001", Severity: finding.Error, File: path, Line: 2, Col: 10,
+		Message: "mutable image tag",
+	}}
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatText, f, 1, false, false); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+
+	if !strings.Contains(got, "2 |   image: node:latest") {
+		t.Errorf("expected the offending source line: %q", got)
+	}
+	// Verify alignment rather than a literal run of spaces: the caret must sit at
+	// the same offset as column 10 of the source line, gutter included.
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	srcIdx := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, "2 | ") {
+			srcIdx = i
+			break
+		}
+	}
+	if srcIdx < 0 || srcIdx+1 >= len(lines) {
+		t.Fatalf("expected a source line followed by a caret line: %q", got)
+	}
+	caretAt := strings.IndexByte(lines[srcIdx+1], '^')
+	if want := len("2 | ") + 10 - 1; caretAt != want {
+		t.Errorf("caret at offset %d, want %d (column 10): %q", caretAt, want, got)
+	}
+	if !strings.Contains(got, "--> "+path+":2:10") {
+		t.Errorf("expected location with column: %q", got)
+	}
+}
+
+func TestWriteText_OutOfRangeLineDegrades(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/.gitlab-ci.yml"
+	if err := os.WriteFile(path, []byte("build:\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f := []finding.Finding{{
+		RuleID: "GL001", Severity: finding.Warn, File: path, Line: 99, Col: 3, Message: "x",
+	}}
+	var buf bytes.Buffer
+	if err := Write(&buf, FormatText, f, 1, false, false); err != nil {
+		t.Fatalf("a line past the end of the file must not error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "warn[GL001]:") {
+		t.Errorf("header should still be printed: %q", buf.String())
 	}
 }


### PR DESCRIPTION
Closes #426. Phase 1 only: the source line plus a caret at the column already recorded. No rule was touched.

## Before

```
ERROR  .gitlab-ci.yml:2  GL001  [build]  image "node:latest" uses mutable tag "latest"
```

## After

```
error[GL001]: image "node:latest" uses mutable tag "latest" — pin to a specific version or digest
  --> .gitlab-ci.yml:2:10 (job: build)
  |
2 |   image: node:latest
  |          ^
```

The column was already being collected by every rule and thrown away by every output format. This starts using it.

## The other formats are untouched, and that is verified

This was the main risk, so it was checked rather than asserted. Both binaries were built, the old one from `main` and the new one from this branch, and run over the same file:

| format | old vs new |
|---|---|
| json | byte identical |
| sarif | byte identical |
| codeclimate | byte identical |
| junit | byte identical |
| table | byte identical |
| text | changed, as intended |

The existing test suite says the same thing: of 23 output tests, only the two text ones needed updating and every JSON, SARIF, Code Climate, JUnit and table test passed unchanged.

Nothing downstream parses the text output either. The only consumer is `hooks/hooks.json`, which runs glsec for its exit code and ignores stdout.

## Behaviour details

- **`table` is unchanged** and is now called out in the README as the compact view for large result sets.
- **Degrades rather than fails.** A file that cannot be read, a line past the end of the file, or a zero column each print less, never an error. Findings from a file that has since moved still render their header.
- **One read per file.** A small cache keyed by path means many findings in one file cost a single read, and an unreadable file is remembered rather than retried.
- **Severity is lowercase now** (`error[GL001]`) to match the compiler-diagnostic convention. `table` still prints uppercase.

## On the caret's precision

The caret marks the start of the offending YAML node, not always the exact token. For GL001 it lands on the image value; for a script-level rule like GL002 it lands at the start of the script item rather than on the variable inside it.

That is the documented phase-1 limit: `node.Column` is what rules record today. Exact spans would mean every rule reporting a start and end offset, which is not worth doing for a presentation change until this proves useful.

## Tests

Updated the two text tests, and added coverage for the source block rendering, the caret alignment (asserted as an offset relationship rather than a literal run of spaces, so it cannot pass by accident), and graceful degradation on an out-of-range line.

`go test ./...` passes and `golangci-lint` reports 0 issues.
