### PR TITLE
New rule GL082: managed security scan disabled via CI/CD variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Any inline `# glsec:ignore` without a `-- reason` is then reported with its file
 
 ## Rules
 
-81 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+82 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
@@ -257,7 +257,7 @@ Any inline `# glsec:ignore` without a `-- reason` is then reported with its file
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075, GL079 |
 | Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
-| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074, GL080, GL081 |
+| Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074, GL080, GL081, GL082 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063, GL076, GL077 |
 
 → **[Full rule reference with descriptions and examples](docs/rules.md)**

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -109,6 +109,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 | [GL055](rules/GL055.md) | `warn`  | `DOCKER_HOST` points at the host Docker socket (`/var/run/docker.sock`) — full control of the runner's Docker daemon |
 | [GL080](rules/GL080.md) | `warn`  | Sensitive/deploy job with no pipeline-source guard (no `rules:`/`only:` or a `rules:` with no `if:`) — runs on every source including fork MRs |
 | [GL081](rules/GL081.md) | `warn`  | Job issues an OIDC `id_tokens:` credential on an unrestricted pipeline source — any branch or merge request can mint a cloud-federating token (GitLab ≥ 15.7) |
+| [GL082](rules/GL082.md) | `warn`  | Managed security scan switched off by CI/CD variable (`SAST_DISABLED`, `SECRET_DETECTION_DISABLED`, …) — the template's jobs never run |
 
 ---
 
@@ -151,7 +152,7 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 | V14.2.2 — Components up to date and pinned | GL001, GL022, GL023, GL026, GL041 |
 | V14.2.3 — Dependencies verified for integrity | GL020 |
 | V14.3.1 — Pipeline config protected from modification | GL003, GL019 |
-| V14.3.2 — Security tools run and failures block the build | GL008, GL039 |
+| V14.3.2 — Security tools run and failures block the build | GL008, GL039, GL082 |
 | V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038, GL066, GL068 |
 | V14.3.4 — Build environment isolated | GL007, GL015, GL025 |
 | V14.4.1 — Third-party CI/CD service dependence minimised | GL041 |

--- a/docs/rules/GL082.md
+++ b/docs/rules/GL082.md
@@ -1,0 +1,98 @@
+# GL082 — Managed security scan disabled by CI/CD variable
+
+**Severity:** `warn`
+**OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
+
+## What glsec checks
+
+Each GitLab-managed security template gates its jobs on a kill-switch variable:
+
+```yaml
+# from Jobs/SAST.gitlab-ci.yml
+rules:
+  - if: $SAST_DISABLED == 'true' || $SAST_DISABLED == '1'
+    when: never
+```
+
+Set that variable and the scan disappears from the pipeline. glsec flags it in `variables:` at the top level, under `default:`, or in a job:
+
+| Variable | Scan removed |
+|----------|--------------|
+| `SAST_DISABLED` | SAST (all analyzers) |
+| `SECRET_DETECTION_DISABLED` | Secret detection |
+| `CONTAINER_SCANNING_DISABLED` | Container scanning |
+| `DEPENDENCY_SCANNING_DISABLED` | Dependency scanning |
+| `DAST_DISABLED` | DAST |
+| `DAST_DISABLED_FOR_DEFAULT_BRANCH` | DAST, on the default branch only |
+| `COVFUZZ_DISABLED` | Coverage-guided fuzzing |
+| `API_FUZZING_DISABLED` | API fuzzing |
+| `DAST_API_DISABLED` | DAST API |
+
+## Which values count
+
+The templates compare against strings, case-sensitively, so only `true` and `1` disable anything:
+
+```yaml
+variables:
+  SAST_DISABLED: "true"    # flagged — matches the gate
+  SAST_DISABLED: "1"       # flagged — matches the gate
+  SAST_DISABLED: true      # flagged — YAML boolean, GitLab stringifies it to "true"
+  SAST_DISABLED: "True"    # NOT flagged — "True" != 'true', the scan still runs
+  SAST_DISABLED: "false"   # NOT flagged
+```
+
+The quoted `"True"` case is worth knowing about in its own right: it reads as a disabled scan but is not one.
+
+## Why it matters
+
+This is the quiet way to lose a scan. [GL008](GL008.md) catches `allow_failure: true` on a scan job and [GL039](GL039.md) catches a tool silenced with `|| true`, but both need a job to inspect. Here the job is contributed by an `include:`d template and never materialises — the pipeline is green, the security dashboard has no new findings, and nothing in the YAML looks broken.
+
+A one-line variable is also cheap to add and easy to forget, which is exactly the shape of change that outlives the incident it was added for.
+
+## Trigger example
+
+```yaml
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+  - template: Jobs/Secret-Detection.gitlab-ci.yml
+
+variables:
+  SAST_DISABLED: "true"           # warn
+  SECRET_DETECTION_DISABLED: "1"  # warn
+
+build:
+  stage: build
+  image: alpine:3.19.1
+  script:
+    - make
+```
+
+## Safe alternative
+
+Keep the scan and narrow what it looks at, rather than switching it off:
+
+```yaml
+variables:
+  SAST_EXCLUDED_PATHS: "spec, test, tests, tmp, vendor"
+```
+
+If a scan genuinely does not apply — no supported language, or the scan runs in a different pipeline — suppress it inline with the reason recorded:
+
+```yaml
+variables:
+  SAST_DISABLED: "true"  # glsec:ignore GL082 -- no supported language here, SAST runs in the monorepo pipeline
+```
+
+## Notes
+
+- glsec does not resolve `include:`, so it cannot confirm the matching template is actually included. The variable is meaningless without it, so the finding is reported wherever the variable is set.
+- `LICENSE_SCANNING_DISABLED` and `LICENSE_MANAGEMENT_DISABLED` are deliberately absent: the License-Scanning and License-Management templates have been removed from GitLab, so the variables no longer gate anything.
+- `CODE_QUALITY_DISABLED` gates `Jobs/Code-Quality.gitlab-ci.yml` the same way, but Code Quality is not a security scan and is out of this rule's scope.
+- `SAST_EXCLUDED_ANALYZERS` and `DS_EXCLUDED_ANALYZERS` disable *individual* analyzers through the same `when: never` mechanism. They take analyzer-name lists rather than a boolean and are not covered by this rule.
+- Only `variables:` blocks are inspected. A job that implements the same gate itself (`rules: - if: $SECRET_DETECTION_DISABLED`) is defining the switch, not flipping it, and is not flagged.
+
+## See also
+
+- [GL008](GL008.md) — `allow_failure: true` on a security scan job
+- [GL039](GL039.md) — security tool silenced with `|| true`
+- [GL067](GL067.md) — analyzer images repointed off the official registry

