### PR TITLE
GL008: flag security scan jobs silenced by when:manual or a lone when:never rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -95,7 +95,7 @@ Gates bypassed, runners untrusted, or downstream pipelines outside access contro
 
 | ID | Severity | Description |
 |----|----------|-------------|
-| [GL008](rules/GL008.md) | `warn`  | `allow_failure: true` on a GitLab security scan job |
+| [GL008](rules/GL008.md) | `warn`  | GitLab security scan job silenced — `allow_failure: true`, `when: manual`, or a lone `rules: [when: never]` |
 | [GL012](rules/GL012.md) | `warn`  | `when: always` on a deploy/release job bypasses upstream quality gates |
 | [GL013](rules/GL013.md) | `warn`  | Production deploy job has no `rules:` or `only:` branch restriction |
 | [GL019](rules/GL019.md) | `warn`  | Deploy/publish job has no `resource_group:` — concurrent runs risk race conditions or partial deploys |

--- a/docs/rules/GL008.md
+++ b/docs/rules/GL008.md
@@ -1,11 +1,20 @@
-# GL008 — `allow_failure: true` on security scan jobs
+# GL008 — Security scan job silenced
 
 **Severity:** warn  
 **OWASP:** [CICD-SEC-1 – Insufficient Flow Control Mechanisms](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-01-Insufficient-Flow-Control-Mechanisms)
 
 ## What glsec checks
 
-glsec flags any of GitLab's predefined security scan jobs that have `allow_failure: true` set:
+glsec flags any of GitLab's predefined security scan jobs that has been silenced — its failures ignored, or the job kept from running at all:
+
+| Form | Effect |
+|------|--------|
+| `allow_failure: true` | The scan runs, but its failure does not block the pipeline |
+| `when: manual` (job has no `rules:`) | The scan never runs on its own |
+| `rules:` whose **only** entry is an unconditional `when: never` | The job is switched off in every context |
+| `rules:` whose **only** entry is an unconditional `when: manual` | The job never runs on its own |
+
+The job names, and the templates that define them:
 
 | Job name | Template |
 |----------|----------|
@@ -22,6 +31,25 @@ glsec flags any of GitLab's predefined security scan jobs that have `allow_failu
 
 The `allow_failure: {exit_codes: [...]}` form (exit-code-specific) is not flagged — that is a deliberate choice, not a blanket suppression.
 
+### What is deliberately not flagged
+
+The `rules:` check is narrow, because most `when: never` entries on a scan job are legitimate:
+
+```yaml
+secret_detection:
+  rules:
+    - if: $SECRET_DETECTION_DISABLED   # the template's own kill switch — keeping
+      when: never                      # it in an override is idiomatic
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+
+sast:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - when: never                      # "otherwise don't run" — scoping, not disabling
+```
+
+A *conditional* `when: never` scopes the job; only a lone, unconditional entry disables it outright. The dangerous half of the first example — actually setting `SECRET_DETECTION_DISABLED` — is [GL082](GL082.md)'s job.
+
 ## Trigger example
 
 ```yaml
@@ -30,6 +58,13 @@ include:
 
 sast:
   allow_failure: true   # scan failures are silently ignored
+
+secret_detection:
+  when: manual          # never runs unless somebody clicks it
+
+dast:
+  rules:
+    - when: never       # switched off outright
 ```
 
 ## Safe alternative

--- a/rules/gl008.go
+++ b/rules/gl008.go
@@ -37,26 +37,119 @@ func (r *gl008) Check(doc *yaml.Node, file string) []finding.Finding {
 		if !securityScanJobs[name.Value] {
 			return
 		}
-		af := parser.FindKey(job, "allow_failure")
-		if af == nil {
-			return
-		}
-		// Only flag scalar `true`; allow_failure: {exit_codes: [...]} is intentional.
-		if af.Kind == yaml.ScalarNode && af.Value == "true" {
-			findings = append(findings, finding.Finding{
-				RuleID:   "GL008",
-				Severity: finding.Warn,
-				Job:      name.Value,
-				Message: fmt.Sprintf(
-					"security scan job %q has allow_failure: true — scan failures are silently ignored and security results may not be ingested by GitLab",
-					name.Value,
-				),
-				File: file,
-				Line: af.Line,
-				Col:  af.Column,
-			})
-		}
+		findings = append(findings, r.checkAllowFailure(name, job, file)...)
+		findings = append(findings, r.checkNeverRuns(name, job, file)...)
 	})
 
 	return findings
