### PR TITLE
GL016: cover git:// transport and git fetches over plain HTTP

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -45,7 +45,7 @@ Mutable references that allow silent substitution of images, templates, or packa
 | [GL001](rules/GL001.md) | `error` | Mutable image tag (`latest`, no tag, non-digest pin) |
 | [GL003](rules/GL003.md) | `error` | Remote `include:` with mutable or missing `ref` |
 | [GL011](rules/GL011.md) | `error` | Download-and-execute pattern in script (`curl \| bash`, `wget \| sh`) |
-| [GL016](rules/GL016.md) | varies  | HTTP instead of HTTPS (`include:remote`, scripts, variables) |
+| [GL016](rules/GL016.md) | varies  | Insecure transport — HTTP or `git://` (`include:remote`, scripts, variables) |
 | [GL022](rules/GL022.md) | `warn`  | Package manager install without version pin or explicit update-to-latest in CI |
 | [GL023](rules/GL023.md) | `warn`  | Lockfile not enforced (`npm install` instead of `npm ci`, `yarn install` without `--frozen-lockfile`, etc.) |
 | [GL046](rules/GL046.md) | `warn`  | `cache: key:` derived from user-controlled variable — attacker can craft a branch name to collide with and poison the cache of a protected pipeline |

--- a/docs/rules/GL016.md
+++ b/docs/rules/GL016.md
@@ -1,17 +1,21 @@
-# GL016 — HTTP instead of HTTPS in URLs
+# GL016 — Insecure transport in URLs (HTTP, git://)
 
 **Severity:** varies by context (see below)  
 **OWASP:** [CICD-SEC-3 – Dependency Chain Abuse](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-03-Dependency-Chain-Abuse)
 
 ## What glsec checks
 
-glsec flags HTTP URLs in security-sensitive locations. Severity depends on context:
+glsec flags plaintext transports — HTTP and git's legacy `git://` protocol — in security-sensitive locations. Severity depends on context:
 
 | Location | Severity | Risk |
 |----------|----------|------|
 | `include: remote: http://...` | `error` | MITM attacker injects arbitrary pipeline configuration |
 | `curl http://...` / `wget http://...` in scripts | `warn` | MITM attacker serves malicious content |
-| `variables:` value with `http://` | `warn` (public) / `info` (private) | Credential or data interception |
+| `git clone/fetch/pull/remote add/submodule add http://...` in scripts | `warn` | MITM attacker serves modified source |
+| `git://...` anywhere in a script line | `warn` | Plaintext **and** unauthenticated — no server identity check at all |
+| `variables:` value with `http://` or `git://` | `warn` (public) / `info` (private) | Credential or data interception |
+
+`git://` is git's daemon protocol. It offers neither encryption nor server authentication, so an attacker on the path can substitute the repository contents outright. Major forges dropped support for it years ago; a surviving `git://` URL in a pipeline is usually stale configuration pointing at something that no longer answers — or at an internal daemon nobody has reviewed.
 
 ## Host classification
 
@@ -32,6 +36,8 @@ include:
 build:
   script:
     - curl http://install.example.com/tool.sh -o tool.sh   # warn
+    - git clone http://git.example.com/vendor/lib.git      # warn
+    - git clone git://git.example.com/vendor/tool.git      # warn
 
 variables:
   REGISTRY: "http://nexus.internal/repo"   # info — internal host
@@ -48,7 +54,10 @@ build:
     - curl https://install.example.com/tool.sh -o tool.sh
     - echo "abc123…  tool.sh" | sha256sum --check
     - bash tool.sh
+    - git clone https://git.example.com/vendor/lib.git
 ```
+
+For git remotes, `ssh://` is equally acceptable — both authenticate the server.
 
 ## Enterprise allowlist
 