--- a/rules/all.go
+++ b/rules/all.go
@@ -85,5 +85,6 @@ func All() []rule.Rule {
 		GL079,
 		GL080,
 		GL081,
+		GL082,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -26,6 +26,7 @@ var asvsRequirements = map[string][]string{
 	"GL006": {"ASVS-V14.3.3"},
 	"GL007": {"ASVS-V14.3.4"},
 	"GL008": {"ASVS-V14.3.2"},
+	"GL082": {"ASVS-V14.3.2"},
 	"GL011": {"ASVS-V14.2.1"},
 	"GL014": {"ASVS-V14.3.3"},
 	"GL015": {"ASVS-V14.3.4"},

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -83,6 +83,7 @@ var cweIDs = map[string]string{
 	"GL079": "CWE-829",
 	"GL080": "CWE-691",
 	"GL081": "CWE-284",
+	"GL082": "CWE-693",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -99,6 +100,7 @@ var cweNames = map[string]string{
 	"CWE-522":  "Insufficiently Protected Credentials",
 	"CWE-532":  "Insertion of Sensitive Information into Log File",
 	"CWE-538":  "Insertion of Sensitive Information into Externally-Accessible File or Directory",
+	"CWE-693":  "Protection Mechanism Failure",
 	"CWE-691":  "Insufficient Control Flow Management",
 	"CWE-798":  "Use of Hard-coded Credentials",
 	"CWE-250":  "Execution with Unnecessary Privileges",

--- a/rules/gl082.go
+++ b/rules/gl082.go
@@ -1,0 +1,108 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl082 struct{}
+
+var GL082 = &gl082{}
+
+func (r *gl082) ID() string { return "GL082" }
+
+// scanDisableVars maps each CI/CD variable that switches off a GitLab-managed
+// security scan to the scan it disables. Every managed template gates its jobs
+// on `rules: - if: $VAR == 'true' || $VAR == '1' → when: never`, so setting one
+// of these removes the scan from the pipeline entirely — no job, no report, and
+// nothing for the allow_failure check in GL008 to look at.
+var scanDisableVars = map[string]string{
+	"SAST_DISABLED":                "SAST",
+	"SECRET_DETECTION_DISABLED":    "secret detection",
+	"CONTAINER_SCANNING_DISABLED":  "container scanning",
+	"DEPENDENCY_SCANNING_DISABLED": "dependency scanning",
+	"DAST_DISABLED":                "DAST",
+	"COVFUZZ_DISABLED":             "coverage-guided fuzzing",
+	"API_FUZZING_DISABLED":         "API fuzzing",
+	"DAST_API_DISABLED":            "DAST API",
+}
+
+// dastDefaultBranchVar disables DAST on the default branch only, so it gets its
+// own message.
+const dastDefaultBranchVar = "DAST_DISABLED_FOR_DEFAULT_BRANCH"
+
+func (r *gl082) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	mapping := parser.Unwrap(doc)
+
+	findings = append(findings, r.checkVariables(parser.FindKey(mapping, "variables"), file)...)
+
+	if def := parser.FindKey(mapping, "default"); def != nil {
+		findings = append(findings, r.checkVariables(parser.FindKey(def, "variables"), file)...)
+	}
+
+	parser.EachJob(doc, func(name *yaml.Node, job *yaml.Node) {
+		for _, f := range r.checkVariables(parser.FindKey(job, "variables"), file) {
+			f.Job = name.Value
+			findings = append(findings, f)
+		}
+	})
+
+	return findings
+}
+
+func (r *gl082) checkVariables(node *yaml.Node, file string) []finding.Finding {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	var findings []finding.Finding
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		scan, known := scanDisableVars[key]
+		if !known && key != dastDefaultBranchVar {
+			continue
+		}
+
+		scalar := analyzerScalar(node.Content[i+1])
+		if scalar == nil || !disablesScan(scalar) {
+			continue
+		}
+
+		msg := fmt.Sprintf(
+			"%s turns off managed %s — the template gates its jobs on this variable, so nothing scans and no report is produced; remove it, or narrow the exception and document why",
+			key, scan,
+		)
+		if key == dastDefaultBranchVar {
+			msg = fmt.Sprintf(
+				"%s turns off managed DAST on the default branch — the branch that ships is the one left unscanned; remove it, or narrow the exception and document why",
+				key,
+			)
+		}
+
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL082",
+			Severity: finding.Warn,
+			Message:  msg,
+			File:     file,
+			Line:     scalar.Line,
+			Col:      scalar.Column,
+		})
+	}
+	return findings
+}
+
+// disablesScan reports whether a variable value actually satisfies the
+// templates' `$VAR == 'true' || $VAR == '1'` gate. That comparison is against
+// strings and is case-sensitive, so a quoted "True" does not disable anything —
+// but an unquoted YAML boolean does, in any spelling, because GitLab stringifies
+// it to "true" before the rule is evaluated.
+func disablesScan(n *yaml.Node) bool {
+	if n.Tag == "!!bool" {
+		return strings.EqualFold(n.Value, "true")
+	}
+	return n.Value == "true" || n.Value == "1"
+}