+}
+
+func (r *gl008) checkAllowFailure(name, job *yaml.Node, file string) []finding.Finding {
+	af := parser.FindKey(job, "allow_failure")
+	if af == nil {
+		return nil
+	}
+	// Only flag scalar `true`; allow_failure: {exit_codes: [...]} is intentional.
+	if af.Kind != yaml.ScalarNode || af.Value != "true" {
+		return nil
+	}
+	return []finding.Finding{{
+		RuleID:   "GL008",
+		Severity: finding.Warn,
+		Job:      name.Value,
+		Message: fmt.Sprintf(
+			"security scan job %q has allow_failure: true — scan failures are silently ignored and security results may not be ingested by GitLab",
+			name.Value,
+		),
+		File: file,
+		Line: af.Line,
+		Col:  af.Column,
+	}}
+}
+
+// checkNeverRuns covers the two ways a scan job is silenced without touching
+// allow_failure: made manual, or given a rule that unconditionally prevents it
+// from running. Both are deliberately narrow — see whenNeverRuns.
+func (r *gl008) checkNeverRuns(name, job *yaml.Node, file string) []finding.Finding {
+	rulesNode := parser.FindKey(job, "rules")
+
+	if rulesNode == nil {
+		w := parser.FindKey(job, "when")
+		if w == nil || w.Kind != yaml.ScalarNode || w.Value != "manual" {
+			return nil
+		}
+		return []finding.Finding{{
+			RuleID:   "GL008",
+			Severity: finding.Warn,
+			Job:      name.Value,
+			Message: fmt.Sprintf(
+				"security scan job %q is when: manual — it never runs on its own, so a green pipeline says nothing about whether the code was scanned",
+				name.Value,
+			),
+			File: file,
+			Line: w.Line,
+			Col:  w.Column,
+		}}
+	}
+
+	entry := soleUnconditionalRule(rulesNode)
+	if entry == nil {
+		return nil
+	}
+	w := parser.FindKey(entry, "when")
+	if w == nil || w.Kind != yaml.ScalarNode {
+		return nil
+	}
+
+	var msg string
+	switch w.Value {
+	case "never":
+		msg = fmt.Sprintf(
+			"security scan job %q has rules: [when: never] as its only rule — the job is switched off in every context",
+			name.Value,
+		)
+	case "manual":
+		msg = fmt.Sprintf(
+			"security scan job %q has rules: [when: manual] as its only rule — it never runs on its own, so a green pipeline says nothing about whether the code was scanned",
+			name.Value,
+		)
+	default:
+		return nil
+	}
+
+	return []finding.Finding{{
+		RuleID:   "GL008",
+		Severity: finding.Warn,
+		Job:      name.Value,
+		Message:  msg,
+		File:     file,
+		Line:     w.Line,
+		Col:      w.Column,
+	}}
+}
+
+// soleUnconditionalRule returns the single rules: entry of a job when that
+// entry carries no condition, and nil otherwise.
+//
+// The narrowness is the point. A conditional `when: never` is how GitLab's own
+// templates express their kill switch (`- if: $SAST_DISABLED / when: never`),
+// and overriding a scan job's rules while keeping that entry is idiomatic — the
+// dangerous half of it, actually setting the variable, is GL082's job. An
+// unconditional `when: never` trailing a list of conditional rules is the
+// equally idiomatic "otherwise don't run" catch-all. Only a lone, unconditional
+// entry disables the job outright in every context.
+func soleUnconditionalRule(rulesNode *yaml.Node) *yaml.Node {
+	if rulesNode.Kind != yaml.SequenceNode || len(rulesNode.Content) != 1 {
+		return nil
+	}
+	entry := rulesNode.Content[0]
+	if entry.Kind != yaml.MappingNode {
+		return nil
+	}
+	for _, cond := range []string{"if", "changes", "exists"} {
+		if parser.FindKey(entry, cond) != nil {
+			return nil
+		}
+	}
+	return entry
 }

--- a/rules/gl008_test.go
+++ b/rules/gl008_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/glsec/glsec/internal/finding"
@@ -122,5 +123,119 @@ sast:
 	}
 	if f[0].Line == 0 {
 		t.Error("expected non-zero line number")
+	}
+}
+
+func TestGL008_WhenManual_Warn(t *testing.T) {
+	f := findings008(t, `
+sast:
+  when: manual
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for when: manual, got %d", len(f))
+	}
+	if f[0].Severity != finding.Warn {
+		t.Errorf("expected Warn severity, got %s", f[0].Severity)
+	}
+	if f[0].Job != "sast" {
+		t.Errorf("expected job attribution %q, got %q", "sast", f[0].Job)
+	}
+}
+
+func TestGL008_WhenOnSuccess_NoFinding(t *testing.T) {
+	f := findings008(t, `
+sast:
+  when: on_success
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for when: on_success, got %d", len(f))
+	}
+}
+
+func TestGL008_SoleUnconditionalNeverRule_Warn(t *testing.T) {
+	f := findings008(t, `
+secret_detection:
+  rules:
+    - when: never
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for rules: [when: never], got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "every context") {
+		t.Errorf("unexpected message: %q", f[0].Message)
+	}
+}
+
+func TestGL008_SoleUnconditionalManualRule_Warn(t *testing.T) {
+	f := findings008(t, `
+dast:
+  rules:
+    - when: manual
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for rules: [when: manual], got %d", len(f))
+	}
+}
+
+// The kill-switch guard GitLab's own templates ship is conditional, and keeping
+// it in an override is idiomatic. Flagging it would be a false positive; the
+// dangerous half — setting the variable — is GL082's job.
+func TestGL008_ConditionalNeverRule_NoFinding(t *testing.T) {
+	f := findings008(t, `
+secret_detection:
+  rules:
+    - if: $SECRET_DETECTION_DISABLED
+      when: never
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a conditional when: never, got %d", len(f))
+	}
+}
+
+// "Run on merge requests, otherwise don't" is scoping, not disabling.
+func TestGL008_TrailingNeverCatchAll_NoFinding(t *testing.T) {
+	f := findings008(t, `
+sast:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - when: never
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a trailing catch-all, got %d", len(f))
+	}
+}
+
+func TestGL008_SoleRuleWithChangesOrExists_NoFinding(t *testing.T) {
+	for _, cond := range []string{
+		"changes: [\"**/*.go\"]",
+		"exists: [\"go.mod\"]",
+	} {
+		f := findings008(t, "sast:\n  rules:\n    - "+cond+"\n      when: never\n")
+		if len(f) != 0 {
+			t.Errorf("expected no finding for a rule gated on %s, got %d", cond, len(f))
+		}
+	}
+}
+
+func TestGL008_NonSecurityJobManual_NoFinding(t *testing.T) {
+	f := findings008(t, `
+deploy:
+  when: manual
+  rules:
+    - when: never
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for a non-security job, got %d", len(f))
+	}
+}
+
+func TestGL008_AllowFailureAndManual_BothReported(t *testing.T) {
+	f := findings008(t, `
+sast:
+  allow_failure: true
+  when: manual
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected both findings, got %d", len(f))
 	}
 }