--- a/docs/rules/GL040.md
+++ b/docs/rules/GL040.md
@@ -40,7 +40,7 @@ deploy:
 ## References
 
 - [RFC 4217 — Securing FTP with TLS](https://www.rfc-editor.org/rfc/rfc4217)
-- GL016: HTTP instead of HTTPS in `include:remote`, scripts, variables
+- GL016: insecure transport (HTTP, `git://`) in `include:remote`, scripts, variables
 - GL038: hardcoded credential literals in script commands
 
 ## See also

--- a/rules/gl016.go
+++ b/rules/gl016.go
@@ -26,7 +26,10 @@ func (r *gl016) SetTrustedHosts(hosts []string) {
 
 var (
 	httpURLRe      = regexp.MustCompile(`https?://[^\s'"]+`)
+	gitURLRe       = regexp.MustCompile(`\bgit://[^\s'"]+`)
 	curlWgetHTTPRe = regexp.MustCompile(`\b(?:curl|wget)\b[^|]*\bhttp://`)
+	// git fetches remote content just like curl/wget, so the same HTTP check applies.
+	gitFetchHTTPRe = regexp.MustCompile(`\bgit\b[^|]*\b(?:clone|fetch|pull|remote\s+add|submodule\s+add)\b[^|]*\bhttp://`)
 	privateRanges  []*net.IPNet
 	internalTLDs   = []string{".local", ".internal", ".corp", ".lan"}
 )
@@ -106,7 +109,13 @@ func (r *gl016) checkIncludes(node *yaml.Node, file string) []finding.Finding {
 		if remote == nil || remote.Kind != yaml.ScalarNode {
 			continue
 		}
-		if !strings.HasPrefix(remote.Value, "http://") {
+		var scheme string
+		switch {
+		case strings.HasPrefix(remote.Value, "http://"):
+			scheme = "HTTP"
+		case strings.HasPrefix(remote.Value, "git://"):
+			scheme = "the plaintext git:// transport"
+		default:
 			continue
 		}
 		host := hostOf(remote.Value)
@@ -114,10 +123,10 @@ func (r *gl016) checkIncludes(node *yaml.Node, file string) []finding.Finding {
 			continue
 		}
 		sev := finding.Error
-		msg := "include: remote: uses HTTP — a MITM attacker can inject arbitrary pipeline configuration"
+		msg := "include: remote: uses " + scheme + " — a MITM attacker can inject arbitrary pipeline configuration"
 		if isPrivateOrInternal(host) {
 			sev = finding.Info
-			msg = "include: remote: uses HTTP to a private/internal host — consider HTTPS even on internal networks"
+			msg = "include: remote: uses " + scheme + " to a private/internal host — consider HTTPS even on internal networks"
 		}
 		findings = append(findings, finding.Finding{
 			RuleID: "GL016", Severity: sev, Message: msg,
@@ -143,18 +152,27 @@ func (r *gl016) checkVariablesHTTP(node *yaml.Node, file string) []finding.Findi
 				scalar = v
 			}
 		}
-		if scalar == nil || !strings.Contains(scalar.Value, "http://") {
+		if scalar == nil {
 			continue
 		}
-		host := hostOf(scalar.Value)
+		var rawURL, scheme string
+		switch {
+		case strings.Contains(scalar.Value, "http://"):
+			rawURL, scheme = scalar.Value, "HTTP"
+		case gitURLRe.MatchString(scalar.Value):
+			rawURL, scheme = gitURLRe.FindString(scalar.Value), "the plaintext git:// transport"
+		default:
+			continue
+		}
+		host := hostOf(rawURL)
 		if r.skip(host) {
 			continue
 		}
 		sev := finding.Info
-		msg := "variable value uses HTTP — consider HTTPS to protect data in transit"
+		msg := "variable value uses " + scheme + " — consider HTTPS to protect data in transit"
 		if !isPrivateOrInternal(host) {
 			sev = finding.Warn
-			msg = "variable value uses HTTP to a public host — a MITM attacker can read or modify traffic"
+			msg = "variable value uses " + scheme + " to a public host — a MITM attacker can read or modify traffic"
 		}
 		findings = append(findings, finding.Finding{
 			RuleID: "GL016", Severity: sev, Message: msg,
@@ -173,30 +191,55 @@ func (r *gl016) checkScriptHTTP(node *yaml.Node, file string) []finding.Finding 
 		if item.Kind != yaml.ScalarNode {
 			continue
 		}
-		if !curlWgetHTTPRe.MatchString(item.Value) {
-			continue
+		if f := r.scriptLineFinding(item, file); f != nil {
+			findings = append(findings, *f)
 		}
-		// Extract the http:// URL from the line to get the host.
-		m := httpURLRe.FindString(item.Value)
-		if m == "" || !strings.HasPrefix(m, "http://") {
-			continue
-		}
-		host := hostOf(m)
-		if r.skip(host) {
-			continue
-		}
-		sev := finding.Warn
-		msg := "script downloads over HTTP — a MITM attacker can serve malicious content"
-		if isPrivateOrInternal(host) {
-			sev = finding.Info
-			msg = "script downloads over HTTP from a private/internal host — consider HTTPS"
-		}
-		findings = append(findings, finding.Finding{
-			RuleID: "GL016", Severity: sev, Message: msg,
-			File: file, Line: item.Line, Col: item.Column,
-		})
 	}
 	return findings
+}
+
+// scriptLineFinding reports at most one insecure-transport finding for a single
+// script line: git:// anywhere on the line, otherwise an HTTP URL fetched by a
+// known downloader (curl, wget, git).
+func (r *gl016) scriptLineFinding(item *yaml.Node, file string) *finding.Finding {
+	if m := gitURLRe.FindString(item.Value); m != "" {
+		host := hostOf(m)
+		if !r.skip(host) {
+			sev := finding.Warn
+			msg := "script fetches over git:// — git's plaintext, unauthenticated transport lets a MITM attacker serve modified source; use https:// or ssh://"
+			if isPrivateOrInternal(host) {
+				sev = finding.Info
+				msg = "script fetches over git:// from a private/internal host — use https:// or ssh://"
+			}
+			return &finding.Finding{
+				RuleID: "GL016", Severity: sev, Message: msg,
+				File: file, Line: item.Line, Col: item.Column,
+			}
+		}
+	}
+
+	if !curlWgetHTTPRe.MatchString(item.Value) && !gitFetchHTTPRe.MatchString(item.Value) {
+		return nil
+	}
+	// Extract the http:// URL from the line to get the host.
+	m := httpURLRe.FindString(item.Value)
+	if m == "" || !strings.HasPrefix(m, "http://") {
+		return nil
+	}
+	host := hostOf(m)
+	if r.skip(host) {
+		return nil
+	}
+	sev := finding.Warn
+	msg := "script downloads over HTTP — a MITM attacker can serve malicious content"
+	if isPrivateOrInternal(host) {
+		sev = finding.Info
+		msg = "script downloads over HTTP from a private/internal host — consider HTTPS"
+	}
+	return &finding.Finding{
+		RuleID: "GL016", Severity: sev, Message: msg,
+		File: file, Line: item.Line, Col: item.Column,
+	}
 }
 
 // skip returns true if the host should never be flagged (loopback or trusted).

--- a/rules/gl016_test.go
+++ b/rules/gl016_test.go
@@ -278,6 +278,153 @@ build:
 	}
 }
 
+func TestGL016_ScriptGitCloneHTTP_Warn(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - git clone http://git.example.com/vendor/lib.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for git clone http://, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity for git clone over HTTP, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_ScriptGitSubcommandsHTTP_Warn(t *testing.T) {
+	for _, line := range []string{
+		"git -C vendor clone --depth 1 http://git.example.com/lib.git",
+		"git fetch http://git.example.com/lib.git main",
+		"git pull http://git.example.com/lib.git",
+		"git remote add upstream http://git.example.com/lib.git",
+		"git submodule add http://git.example.com/lib.git vendor/lib",
+	} {
+		f := findings016(t, "build:\n  script:\n    - "+line+"\n")
+		if len(f) != 1 {
+			t.Errorf("expected 1 finding for %q, got %d", line, len(f))
+		}
+	}
+}
+
+func TestGL016_ScriptGitCloneHTTPS_NoFinding(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - git clone https://git.example.com/vendor/lib.git
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for git clone https://, got %d", len(f))
+	}
+}
+
+func TestGL016_ScriptGitProtocol_Warn(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - git clone git://git.example.com/vendor/lib.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for git:// clone, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity for git:// transport, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_ScriptGitProtocolPrivate_Info(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - git clone git://10.0.1.5/vendor/lib.git
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for git:// to private IP, got %d", len(f))
+	}
+	if f[0].Severity != finding.Info {
+		t.Errorf("expected Info severity for private host, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_ScriptGitProtocolTrusted_NoFinding(t *testing.T) {
+	f := findings016trusted(t, `
+build:
+  script:
+    - git clone git://git.corp.example.com/vendor/lib.git
+`, []string{"git.corp.example.com"})
+	if len(f) != 0 {
+		t.Errorf("expected no finding for trusted host, got %d", len(f))
+	}
+}
+
+func TestGL016_VariableGitProtocol_Warn(t *testing.T) {
+	f := findings016(t, `
+variables:
+  VENDOR_REPO: "git://git.example.com/vendor/lib.git"
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for git:// variable, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn for public host in git:// variable, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_VariableGitProtocolInternal_Info(t *testing.T) {
+	f := findings016(t, `
+variables:
+  VENDOR_REPO: "git://git.internal/vendor/lib.git"
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for internal git:// variable, got %d", len(f))
+	}
+	if f[0].Severity != finding.Info {
+		t.Errorf("expected Info for .internal host, got %s", f[0].Severity)
+	}
+}
+
+func TestGL016_IncludeRemoteGitProtocol_Error(t *testing.T) {
+	f := findings016(t, `
+include:
+  - remote: "git://templates.example.com/ci.yml"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for git:// include, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected Error severity for git:// include, got %s", f[0].Severity)
+	}
+}
+
+// The scheme match is anchored on a word boundary so substrings such as
+// "digit://" in an unrelated URL path do not count as git transport.
+func TestGL016_GitSchemeSubstring_NoFinding(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - echo "see https://docs.example.com/digit://notes"
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for digit:// substring, got %d", len(f))
+	}
+}
+
+func TestGL016_ScriptGitStatusNoURL_NoFinding(t *testing.T) {
+	f := findings016(t, `
+build:
+  script:
+    - git status
+    - git log --oneline -1
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for plain git commands, got %d", len(f))
+	}
+}
+
 func TestGL016_LineNumber(t *testing.T) {
 	f := findings016(t, `
 include:

--- a/testdata/fixtures/gl016-http-urls.yml
+++ b/testdata/fixtures/gl016-http-urls.yml
@@ -14,3 +14,5 @@ build:
     - npm ci
     - curl http://install.example.com/tool.sh -o tool.sh
     - bash tool.sh
+    - git clone http://git.example.com/vendor/lib.git
+    - git clone git://git.example.com/vendor/tool.git


### PR DESCRIPTION
Closes #445.

## What changed

GL016 was the insecure-transport rule but only knew one insecure scheme, `http://`, and only recognised one pair of downloaders, `curl` and `wget`. Two holes followed from that, both now closed:

**1. `git://` was invisible.** Git's daemon protocol is plaintext *and* unauthenticated — no encryption, no server identity check — so a MITM can substitute the repository contents outright. It is now flagged in all three locations GL016 already inspects:

- `include: remote:` → `error` (GitLab only accepts http(s) here, so this is belt-and-braces)
- `variables:` values → `warn` public / `info` private
- anywhere on a script line → `warn` public / `info` private

**2. `git clone http://…` slipped past the script check.** `checkScriptHTTP` gated on `\b(?:curl|wget)\b` before it ever looked for a URL. The gate now also matches `git` paired with `clone`, `fetch`, `pull`, `remote add` or `submodule add`, which covers `git -C dir clone …` and flag-laden invocations too. Severity `warn`, matching the existing curl/wget row.

Host classification is untouched: loopback and `trusted-hosts:` entries are still skipped, and RFC 1918 / `.local` / `.internal` / `.corp` / `.lan` hosts are still downgraded to `info`.

`checkScriptHTTP`'s per-line body moved into a `scriptLineFinding` helper so the two schemes can be evaluated in order without nesting. Behaviour is unchanged for lines that were already flagged: still at most one finding per script line.

## Why not a new rule ID

Same threat class (CICD-SEC-3, plaintext transport), same remediation, same allowlist semantics. Splitting it would mean users configure `trusted-hosts:` twice.

## How to test

```yaml
build:
  script:
    - git clone http://git.example.com/vendor/lib.git
    - git clone git://git.example.com/vendor/tool.git
    - git clone https://git.example.com/vendor/ok.git
variables:
  VENDOR_REPO: "git://git.example.com/vendor/lib.git"
```

Before: only GL026 (mutable ref) on the two clone lines, nothing on the variable. After: three GL016 findings — HTTP download, `git://` fetch, `git://` variable — and the `https://` line stays silent.

- `go test ./rules/ -run TestGL016` — 12 new cases: each git subcommand over HTTP, `git://` in scripts/variables/`include:`, private-host downgrade, trusted-host suppression, `https://` and bare `git status` staying silent, plus a guard that the `\bgit://` word boundary does not match a `digit://` substring.
- Full suite, `golangci-lint run ./...` and `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml` all pass locally.

## False-positive scan

Scanned 199 real root `.gitlab-ci.yml` files harvested from the most-starred public GitLab projects, comparing this branch against `main`: **11 GL016 findings on both, byte-identical** — no new noise, no regressions. Note what that does and does not show: the corpus contains zero `git://` URLs and zero git-over-HTTP fetches, so it confirms the widened patterns do not misfire on real pipelines, but it does not exercise the new paths positively. That coverage comes from the unit tests.

Real-world FP risk stays low for a different reason: the major forges dropped `git://` years ago, so surviving occurrences are stale config or unreviewed internal daemons — both worth a `warn`. Internal hosts still get the `info` downgrade, and `trusted-hosts:` remains the escape hatch.

## Docs

`docs/rules/GL016.md` retitled ("Insecure transport in URLs (HTTP, git://)"), two rows added to the check table with a paragraph on why `git://` is worse than plain HTTP, plus trigger and safe-alternative examples. Summary line in `docs/rules.md` and the cross-reference in `docs/rules/GL040.md` widened to match. Fixture extended with both new cases.