--- a/rules/gl082_test.go
+++ b/rules/gl082_test.go
@@ -1,0 +1,200 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings082(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL082.Check(doc.Root, "test.yml")
+}
+
+func TestGL082_TopLevelDisabled_Warn(t *testing.T) {
+	f := findings082(t, `
+variables:
+  SAST_DISABLED: "true"
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+	if !strings.Contains(f[0].Message, "SAST") {
+		t.Errorf("message should name the scan, got %q", f[0].Message)
+	}
+}
+
+func TestGL082_AllDisableVars(t *testing.T) {
+	for v := range scanDisableVars {
+		f := findings082(t, "variables:\n  "+v+": \"true\"\nbuild:\n  script: [make]\n")
+		if len(f) != 1 {
+			t.Errorf("expected 1 finding for %s, got %d", v, len(f))
+		}
+	}
+}
+
+func TestGL082_DastDefaultBranchVar_Warn(t *testing.T) {
+	f := findings082(t, `
+variables:
+  DAST_DISABLED_FOR_DEFAULT_BRANCH: "true"
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "default branch") {
+		t.Errorf("expected the default-branch wording, got %q", f[0].Message)
+	}
+}
+
+func TestGL082_ValueOne_Warn(t *testing.T) {
+	f := findings082(t, `
+variables:
+  SECRET_DETECTION_DISABLED: "1"
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf(`expected 1 finding for "1", got %d`, len(f))
+	}
+}
+
+// An unquoted YAML boolean is stringified to "true" by GitLab, so every
+// boolean spelling satisfies the template gate.
+func TestGL082_YAMLBooleanSpellings_Warn(t *testing.T) {
+	for _, v := range []string{"true", "True", "TRUE"} {
+		f := findings082(t, "variables:\n  SAST_DISABLED: "+v+"\nbuild:\n  script: [make]\n")
+		if len(f) != 1 {
+			t.Errorf("expected 1 finding for unquoted %s, got %d", v, len(f))
+		}
+	}
+}
+
+// The templates compare `$VAR == 'true'` against a string, case-sensitively, so
+// a quoted "True" leaves the scan running and must not be reported as disabled.
+func TestGL082_QuotedTrueMixedCase_NoFinding(t *testing.T) {
+	for _, v := range []string{`"True"`, `"TRUE"`, `"yes"`, `"on"`} {
+		f := findings082(t, "variables:\n  SAST_DISABLED: "+v+"\nbuild:\n  script: [make]\n")
+		if len(f) != 0 {
+			t.Errorf("expected no finding for %s, got %d", v, len(f))
+		}
+	}
+}
+
+func TestGL082_FalseValues_NoFinding(t *testing.T) {
+	for _, v := range []string{`"false"`, "false", `"0"`, "0", `""`} {
+		f := findings082(t, "variables:\n  SAST_DISABLED: "+v+"\nbuild:\n  script: [make]\n")
+		if len(f) != 0 {
+			t.Errorf("expected no finding for %s, got %d", v, len(f))
+		}
+	}
+}
+
+func TestGL082_UnrelatedVariable_NoFinding(t *testing.T) {
+	f := findings082(t, `
+variables:
+  DEPLOY_DISABLED: "true"
+  SAST_EXCLUDED_PATHS: "spec, test"
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL082_DefaultVariables_Warn(t *testing.T) {
+	f := findings082(t, `
+default:
+  variables:
+    CONTAINER_SCANNING_DISABLED: "true"
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for default: variables:, got %d", len(f))
+	}
+}
+
+func TestGL082_JobVariables_WarnWithJobName(t *testing.T) {
+	f := findings082(t, `
+build:
+  variables:
+    DEPENDENCY_SCANNING_DISABLED: "true"
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for job variables, got %d", len(f))
+	}
+	if f[0].Job != "build" {
+		t.Errorf("expected job attribution %q, got %q", "build", f[0].Job)
+	}
+}
+
+// The extended variable form carries the value under `value:`.
+func TestGL082_ExtendedVariableForm_Warn(t *testing.T) {
+	f := findings082(t, `
+variables:
+  SAST_DISABLED:
+    value: "true"
+    description: "turn SAST off"
+build:
+  script: [make]
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for the extended form, got %d", len(f))
+	}
+}
+
+func TestGL082_MultipleDisabled_OnePerVariable(t *testing.T) {
+	f := findings082(t, `
+variables:
+  SAST_DISABLED: "true"
+  SECRET_DETECTION_DISABLED: "true"
+  DAST_DISABLED: "1"
+build:
+  script: [make]
+`)
+	if len(f) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(f))
+	}
+}
+
+func TestGL082_CleanPipeline_NoFinding(t *testing.T) {
+	f := findings082(t, `
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+variables:
+  SAST_EXCLUDED_PATHS: "spec, test, tests, tmp"
+build:
+  script: [make]
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding, got %d", len(f))
+	}
+}
+
+func TestGL082_LineNumber(t *testing.T) {
+	f := findings082(t, `
+variables:
+  SAST_DISABLED: "true"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding")
+	}
+	if f[0].Line == 0 {
+		t.Error("expected non-zero line number")
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -84,6 +84,7 @@ var owaspCategories = map[string][]string{
 	"GL079": {"CICD-SEC-3"},
 	"GL080": {"CICD-SEC-1"},
 	"GL081": {"CICD-SEC-5"},
+	"GL082": {"CICD-SEC-1"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl082-security-scan-disabled.yml
+++ b/testdata/fixtures/gl082-security-scan-disabled.yml
@@ -1,0 +1,18 @@
+include:
+  - template: Jobs/SAST.gitlab-ci.yml
+  - template: Jobs/Secret-Detection.gitlab-ci.yml
+
+stages:
+  - build
+
+variables:
+  SAST_DISABLED: "true"
+  SECRET_DETECTION_DISABLED: "1"
+
+build:
+  stage: build
+  image: alpine:3.19.1
+  variables:
+    DEPENDENCY_SCANNING_DISABLED: true
+  script:
+    - make


### PR DESCRIPTION
Closes #449.

## What changed

New rule **GL082** — a managed security scan switched off by its kill-switch CI/CD variable. `warn`, CICD-SEC-1, CWE-693 (Protection Mechanism Failure), ASVS V14.3.2.

Nine variables, each verified against the live template on `master` rather than taken from documentation:

| Variable | Template | Scan removed |
|---|---|---|
| `SAST_DISABLED` | `Jobs/SAST.gitlab-ci.yml` | SAST, all analyzers |
| `SECRET_DETECTION_DISABLED` | `Jobs/Secret-Detection.gitlab-ci.yml` | Secret detection |
| `CONTAINER_SCANNING_DISABLED` | `Jobs/Container-Scanning.gitlab-ci.yml` | Container scanning |
| `DEPENDENCY_SCANNING_DISABLED` | `Jobs/Dependency-Scanning.gitlab-ci.yml` | Dependency scanning |
| `DAST_DISABLED` | `Security/DAST.gitlab-ci.yml` | DAST |
| `DAST_DISABLED_FOR_DEFAULT_BRANCH` | `Security/DAST.gitlab-ci.yml` | DAST, default branch only |
| `COVFUZZ_DISABLED` | `Security/Coverage-Fuzzing.gitlab-ci.yml` | Coverage-guided fuzzing |
| `API_FUZZING_DISABLED` | `Security/API-Fuzzing.gitlab-ci.yml` | API fuzzing |
| `DAST_API_DISABLED` | `Security/DAST-API.gitlab-ci.yml` | DAST API |

Checked in `variables:` at the top level, under `default:`, and per job, including the extended `{value:, description:}` form.

## Which values count, and why it is not just "truthy"

Every template gates on `if: $VAR == 'true' || $VAR == '1'` → `when: never`. That is a case-sensitive string comparison, so the rule mirrors it exactly:

- `"true"`, `"1"`, `1` → flagged.
- unquoted `true` / `True` / `TRUE` → flagged. These parse as YAML booleans and GitLab stringifies them to `"true"`, so they do disable the scan.
- quoted `"True"`, `"TRUE"`, `"yes"`, `"on"` → **not** flagged. They are strings, they do not equal `'true'`, and the scan keeps running. Reporting them as disabled would be wrong, even though they read as if they were.

That distinction is the one piece of this rule that is easy to get wrong, so it has its own tests on both sides.

## Why a new rule rather than extending GL008

GL008 needs a job to inspect. This failure mode has no job: the scan is contributed by an `include:`d template and the variable stops it from ever materialising. Nothing appears in the YAML that looks like a security job, so there is nothing for GL008's `allow_failure` check — or GL039's `|| true` check — to attach to. The pipeline is green, the dashboard is empty, and the diff that caused it is one line.

## Deliberate exclusions

- `CODE_QUALITY_DISABLED` gates `Jobs/Code-Quality.gitlab-ci.yml` identically, but Code Quality is not a security scan.
- `LICENSE_SCANNING_DISABLED` / `LICENSE_MANAGEMENT_DISABLED` — every License-Scanning and License-Management template now 404s; the variables gate nothing.
- `SAST_EXCLUDED_ANALYZERS` / `DS_EXCLUDED_ANALYZERS` disable *individual* analyzers through the same mechanism, but take analyzer-name lists rather than a boolean. Different check, left for a follow-up.
- Only `variables:` blocks are inspected. A job carrying `rules: - if: $SECRET_DETECTION_DISABLED` is *defining* the switch, not flipping it.

## How to test

```yaml
include:
  - template: Jobs/SAST.gitlab-ci.yml

variables:
  SAST_DISABLED: "true"           # warn
  SECRET_DETECTION_DISABLED: "1"  # warn
  CONTAINER_SCANNING_DISABLED: "True"  # silent — string, does not match the gate

build:
  stage: build
  image: alpine:3.19.1
  variables:
    DEPENDENCY_SCANNING_DISABLED: true  # warn — YAML boolean
  script: [make]
```

14 test functions in `rules/gl082_test.go` cover every variable, the value semantics on both sides, the three placements, job attribution, the extended variable form, and near-miss variable names (`DEPLOY_DISABLED`, `SAST_EXCLUDED_PATHS`).

`go test ./...`, `golangci-lint run ./...` and `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml` all pass.

## False-positive scan

Scanned 199 real root `.gitlab-ci.yml` files from the most-starred public GitLab projects: **3 findings in 1 file, all true positives.** That file sets, under a `# GitLab security templates` comment, `DEPENDENCY_SCANNING_DISABLED`, `SAST_DISABLED` and `CONTAINER_SCANNING_DISABLED` to `"true"` — exactly the case this rule exists for.

Two further files contain these variable names and are correctly silent: both are GitLab's own repositories implementing the gate in their own jobs (`rules: - if: $SECRET_DETECTION_DISABLED`) rather than setting it. A third matched `DS_DISABLED_RESOLUTION_JOBS`, an unrelated variable that the exact-key match does not confuse with a kill switch. In other words, every occurrence in the corpus was classified correctly in both directions.
