### PR TITLE
fix: bump Claude Code plugin pins to 1.13.0 and guard drift in CI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glsec",
   "description": "Static security scanner for GitLab CI/CD pipelines",
-  "version": "1.5.1",
+  "version": "1.13.0",
   "author": {
     "name": "glsec",
     "url": "https://github.com/glsec/glsec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,44 @@ jobs:
       - run: pip install check-jsonschema
       - name: Validate against GitLab CI schema
         run: check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
+
+  version-pins:
+    name: Check version pins agree
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # The Claude Code plugin ships its own version pin and downloads the
+      # matching release asset, so a release bump that misses it leaves plugin
+      # users on an old glsec (#441). The GitLab component version
+      # (gitlab.com/glsec-io/...@vX.Y.Z) is released separately and excluded.
+      - name: Compare plugin pins against README
+        run: |
+          set -euo pipefail
+
+          want=$(jq -r .version .claude-plugin/plugin.json)
+          echo "plugin.json: $want"
+
+          found=$(
+            {
+              grep -oE 'VERSION="[0-9]+\.[0-9]+\.[0-9]+"' bin/glsec |
+                grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+              grep -hoE \
+                -e 'glsec_[0-9]+\.[0-9]+\.[0-9]+_' \
+                -e 'ghcr\.io/glsec/glsec:[0-9]+\.[0-9]+\.[0-9]+' \
+                -e 'releases/download/v[0-9]+\.[0-9]+\.[0-9]+' \
+                -e 'rev: v[0-9]+\.[0-9]+\.[0-9]+' \
+                -e 'GLSEC_VERSION: "[0-9]+\.[0-9]+\.[0-9]+"' \
+                -e '`[0-9]+\.[0-9]+\.[0-9]+`, not `:latest`' \
+                README.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+            } | sort -u
+          )
+
+          if [ "$found" != "$want" ]; then
+            echo "::error::version pins disagree; expected $want everywhere, found:"
+            printf '%s\n' "$found"
+            exit 1
+          fi
+          echo "all pins agree on $want"

--- a/bin/glsec
+++ b/bin/glsec
@@ -12,7 +12,7 @@
 # Supports linux + darwin only. VERSION is kept in lockstep with the release.
 set -eu
 
-VERSION="1.5.1"
+VERSION="1.13.0"
 REPO="glsec/glsec"
 
 hint() {


### PR DESCRIPTION
Closes #441.

## What changed

- `.claude-plugin/plugin.json` → `1.13.0` (was `1.5.1`)
- `bin/glsec` → `VERSION="1.13.0"` (was `1.5.1`)
- New CI job `version-pins`: takes `plugin.json`'s version as the source of truth and fails if the wrapper pin or any glsec release reference in the README disagrees with it.

## Why

The plugin pins were last touched in #311 and have sat at 1.5.1 through eight releases. The wrapper only downloads when no `glsec` is already on `PATH`, so this was invisible to anyone who also has glsec installed — but a fresh plugin install on a clean machine fetched `glsec_1.5.1_<os>_<arch>.tar.gz` and got a scanner missing every rule added since.

Nothing tied the plugin pins to the release version, so the release bumps (most recently #440) kept updating the README and left the plugin behind. The new CI job closes that loop.

The check covers the structured release references — `glsec_X.Y.Z_`, `ghcr.io/glsec/glsec:X.Y.Z`, `releases/download/vX.Y.Z`, the pre-commit `rev:`, `GLSEC_VERSION:`, and the prose "pin to a specific tag" example. The GitLab CI/CD Catalog component version (`gitlab.com/glsec-io/glsec/glsec@v1.0.9`) is deliberately excluded — it is released on its own cadence.

## How to test

CI runs the new `version-pins` job. Locally:

```sh
# passes on this branch
jq -r .version .claude-plugin/plugin.json   # 1.13.0
grep VERSION= bin/glsec                     # VERSION="1.13.0"
```

To confirm the guard bites, revert either pin to `1.5.1` and re-run the job — it reports both versions and exits 1 (verified against a stale copy of `bin/glsec` before pushing).

End-to-end plugin check on a machine without glsec on `PATH`:

```sh
rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/glsec"
./bin/glsec --version   # downloads + checksum-verifies the 1.13.0 asset
```

The v1.13.0 release assets and `checksums.txt` the wrapper needs are already published.