### PR TITLE
ci: verify module cache integrity with go mod verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - run: go mod verify
       - run: go build ./...
 
   test:
@@ -34,6 +35,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - run: go mod verify
       - run: go test -race -coverprofile=coverage.out ./...
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
Resolves the actionable part of #429.

## What

Adds a `go mod verify` step to the `build` and `test` CI jobs, right after `setup-go` restores the module cache and before compiling.

## Why

#429 proposed vendoring dependencies as supply-chain hardening. I decided against vendoring (rationale in the issue): `go.sum` + the checksum database already provide the integrity guarantee, our dependency tree is a single direct dep (`yaml.v3`), and the re-vendor-on-every-bump maintenance isn't worth it for that.

`go mod verify` is the cheap, useful subset. Each CI job restores the module cache from the Actions cache (`cache: true`); `go mod verify` checks that restored cache against the hashes in `go.sum`, so a corrupted or tampered cache fails the build instead of being compiled silently. It has real precedent among comparable Go tools (e.g. poutine and golangci-lint run it in CI), whereas an explicit `GOFLAGS=-mod=readonly` has essentially none — it's already the Go default since 1.16 — so that half was dropped.

## How to test

- CI: the new `go mod verify` steps run in the `build` and `test` jobs; both pass (locally: `all modules verified`).
- No source or dependency changes — this is CI-only.
