### PR TITLE
New rule GL081: id_tokens issued on an unrestricted pipeline source

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Any inline `# glsec:ignore` without a `-- reason` is then reported with its file
 
 ## Rules
 
-80 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+81 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -257,7 +257,7 @@ Any inline `# glsec:ignore` without a `-- reason` is then reported with its file
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075, GL079 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
-| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074, GL080 |
+| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074, GL080, GL081 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063, GL076, GL077 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -108,6 +108,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL074](rules/GL074.md) | `warn`  | Tautological (always-true) `rules:if` condition — the gate is a no-op and the job runs in every context it was meant to restrict |
 | [GL055](rules/GL055.md) | `warn`  | `DOCKER_HOST` points at the host Docker socket (`/var/run/docker.sock`) — full control of the runner's Docker daemon |
 | [GL080](rules/GL080.md) | `warn`  | Sensitive/deploy job with no pipeline-source guard (no `rules:`/`only:` or a `rules:` with no `if:`) — runs on every source including fork MRs |
+| [GL081](rules/GL081.md) | `warn`  | Job issues an OIDC `id_tokens:` credential on an unrestricted pipeline source — any branch or merge request can mint a cloud-federating token (GitLab ≥ 15.7) |
 
 ---
 

--- a/docs/rules/GL081.md
+++ b/docs/rules/GL081.md
@@ -29,6 +29,7 @@ GL081 does **not** fire when:
 - a top-level `workflow:rules` confines the whole pipeline to protected refs (every admitting rule restricts to a protected ref and none admits `merge_request_event`).
 - the job inherits config via `extends:` or a YAML merge (`<<:`) — the guard may live in an unresolved base.
 - the job is a hidden template (name starting with `.`).
+- `id_tokens:` is declared in the top-level `default:` block rather than on a job — pipeline-wide inheritance is out of scope, on the same footing as `extends:` (glsec flags the per-job declaration, not the inherited one).
 
 ## Trigger example
 

