### PR TITLE
ci: pin zizmor to 1.28.0 (avoid token-leaking 1.27.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install zizmor
-        run: pip install zizmor
+        run: pip install zizmor==1.28.0
       - name: Run zizmor
         run: zizmor --gh-token "${{ secrets.GITHUB_TOKEN }}" .github/workflows/
 


### PR DESCRIPTION
Closes #438.

## What

Pins the zizmor install in CI to `1.28.0` instead of an unpinned `pip install zizmor`.

## Why

zizmor v1.27.0 logs a passed `--gh-token` in cleartext ([GHSA-f42p-wjw5-97qh](https://github.com/zizmorcore/zizmor/security/advisories/GHSA-f42p-wjw5-97qh)), fixed in v1.28.0. Our zizmor job passes `secrets.GITHUB_TOKEN`, so an unpinned install could pull the leaking version and print the token into the public Actions log. The token is job-scoped/ephemeral (low historical severity), but pinning removes the exposure path going forward and closes the standing "tools unpinned inside SHA-pinned jobs" hygiene gap for this step.

Surfaced by the weekly peer-tool scan.

## How to test

CI: the `Security (zizmor)` job installs `zizmor==1.28.0` and passes as before.
