### PR TITLE
GL002: treat CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME as user-controlled

### DIFF
--- a/docs/rules/GL002.md
+++ b/docs/rules/GL002.md
@@ -24,8 +24,11 @@ Several GitLab CI predefined variables are populated from user-supplied data: br
 | `CI_COMMIT_AUTHOR` | Commit author `Name <email>`, set verbatim from the commit |
 | `GITLAB_USER_NAME` | Account display name, free-text and user-editable |
 | `GITLAB_USER_EMAIL` | Account email, user-editable |
+| `CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME` | Source branch of an external pull request, named by its author |
 
 In a fork merge-request pipeline the identity variables (`CI_COMMIT_AUTHOR`, `GITLAB_USER_NAME`, `GITLAB_USER_EMAIL`) reflect the external MR author and are attacker-controlled. `GITLAB_USER_LOGIN` is intentionally **not** flagged — its username charset excludes shell metacharacters.
+
+`CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME` is set only in [external pull request pipelines](https://docs.gitlab.com/ci/ci_cd_for_external_repos/), where a project mirrors an external repository. The rest of that family is not flagged: the target branch belongs to the mirroring project rather than the contributor, the `_SHA` variants are hex, and `_IID` is numeric.
 
 ## Trigger example
 

--- a/docs/rules/GL046.md
+++ b/docs/rules/GL046.md
@@ -26,6 +26,7 @@ Any `cache: key:` value (at job level or under `default:`) that contains a user-
 | `$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` | MR author |
 | `$CI_MERGE_REQUEST_TITLE` | MR author |
 | `$CI_PIPELINE_NAME` | API caller |
+| `$CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME` | External pull request author |
 
 ## Trigger examples
 

--- a/rules/gl002.go
+++ b/rules/gl002.go
@@ -30,6 +30,11 @@ var userControlledVars = []string{
 	"CI_MERGE_REQUEST_TITLE",
 	"CI_MERGE_REQUEST_DESCRIPTION",
 	"CI_PIPELINE_NAME",
+	// Set only in external pull request pipelines (a project mirroring an
+	// external repository). The source branch lives in the contributor's fork
+	// on the external host, so the pull request author names it — the same
+	// trust level as CI_MERGE_REQUEST_SOURCE_BRANCH_NAME, and not slugified.
+	"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME",
 	// Identity variables controlled directly by an untrusted contributor via
 	// the commit or their own account profile. In fork MR pipelines these
 	// reflect the external MR author. CI_COMMIT_AUTHOR is "Name <email>" taken

--- a/rules/gl002_test.go
+++ b/rules/gl002_test.go
@@ -305,3 +305,43 @@ build:
 		t.Fatalf("expected 1 finding for unquoted use, got %d", len(f))
 	}
 }
+
+func TestGL002_ExternalPullRequestSourceBranch_Warn(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo building $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME, got %d", len(f))
+	}
+}
+
+// The rest of the external-pull-request family is not attacker-controlled in a
+// way that reaches a shell: the target branch belongs to the mirroring project,
+// the SHAs are hex, and the IID is numeric.
+func TestGL002_OtherExternalPullRequestVars_NoFinding(t *testing.T) {
+	for _, v := range []string{
+		"CI_EXTERNAL_PULL_REQUEST_IID",
+		"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA",
+		"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME",
+		"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA",
+	} {
+		f := findings002(t, "build:\n  script:\n    - echo $"+v+"\n")
+		if len(f) != 0 {
+			t.Errorf("expected no finding for %s, got %d", v, len(f))
+		}
+	}
+}
+
+// The \b anchor must not let the source-branch entry match its own SHA sibling.
+func TestGL002_ExternalPullRequestPrefixNotMatched(t *testing.T) {
+	f := findings002(t, `
+build:
+  script:
+    - echo $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA
+`)
+	if len(f) != 0 {
+		t.Errorf("expected no finding for the SHA variant, got %d", len(f))
+	}
+}


### PR DESCRIPTION
Closes #451.

## What changed

`CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME` joins `userControlledVars` in `rules/gl002.go`.

It is set only in [external pull request pipelines](https://docs.gitlab.com/ci/ci_cd_for_external_repos/), where a GitLab project mirrors an external repository. The source branch lives in the contributor's fork on the external host, so the pull request author names it — the same trust level as `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`, which the list already covers — and unlike `CI_COMMIT_REF_SLUG` it is not slugified, so it can carry shell metacharacters.

The rest of the family stays out, for reasons that differ per variable: `_TARGET_BRANCH_NAME` is a branch in the mirroring project rather than the contributor's, the two `_SHA` variants are hex, and `_IID` is numeric. There are tests asserting each of those stays silent.

## Knock-on effect, intended

`userControlledVars` is shared: `rules/gl046.go` appends `CI_COMMIT_REF_SLUG` to it for cache keys, and `rules/gl052.go` does the same for `environment:name:`. So GL046 and GL052 pick up the variable too, which is right — an attacker-named branch in a cache key is cache poisoning and in an environment name is protected-environment spoofing, regardless of whether the pull request arrived through GitLab or a mirror. Both docs' variable tables are updated to match; GL052's doc has no such table.

## Correction to the issue text

The reproduction in #451 was written with the variable quoted:

```yaml
- echo "building $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME"
```

That produces no finding — but neither does the `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` version the issue offers as the contrast, because GL002 flags **unquoted** expansions only. Quoting is the fix the rule asks for, so a quoted use is correct code. The gap the issue describes is real, it just needs the unquoted form to show:

```yaml
build:
  script:
    - echo building $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME   # warn, after this change
    - echo "building $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME" # silent, quoted — correct code
```

## How to test

```yaml
build:
  script:
    - echo building $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
  cache:
    key: $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
  environment:
    name: review/$CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
```

Before: nothing from GL002, GL046 or GL052. After: one finding from each.

3 new test functions in `rules/gl002_test.go` — the positive case, the four excluded family members, and a check that the `\b` anchor does not let the entry match its own `_SHA` sibling.

`go test ./...`, `golangci-lint run ./...` and `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml` all pass.

## False-positive scan

199 real root `.gitlab-ci.yml` files from the most-starred public GitLab projects, this branch against `main`, comparing **all** findings rather than just GL002 so the GL046/GL052 knock-on is included: **2520 findings on both sides, identical.**

Honest caveat: none of those files mentions `CI_EXTERNAL_PULL_REQUEST` at all, which is unsurprising — external pull request pipelines only exist in projects mirroring GitHub, and the corpus is GitLab-native. The scan therefore shows the change is inert on ordinary pipelines; it does not exercise the new entry. That coverage is in the unit tests.