--- a/docs/rules/GL081.md
+++ b/docs/rules/GL081.md
@@ -1,0 +1,78 @@
+# GL081 — OIDC id_tokens issued on an unrestricted pipeline source
+
+**Severity:** `warn`  
+**OWASP:** [CICD-SEC-5 – Insufficient PBAC](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-05-Insufficient-PBAC)  
+**CWE:** [CWE-284 – Improper Access Control](https://cwe.mitre.org/data/definitions/284.html)  
+**Minimum GitLab version:** 15.7 (`id_tokens:`)
+
+## Risk
+
+A job that declares `id_tokens:` mints an OIDC JWT that federates into a cloud provider or secrets manager (AWS STS, GCP, Vault, …). If nothing restricts **which pipeline sources** run that job, any Developer can trigger it:
+
+1. **Same-project MR and branch pipelines.** Anyone with the Developer role can push a branch, open a merge request, and cause the job to mint a token. Cloud-side trust policies overwhelmingly condition on `project_path` / `project_id` only — in which case a token minted from an unreviewed feature branch is indistinguishable from one minted on the default branch. Effectively every Developer holds whatever role the job can assume, without ever touching a protected branch.
+2. **`ci_allow_fork_pipelines_to_run_in_parent_project`.** A parent-project member can run a fork MR's pipeline in the parent context, where fork-controlled code runs before merge.
+
+(The naive "a fork MR steals your token" framing is *not* the main path: [fork MR pipelines run in the fork project by default](https://docs.gitlab.com/ci/pipelines/merge_request_pipelines/), so the JWT identifies the fork, not the parent, and the parent's trust policy will not accept it.)
+
+The robust fix is a cloud-side condition on the `ref_protected` / `ref` / `pipeline_source` claims — which a YAML linter cannot see. The pipeline-side guard is the part glsec **can** check, and its absence is a reliable signal that nobody scoped which refs may assume the role.
+
+## What glsec checks
+
+GL081 flags a job that declares `id_tokens:` when either:
+
+1. **Its guard explicitly admits `merge_request_event`** — a `rules:if` matching `merge_request_event` (not a `when: never` exclusion), or a legacy `only: merge_requests`.
+2. **It has no effective guard** — no `rules:` / `only:` / `except:`, or a `rules:` block whose items carry no `if:` / `changes:` / `exists:` condition — **and** no top-level `workflow:rules` restricts the pipeline to protected refs.
+
+GL081 does **not** fire when:
+
+- `rules:` restrict to a protected ref or tag — `$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH`, `$CI_COMMIT_TAG`, `$CI_COMMIT_REF_PROTECTED == "true"`, or an explicit branch equality (`$CI_COMMIT_BRANCH == "main"`).
+- a top-level `workflow:rules` confines the whole pipeline to protected refs (every admitting rule restricts to a protected ref and none admits `merge_request_event`).
+- the job inherits config via `extends:` or a YAML merge (`<<:`) — the guard may live in an unresolved base.
+- the job is a hidden template (name starting with `.`).
+
+## Trigger example
+
+```yaml
+aws-integration-test:
+  stage: test
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com    # correct, scoped audience — but…
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'   # …any MR can mint it
+  script:
+    - aws sts assume-role-with-web-identity --web-identity-token "$AWS_ID_TOKEN"
+```
+
+## Safe alternative
+
+Restrict the job to protected refs, and condition the cloud trust policy on the `ref_protected` claim so a feature-branch token cannot assume the role:
+
+```yaml
+aws-deploy:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - aws sts assume-role-with-web-identity --web-identity-token "$AWS_ID_TOKEN"
+```
+
+```jsonc
+// AWS IAM trust policy condition (cloud-side, not visible to glsec)
+"Condition": {
+  "StringEquals": { "gitlab.example.com:sub": "project_path:my/proj:ref_type:branch:ref:main" }
+}
+```
+
+## Relationship to other rules
+
+- **GL009** flags an overly broad OIDC audience (`aud:`). GL081 is independent — a token can have a perfectly narrow audience and still be mintable from any branch. The two can co-fire on the same job; both defects are real.
+- **GL080** flags sensitive *deploy/publish* jobs (by `environment:` or a deploy keyword) with no source guard. GL081 keys on `id_tokens:` specifically, catching jobs GL080 misses — e.g. an `aws-integration-test` or `terraform-plan` job that federates into a cloud account but is named like a test.
+- **GL053** flags a missing or unrestricted top-level `workflow:rules` at the pipeline level.
+
+## False-positive note
+
+Small blast radius by construction — the rule only looks at jobs that already declare `id_tokens:`, which is opt-in and uncommon. The main false-positive class is a guard expressed somewhere glsec does not resolve (`extends:`, an included template), which the `extends:` / `<<:` bail-out already handles. Review each finding against your cloud trust policy: a job restricted only by an unprotected branch condition is still exploitable even when glsec accepts it.

--- a/rules/all.go
+++ b/rules/all.go
@@ -84,5 +84,6 @@ func All() []rule.Rule {
 		GL078,
 		GL079,
 		GL080,
+		GL081,
 	}
 }

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -82,6 +82,7 @@ var cweIDs = map[string]string{
 	"GL078": "CWE-1007",
 	"GL079": "CWE-829",
 	"GL080": "CWE-691",
+	"GL081": "CWE-284",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl081.go
+++ b/rules/gl081.go
@@ -1,0 +1,216 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl081 struct{}
+
+var GL081 = &gl081{}
+
+func (r *gl081) ID() string { return "GL081" }
+
+func (r *gl081) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+
+	// A top-level workflow:rules that confines the pipeline to protected refs
+	// means no job in the file can run on a merge request or an unprotected
+	// branch, so no id_tokens: job can mint a token there — suppress the whole
+	// file. Note this is stricter than GL080's workflowRestrictsSource: a
+	// workflow that merely carries an if: but still admits merge_request_event
+	// does not protect the token and must not suppress here.
+	if workflowRestrictsToProtected(mapping) {
+		return nil
+	}
+
+	var findings []finding.Finding
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		// Hidden jobs (names starting with ".") are templates GitLab never runs.
+		if strings.HasPrefix(name.Value, ".") {
+			return
+		}
+		if !hasIDTokens(job) {
+			return
+		}
+		// A job that pulls config in via extends: or a YAML merge (<<:) may
+		// inherit its guard from a base glsec does not resolve — skip it.
+		if inheritsConfig(job) {
+			return
+		}
+
+		// A guard that explicitly admits merge_request_event (or the legacy
+		// only: merge_requests) lets any MR mint the token, even one that is
+		// otherwise an "effective" restriction on some other ref.
+		if jobAdmitsMR(job) {
+			findings = append(findings, gl081Finding(name, file, gl081ReasonAdmits))
+			return
+		}
+
+		// Otherwise fall back to the same guard classification as GL080: an
+		// absent or condition-less guard leaves the source unrestricted. An
+		// effective guard (restricted to a protected ref, tag, or branch) is
+		// accepted.
+		if jobGuardState(job) != guardEffective {
+			findings = append(findings, gl081Finding(name, file, gl081ReasonUnguarded))
+		}
+	})
+	return findings
+}
+
+func hasIDTokens(job *yaml.Node) bool {
+	t := parser.FindKey(job, "id_tokens")
+	return t != nil && t.Kind == yaml.MappingNode
+}
+
+type gl081Reason int
+
+const (
+	gl081ReasonAdmits gl081Reason = iota
+	gl081ReasonUnguarded
+)
+
+func gl081Finding(name *yaml.Node, file string, reason gl081Reason) finding.Finding {
+	return finding.Finding{
+		RuleID:   "GL081",
+		Severity: finding.Warn,
+		Job:      name.Value,
+		Message:  gl081Message(name.Value, reason),
+		File:     file,
+		Line:     name.Line,
+		Col:      name.Column,
+	}
+}
+
+func gl081Message(job string, reason gl081Reason) string {
+	if reason == gl081ReasonAdmits {
+		return fmt.Sprintf(
+			"job %q issues an OIDC id_tokens: credential and its guard admits merge_request_event — any merge request can mint a cloud-federating token; restrict the job to protected refs and condition the cloud trust policy on the ref_protected claim",
+			job,
+		)
+	}
+	return fmt.Sprintf(
+		"job %q issues an OIDC id_tokens: credential with no guard restricting $CI_PIPELINE_SOURCE or the ref — any branch or merge request can mint a cloud-federating token; add a rules:if that restricts to protected refs and condition the cloud trust policy on the ref_protected claim",
+		job,
+	)
+}
+
+// jobAdmitsMR reports whether a job's guard lets a merge-request pipeline run
+// it: a rules:if that matches merge_request_event (and is not a when: never
+// exclusion), or a legacy only: merge_requests clause.
+func jobAdmitsMR(job *yaml.Node) bool {
+	if onlyAdmitsMR(parser.FindKey(job, "only")) {
+		return true
+	}
+	rules := parser.FindKey(job, "rules")
+	if rules == nil || rules.Kind != yaml.SequenceNode {
+		return false
+	}
+	for _, item := range rules.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		if ruleExcludes(item) {
+			continue
+		}
+		if ifNode := parser.FindKey(item, "if"); ifNode != nil && ifNode.Kind == yaml.ScalarNode && ifAdmitsMR(ifNode.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// onlyAdmitsMR reports whether a legacy only: clause admits merge_requests, in
+// any of its scalar / sequence / refs: mapping shapes.
+func onlyAdmitsMR(n *yaml.Node) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Kind {
+	case yaml.ScalarNode:
+		return n.Value == "merge_requests"
+	case yaml.SequenceNode:
+		for _, c := range n.Content {
+			if onlyAdmitsMR(c) {
+				return true
+			}
+		}
+	case yaml.MappingNode:
+		if refs := parser.FindKey(n, "refs"); refs != nil {
+			return onlyAdmitsMR(refs)
+		}
+	}
+	return false
+}
+
+// ruleExcludes reports whether a rules item is a when: never exclusion, which
+// blocks rather than admits the sources it matches.
+func ruleExcludes(item *yaml.Node) bool {
+	w := parser.FindKey(item, "when")
+	return w != nil && w.Kind == yaml.ScalarNode && w.Value == "never"
+}
+
+// ifAdmitsMR reports whether a rules:if expression admits merge-request
+// pipelines. `$CI_PIPELINE_SOURCE != "merge_request_event"` matches everything
+// *except* MRs, so a != comparison is not an admission.
+func ifAdmitsMR(expr string) bool {
+	return strings.Contains(expr, "merge_request_event") && !strings.Contains(expr, "!=")
+}
+
+var branchEqPat = regexp.MustCompile(`\$CI_COMMIT_(BRANCH|REF_NAME)\s*==\s*['"]`)
+
+// ifRestrictsToProtected reports whether a rules:if expression confines the job
+// to a protected ref, tag, or a named branch: the default branch, a tag, an
+// explicit CI_COMMIT_REF_PROTECTED == "true", or an explicit branch equality.
+func ifRestrictsToProtected(expr string) bool {
+	switch {
+	case strings.Contains(expr, "$CI_DEFAULT_BRANCH"):
+		return true
+	case strings.Contains(expr, "$CI_COMMIT_TAG") && !strings.Contains(expr, "!=") && !strings.Contains(expr, "== null"):
+		return true
+	case strings.Contains(expr, "$CI_COMMIT_REF_PROTECTED") && strings.Contains(expr, "true"):
+		return true
+	case branchEqPat.MatchString(expr):
+		return true
+	}
+	return false
+}
+
+// workflowRestrictsToProtected reports whether the top-level workflow:rules
+// confine the pipeline to protected refs: every admitting rule carries an if:
+// that restricts to a protected ref, and none admits merge_request_event. An
+// unconditional or MR-admitting rule means the workflow does not protect the
+// token, so it returns false.
+func workflowRestrictsToProtected(mapping *yaml.Node) bool {
+	wf := parser.FindKey(mapping, "workflow")
+	if wf == nil {
+		return false
+	}
+	rules := parser.FindKey(wf, "rules")
+	if rules == nil || rules.Kind != yaml.SequenceNode {
+		return false
+	}
+	sawProtected := false
+	for _, item := range rules.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		if ruleExcludes(item) {
+			continue
+		}
+		ifNode := parser.FindKey(item, "if")
+		if ifNode == nil || ifNode.Kind != yaml.ScalarNode {
+			return false // an unconditional allow admits every source
+		}
+		if ifAdmitsMR(ifNode.Value) || !ifRestrictsToProtected(ifNode.Value) {
+			return false
+		}
+		sawProtected = true
+	}
+	return sawProtected
+}

