### PR TITLE
ci: run test suite on macOS and Windows via os matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -37,7 +41,10 @@ jobs:
           cache: true
       - run: go mod verify
       - run: go test -race -coverprofile=coverage.out ./...
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      # Upload coverage from one OS only — a shared artifact name collides across
+      # matrix legs, and Linux coverage is representative.
+      - if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    # Force bash on every OS. The Windows runner defaults to PowerShell, which
+    # mangles `go test -race -coverprofile=coverage.out ./...` into a bogus
+    # ".out" package argument; bash parses the command identically everywhere.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Closes #433.

## What

Runs the `test` job on `ubuntu-latest`, `macos-latest`, and `windows-latest` via a `strategy.matrix.os`, instead of Linux only. All other jobs stay Linux-only (they're platform-independent or Docker-based).

## Why

We ship macOS and Windows binaries but only ever tested on Linux. glsec has OS-sensitive code — POSIX shell analysis, `--recursive` path/glob walking, line-ending handling — that a Linux-only run can't exercise.

## Notes

- `go test -race` is supported on all three runners; the test command is unchanged.
- Coverage is uploaded from the `ubuntu-latest` leg only (a shared artifact name collides across matrix legs, and Linux coverage is representative).
- `fail-fast: false` so one OS failing still reports the others.
- The external-`shellcheck` integration degrades gracefully when the binary is absent (verified: the full suite passes with no `shellcheck` on PATH), so the macOS/Windows legs won't fail on that. Any genuine portability issues the matrix surfaces (e.g. CRLF, path edge cases) will be fixed here per the issue's acceptance criteria.

## How to test

CI: the `Test (ubuntu-latest | macos-latest | windows-latest)` legs must all pass.
