### PR TITLE
GL064: refresh CI Catalog component list

### DIFF
--- a/rules/data/catalog_components.txt
+++ b/rules/data/catalog_components.txt
@@ -1,14 +1,19 @@
-# Popular GitLab CI Catalog component resource paths (namespace/project),
-# sorted by star count at generation time. Used by GL064 for typosquatting
-# detection. Regenerate from the GitLab GraphQL ciCatalogResources API.
+# Popular GitLab CI Catalog component resource paths (namespace/project), the
+# ~60 most-starred at generation time, listed in byte order. Used by GL064 for
+# typosquatting detection. Regenerate from the GitLab GraphQL
+# ciCatalogResources API (sort: STAR_COUNT_DESC).
 # The check-catalog-components workflow watches this monthly and opens an issue
-# when the list drifts from the most-starred components.
+# when the list drifts from the most-starred components. Refreshes are additive
+# unless an entry has fallen out of the API top 100 — an entry ranked 61-100 is
+# still a plausible squat target, so dropping it only loses coverage.
+# Last refreshed: 2026-08-02.
 TECHNOFAB/nix-gitlab-ci
 components/code-quality-oss/codequality-os-scanners-integration
 components/opentofu
 components/sast
 components/secret-detection
 dependabot-gitlab/dependabot-standalone
+gitlab-org/professional-services-automation/tools/utilities/pipeintel
 gitlab-org/quality/pipeline-common
 google-gitlab-components/artifact-registry
 guided-explorations/ci-components/checkov-iac-sast
@@ -16,6 +21,7 @@ guided-explorations/ci-components/kaniko
 guided-explorations/ci-components/scc-code-counter
 guided-explorations/ci-components/ultimate-auto-semversioning
 nagyv/gitlab-opencode
+rust-ci/rust-ci
 to-be-continuous/angular
 to-be-continuous/ansible
 to-be-continuous/aws

--- a/rules/gl064_test.go
+++ b/rules/gl064_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/glsec/glsec/internal/finding"
@@ -118,5 +119,29 @@ func TestEditDistanceAtMostOne(t *testing.T) {
 func TestCatalogCorpusLoaded(t *testing.T) {
 	if len(catalogComponents) < 20 {
 		t.Fatalf("expected a populated corpus, got %d entries", len(catalogComponents))
+	}
+}
+
+// TestCatalogCorpusSelfConsistent guards the corpus against entries that would
+// make each other look like squats. nearestTyposquat scans in file order and
+// only clears a path once it reaches the exact match, so a one-edit neighbour
+// listed earlier would flag a legitimate include of either component.
+func TestCatalogCorpusSelfConsistent(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range catalogComponents {
+		if seen[c] {
+			t.Errorf("duplicate corpus entry %q", c)
+		}
+		seen[c] = true
+
+		if strings.Count(c, "/") < 1 {
+			t.Errorf("corpus entry %q is not a namespace/project path", c)
+		}
+	}
+
+	for _, c := range catalogComponents {
+		if match, ok := nearestTyposquat(c); ok {
+			t.Errorf("corpus entry %q is one edit from corpus entry %q — including either legitimately would be flagged", c, match)
+		}
 	}
 }


### PR DESCRIPTION
Closes #446.

## What changed

Refreshed `rules/data/catalog_components.txt` against the GitLab GraphQL `ciCatalogResources` API (`sort: STAR_COUNT_DESC`, top 100), queried 2026-08-02. Two entries added, none removed:

| Added | Stars | API rank | Why it is legitimate |
|---|---|---|---|
| `gitlab-org/professional-services-automation/tools/utilities/pipeintel` | 16 | 39 | The gap the freshness check reported. Lives under `gitlab-org`, GitLab's own namespace; created 2026-03-15, 3 forks, active as of 2026-07-19. |
| `rust-ci/rust-ci` | 12 | 60 | Created 2023-02-17, still active 2026-07-11, real description ("Generic GitLab CI pipelines … for any rust project"). No star-count spike. |

## Why nothing was removed

A strict "regenerate as the API top 60" would also have dropped `to-be-continuous/spectral` (rank 61) and `guided-explorations/ci-components/scc-code-counter` (rank 62). Both are still popular components and still plausible squat targets, so removing them only loses detection coverage — the rank boundary moved, the risk did not. The workflow already encodes this tolerance: it only reports an entry as stale once it falls out of the API **top 100**, and nothing on the list has. Refreshes are therefore additive, which the header comment now states so the next person does not "clean up" the 61-100 band.

The header also claimed the file was "sorted by star count"; it is and always was in byte order. Corrected, and stamped with the refresh date.

## New test

`TestCatalogCorpusSelfConsistent` checks that no corpus entry is itself flagged by `nearestTyposquat`, plus no duplicates and no entries missing a `/`.

This is the check the issue text asks a human to do by eye ("verify no entry is itself a typosquat"), and it guards a real failure mode rather than a hypothetical one: `nearestTyposquat` scans the corpus in file order and only clears a path when it reaches the exact match (`rules/gl064.go:104`). If a one-edit neighbour under a different namespace were listed earlier, a legitimate include of **either** component would be reported as a squat. The list passes today; the test keeps the next refresh from quietly introducing such a pair.

## How to test

```yaml
include:
  - component: gitlab.com/gitlab-org/professional-services-automation/tools/utilities/pipeintel/scan@1.0.0
  - component: gitlab.com/rust-ci/rust-ci/lint@1.0.0
  - component: gitlab.com/rust-c1/rust-ci/lint@1.0.0
  - component: gitlab.com/gitlab-0rg/professional-services-automation/tools/utilities/pipeintel/scan@1.0.0
```

The two legitimate includes stay silent; the two cross-namespace squats (`rust-c1`, `gitlab-0rg`) are now flagged — neither was detected before this refresh.

Re-running the workflow's own comparison locally against the updated file: no components missing from the API top 40, no entries dropped out of the top 100.

`go test ./...`, `golangci-lint run ./...` and `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml` all pass.