### PR DESCRIPTION
Closes #450.

## What changed

GL008 covered one way of silencing a security scan job. It now covers three:

| Form | Effect |
|------|--------|
| `allow_failure: true` (unchanged) | The scan runs, its failure does not block |
| `when: manual`, on a job with no `rules:` | The scan never runs on its own |
| `rules:` whose **only** entry is an unconditional `when: never` | Switched off in every context |
| `rules:` whose **only** entry is an unconditional `when: manual` | Never runs on its own |

Same job-name set, same severity, distinct message per form. The `allow_failure: {exit_codes: [...]}` exemption is untouched. `Check` now delegates to `checkAllowFailure` and `checkNeverRuns` instead of growing a third level of nesting inside the `EachJob` callback.

## The `rules:` check is narrower than the issue proposed — deliberately

#450 suggested flagging *any* `rules:` entry with `when: never`/`manual`, with a narrower fallback if that proved noisy. It does prove noisy, and the corpus says so concretely rather than hypothetically. Two patterns dominate real overrides of scan jobs:

```yaml
secret_detection:
  rules:
    - if: $SECRET_DETECTION_DISABLED   # the template's own kill switch, preserved
      when: never                      # in the override — idiomatic
    - if: $CI_PIPELINE_SOURCE == "merge_request_event"

container_scanning:
  rules:
    - if: $CI_COMMIT_BRANCH == "main"
      when: always
    - when: never                      # "otherwise don't run" — scoping
```

Both are correct pipeline authoring. Flagging either would train people to ignore GL008. So the rule only fires on a **lone, unconditional** entry — `rules:` with exactly one item that has no `if:`, `changes:` or `exists:` and a `when:` of `never` or `manual`. That is unambiguous: the job cannot run in any context.

The conditional kill-switch case is not left uncovered — the dangerous half of it, actually setting `SECRET_DETECTION_DISABLED`, is [GL082](https://github.com/glsec/glsec/blob/main/docs/rules/GL082.md), merged in #453.

## How to test

```yaml
include:
  - template: Security/SAST.gitlab-ci.yml

sast:
  when: manual          # warn — never runs on its own

secret_detection:
  rules:
    - when: never       # warn — switched off outright

dast:
  rules:
    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
    - when: never       # silent — trailing catch-all, this is scoping
```

9 new test functions in `rules/gl008_test.go`, covering each flagged form, job attribution, both non-flagged `rules:` shapes, a sole rule gated on `changes:`/`exists:`, a non-security job, and `allow_failure` plus `when: manual` on one job reporting both.

`go test ./...`, `golangci-lint run ./...` and `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml` all pass.

## False-positive scan

199 real root `.gitlab-ci.yml` files from the most-starred public GitLab projects, this branch against `main`: **1 GL008 finding on both sides, identical — no new findings, no regressions.**

The corpus does exercise the new code paths, which is what makes that number meaningful:

- 11 files override at least one managed security scan job.
- 5 `when: never`/`manual` entries are conditional — the idiomatic kill-switch and scoping patterns above. Not flagged, by design.
- 1 is unconditional but sits third in a 3-entry list (`main` or release tag → always, otherwise never). Not flagged, by design — and it is the exact case that separates "lone entry" from "any entry". Had the rule shipped as originally proposed, this file would have been a false positive.
- 0 jobs use job-level `when: manual`.

So the new checks looked at every relevant shape in the corpus and correctly stayed quiet on all of them. Positive coverage comes from the unit tests.
