### PR TITLE
docs: clarify Code Quality fingerprint is not password hashing

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -480,6 +480,9 @@ func severityToCodeClimate(s finding.Severity) string {
 	}
 }
 
+// codeClimateFingerprint returns a stable one-way ID for GitLab Code Quality's
+// required fingerprint field. The SHA256 is a content hash over finding
+// metadata, not password hashing — no secret is stored or verified against it.
 func codeClimateFingerprint(f finding.Finding) string {
 	h := sha256.Sum256([]byte(f.RuleID + "|" + f.File + "|" + f.Job + "|" + f.Message + "|" + fmt.Sprintf("%d", f.Line)))
 	return hex.EncodeToString(h[:])


### PR DESCRIPTION
## What

Adds a one-line doc comment to `codeClimateFingerprint` explaining that the SHA256 there is a content fingerprint, not password hashing.

## Why

The new CodeQL workflow (#436) flagged this line as `go/weak-sensitive-data-hashing` ("password used in insecure hash"). It's a false positive — the function builds GitLab Code Quality's required one-way `fingerprint` ID over finding metadata (`RuleID|File|Job|Message|Line`); CodeQL taints the input as a "password" only because finding messages contain words like "secret"/"credential" (GL006/GL036/GL038 etc.). The alert is already dismissed as a false positive; this comment records the reasoning at the source so a future reader — or anyone re-triaging the scan — doesn't have to re-derive it.

No behavior change; comment only.