--- a/rules/gl081_test.go
+++ b/rules/gl081_test.go
@@ -1,0 +1,289 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings081(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL081.Check(doc.Root, "test.yml")
+}
+
+func TestGL081_NoGuard(t *testing.T) {
+	f := findings081(t, `
+terraform-plan:
+  stage: test
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.example.com
+  script:
+    - terraform plan
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL081_AdmitsMergeRequest(t *testing.T) {
+	f := findings081(t, `
+aws-integration-test:
+  stage: test
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+  script:
+    - aws sts assume-role-with-web-identity --web-identity-token "$AWS_ID_TOKEN"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for an MR-admitting guard, got %d", len(f))
+	}
+}
+
+func TestGL081_IneffectiveRules(t *testing.T) {
+	f := findings081(t, `
+oidc-job:
+  stage: test
+  id_tokens:
+    ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - when: on_success
+  script:
+    - ./run.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for rules with no if:, got %d", len(f))
+	}
+}
+
+func TestGL081_RestrictedToDefaultBranch_NoFinding(t *testing.T) {
+	f := findings081(t, `
+deploy:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a job restricted to the default branch, got %d", len(f))
+	}
+}
+
+func TestGL081_RestrictedToTag_NoFinding(t *testing.T) {
+	f := findings081(t, `
+release:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_COMMIT_TAG'
+  script:
+    - ./release.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a tag-only guard, got %d", len(f))
+	}
+}
+
+func TestGL081_RefProtected_NoFinding(t *testing.T) {
+	f := findings081(t, `
+deploy:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when guarded on CI_COMMIT_REF_PROTECTED, got %d", len(f))
+	}
+}
+
+func TestGL081_ExplicitBranchEquality_NoFinding(t *testing.T) {
+	f := findings081(t, `
+deploy:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for explicit branch equality, got %d", len(f))
+	}
+}
+
+func TestGL081_MRExcludedThenDefaultBranch_NoFinding(t *testing.T) {
+	f := findings081(t, `
+deploy:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when MRs are excluded with when: never, got %d", len(f))
+	}
+}
+
+func TestGL081_NoIDTokens_NoFinding(t *testing.T) {
+	f := findings081(t, `
+deploy:
+  stage: deploy
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a job without id_tokens:, got %d", len(f))
+	}
+}
+
+func TestGL081_WorkflowRestrictsToProtected_Suppresses(t *testing.T) {
+	f := findings081(t, `
+workflow:
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+
+oidc-job:
+  stage: test
+  id_tokens:
+    ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  script:
+    - ./run.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding when workflow:rules restrict to protected refs, got %d", len(f))
+	}
+}
+
+func TestGL081_WorkflowAdmitsMR_DoesNotSuppress(t *testing.T) {
+	f := findings081(t, `
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+
+oidc-job:
+  stage: test
+  id_tokens:
+    ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  script:
+    - ./run.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding — an MR-admitting workflow must not suppress, got %d", len(f))
+	}
+}
+
+func TestGL081_OnlyMergeRequests(t *testing.T) {
+	f := findings081(t, `
+oidc-job:
+  stage: test
+  id_tokens:
+    ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  only:
+    - merge_requests
+  script:
+    - ./run.sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for legacy only: merge_requests, got %d", len(f))
+	}
+}
+
+func TestGL081_ExtendsSkipped(t *testing.T) {
+	f := findings081(t, `
+oidc-job:
+  extends: .base
+  stage: test
+  id_tokens:
+    ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  script:
+    - ./run.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a job using extends: (guard may be inherited), got %d", len(f))
+	}
+}
+
+func TestGL081_HiddenJobSkipped(t *testing.T) {
+	f := findings081(t, `
+.oidc-template:
+  id_tokens:
+    ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  script:
+    - ./run.sh
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a hidden (.-prefixed) template job, got %d", len(f))
+	}
+}
+
+func TestGL081_MultipleJobs(t *testing.T) {
+	f := findings081(t, `
+aws-test:
+  stage: test
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+  script:
+    - ./test.sh
+
+vault-plan:
+  stage: test
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.example.com
+  script:
+    - ./plan.sh
+
+deploy-prod:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+  script:
+    - ./deploy.sh
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings (aws-test + vault-plan), got %d", len(f))
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -83,6 +83,7 @@ var owaspCategories = map[string][]string{
 	"GL078": {"CICD-SEC-4"},
 	"GL079": {"CICD-SEC-3"},
 	"GL080": {"CICD-SEC-1"},
+	"GL081": {"CICD-SEC-5"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/rules/versions.go
+++ b/rules/versions.go
@@ -6,6 +6,7 @@ import "github.com/glsec/glsec/internal/version"
 // the feature the rule checks. Rules not listed here have no version gate.
 var minVersions = map[string]version.Version{
 	"GL009": {Major: 15, Minor: 7}, // id_tokens:
+	"GL081": {Major: 15, Minor: 7}, // id_tokens:
 	"GL010": {Major: 14, Minor: 9}, // trigger: forward:
 	"GL014": {Major: 12, Minor: 9}, // artifacts: reports: dotenv:
 }

--- a/testdata/fixtures/gl081-unrestricted-oidc-source.yml
+++ b/testdata/fixtures/gl081-unrestricted-oidc-source.yml
@@ -1,0 +1,36 @@
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+aws-integration-test:
+  stage: test
+  image: amazon/aws-cli:2.15.17
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - aws sts assume-role-with-web-identity --role-arn "$AWS_ROLE_ARN" --web-identity-token "$AWS_ID_TOKEN"
+    - aws s3 ls s3://my-integration-bucket/
+
+terraform-plan:
+  stage: test
+  image: hashicorp/terraform:1.7.3
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.example.com
+  script:
+    - export VAULT_TOKEN="$(vault write -field=token auth/jwt/login role=ci jwt=$VAULT_ID_TOKEN)"
+    - terraform plan
+
+deploy-prod:
+  stage: deploy
+  id_tokens:
+    AWS_ID_TOKEN:
+      aud: https://sts.amazonaws.com
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  script:
+    - aws s3 sync ./build s3://prod-bucket/


### PR DESCRIPTION
Closes #430.

## What

Adds **GL081** — flags a job that issues an OIDC `id_tokens:` credential on an unrestricted pipeline source, where any branch or merge request can mint a cloud-federating token.

## Why

`id_tokens:` mints a JWT that federates into a cloud provider or secrets manager (AWS STS, GCP, Vault, PyPI, …). GL009 is the only existing rule that looks at `id_tokens:`, and it only inspects the audience (`aud:`). A job with a perfectly scoped audience but **no restriction on which pipeline sources run it** is caught by nothing:

- **GL080** keys on a deploy keyword or an `environment:`, so a job named `aws-integration-test` or `terraform-plan` is never considered sensitive.
- **GL053** fires once, file-level, and disappears as soon as any top-level `workflow:rules` exists — including rules that explicitly *admit* `merge_request_event`.

### Threat model

The naive framing ("a fork MR steals your token") is *not* the main path — fork MR pipelines run in the fork project by default, so the JWT identifies the fork. The two paths that hold:

1. **Same-project MR and branch pipelines.** Any Developer can push a branch / open an MR and mint a token. Cloud trust policies overwhelmingly condition on `project_path` only, so a feature-branch token is indistinguishable from a default-branch one.
2. **`ci_allow_fork_pipelines_to_run_in_parent_project`**, where fork-controlled code runs in the parent context before merge.

The robust fix is a cloud-side condition on the `ref_protected` claim, which a linter cannot see — but the *absence of a pipeline-side ref guard* is a reliable signal nobody scoped it.

## What glsec checks

Fires on a job with `id_tokens:` when either:
- its guard explicitly admits `merge_request_event` (`rules:if` or legacy `only: merge_requests`), or
- it has no effective guard **and** no `workflow:rules` confine the pipeline to protected refs.

Does **not** fire when: `rules:` restrict to a protected ref/tag (`$CI_DEFAULT_BRANCH`, `$CI_COMMIT_TAG`, `$CI_COMMIT_REF_PROTECTED == "true"`, explicit branch equality); the job uses `extends:` / `<<:`; it's a hidden template; or `id_tokens:` is declared in the top-level `default:` block.

Reuses `jobGuardState` / `inheritsConfig` from `rules/gl080.go`. Adds a GL081-specific `workflowRestrictsToProtected` — stricter than gl080's `workflowRestrictsSource`, so a workflow that carries an `if:` but still admits `merge_request_event` does not suppress the finding.

Metadata: CICD-SEC-5 · CWE-284 · minVersion 15.7 (consistent with GL009).

## Testing

- `go test ./...` — all green, including `TestRuleConsistency`. 16 new unit tests in `rules/gl081_test.go`.
- `gofmt` / `go vet` clean.
- Fixture validates against the GitLab CI builtin schema (`check-jsonschema`).
- **False-positive scan** against 261 root `.gitlab-ci.yml` from the most-starred public GitLab projects (10 contained `id_tokens:`): **2 findings, 0 false positives.** Both true positives were a project's PyPI-publish jobs (`stage: deploy` + bare `when: manual`, no `rules:`) under a workflow that admits any-branch push. The 8 non-firing `id_tokens:` files were all correctly suppressed (hidden templates / `extends:` / `<<:` merges / a schedule-gated job / a `default:`-level declaration).

## Scope

`rules/gl081.go`, `rules/gl081_test.go`, `rules/all.go`, metadata maps (`owasp.go`, `cwe.go`, `versions.go`), `docs/rules/GL081.md`, `docs/rules.md`, README (rule count 80 → 81), `testdata/fixtures/gl081-unrestricted-oidc-source.yml`.
