### PR TITLE
ci: bump zizmor pin to 1.29.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install zizmor
-        run: pip install zizmor==1.28.0
+        run: pip install zizmor==1.29.0
       - name: Run zizmor
         run: zizmor --gh-token "${{ secrets.GITHUB_TOKEN }}" .github/workflows/
 


### PR DESCRIPTION
Bumps the `Security (zizmor)` job's pin from `zizmor==1.28.0` to `1.29.0`, released 2026-08-01.

## Why now

The pin was introduced in #439 to get off the token-leaking 1.27.0, and 1.28.0 was the current release at the time. Nothing in CI watches this pin — the "Check version pins agree" job only compares the Claude Code plugin pins against the README, and `check-framework-versions.yml` is ASVS-only — so it stays put until someone bumps it deliberately.

## What is in 1.29.0

Nothing that changes what this job reports on a GitLab-CI linter's own workflows:

- **New audit `insecure-url-scheme`** — plaintext `http://` and `git://` in URLs, currently limited to pre-commit inputs. This repo has no `.pre-commit-config.yaml` of its own (`.pre-commit-hooks.yaml` is the hook *definition* glsec publishes for consumers, a different file), so it has nothing to match.
- Experimental auditing of pre-commit inputs — same story.
- `unpinned-uses` and `unpinned-images` split responsibilities: Git-style `uses:` versus `docker://`-style. Both audits already ran here; only which one owns a clause changed.
- Support for GitHub's self-repository `uses: $/foo/bar` syntax — not used in this repo.
- Removal of `--collect=workflows-only` / `--collect=actions-only`. This job passes neither flag.

## Verification

Ran both versions against `.github/workflows/` with the same arguments CI uses, on the release binaries for `x86_64-unknown-linux-gnu`:

```
zizmor 1.28.0 → No findings to report. Good job! (11 suppressed)  exit=0
zizmor 1.29.0 → No findings to report. Good job! (11 suppressed)  exit=0
```

Identical, including the suppression count, so the bump does not change the job's outcome. An offline run (`--no-online-audits`) on 1.29.0 is likewise clean.
