### PR TITLE
ci: add CodeQL analysis workflow for Go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload analysis results to the Code Scanning tab
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - uses: github/codeql-action/init@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        with:
+          languages: go
+      - uses: github/codeql-action/autobuild@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+      - uses: github/codeql-action/analyze@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        with:
+          category: "/language:go"


### PR DESCRIPTION
Closes #435.

## What

Adds `.github/workflows/codeql.yml` — CodeQL static analysis for Go, running on push to `main`, PRs to `main`, and a weekly schedule. Results upload to the repo's Code Scanning tab.

## Why

A scan of the 30 best-known Go security tools' pipelines found CodeQL `analyze` is the most widely adopted CI security step we didn't run (17/29). It adds interprocedural taint/dataflow analysis beyond what our pattern-based stack (gosec/staticcheck/govet via golangci-lint, govulncheck, zizmor) covers, and its upload also surfaces findings in the Security tab.

## Notes

- `setup-go` (pinned, `go-version-file: go.mod`, `cache: false`) runs before `init` so CodeQL builds against our toolchain; classic `init` → `autobuild` → `analyze`.
- Least privilege: top-level `contents: read`; the job adds `security-events: write` only.
- All actions SHA-pinned with version comments, `persist-credentials: false` — `zizmor` passes locally (no findings).
- **Advisory, not a required status check** — it won't gate merges. Can be promoted to required later (via branch-protection required checks) if wanted.

## How to test

CI: the new `Analyze (Go)` job runs green and uploads to Code Scanning; the existing `zizmor` job stays green on the new workflow.
