### PR TITLE
chore: bump version refs to 1.14.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glsec",
   "description": "Static security scanner for GitLab CI/CD pipelines",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "author": {
     "name": "glsec",
     "url": "https://github.com/glsec/glsec"

--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ Every release is signed and carries build provenance, so you can confirm an arti
 **Release binaries** carry a SLSA provenance attestation. Verify a downloaded archive with the [GitHub CLI](https://cli.github.com/):
 
 ```sh
-gh attestation verify glsec_1.13.0_linux_amd64.tar.gz --owner glsec
+gh attestation verify glsec_1.14.0_linux_amd64.tar.gz --owner glsec
 ```
 
 **The container image** is signed with [cosign](https://github.com/sigstore/cosign) and carries provenance plus an SBOM attestation:
 
 ```sh
-cosign verify ghcr.io/glsec/glsec:1.13.0 \
+cosign verify ghcr.io/glsec/glsec:1.14.0 \
   --certificate-identity-regexp 'https://github.com/glsec/glsec/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # list everything attached to the image (signature, provenance, SBOM)
-cosign tree ghcr.io/glsec/glsec:1.13.0
+cosign tree ghcr.io/glsec/glsec:1.14.0
 ```
 
 The two `--certificate-*` flags are what bind the signature to this repository's GitHub Actions workflow. Without them `cosign verify` accepts a signature from any identity, which defeats the point.
@@ -79,7 +79,7 @@ The two `--certificate-*` flags are what bind the signature to this repository's
 **Checksums** are published as `checksums.txt` next to the archives:
 
 ```sh
-curl -sSLO https://github.com/glsec/glsec/releases/download/v1.13.0/checksums.txt
+curl -sSLO https://github.com/glsec/glsec/releases/download/v1.14.0/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
 ```
 
@@ -317,7 +317,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.13.0
+    rev: v1.14.0
     hooks:
       - id: glsec
 ```
@@ -371,7 +371,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.9
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.14
 
 stages:
   - test
@@ -381,7 +381,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.9
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.14
 
 stages:
   - test
@@ -408,13 +408,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.13.0
+    name: ghcr.io/glsec/glsec:1.14.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.13.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.14.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -422,7 +422,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.13.0"
+  GLSEC_VERSION: "1.14.0"
 
 glsec:
   stage: test
@@ -444,7 +444,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.13.0
+    name: ghcr.io/glsec/glsec:1.14.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -463,7 +463,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.13.0
+    name: ghcr.io/glsec/glsec:1.14.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true

--- a/bin/glsec
+++ b/bin/glsec
@@ -12,7 +12,7 @@
 # Supports linux + darwin only. VERSION is kept in lockstep with the release.
 set -eu
 
-VERSION="1.13.0"
+VERSION="1.14.0"
 REPO="glsec/glsec"
 
 hint() {


### PR DESCRIPTION
Version bump for the 1.14.0 release. No behaviour change.

## What is in 1.14.0

| Change | PR |
|---|---|
| **New rule GL082** — managed security scan switched off by its `*_DISABLED` CI/CD variable | #453 |
| GL016 extended — `git://` transport and git fetches over plain HTTP | #447 |
| GL008 extended — scan jobs silenced by `when: manual` or a lone `rules: [when: never]` | #454 |
| GL002 extended — `CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME`, which also reaches GL046 and GL052 | #455 |
| GL064 — CI Catalog component list refreshed, corpus self-consistency test added | #448 |
| CI — zizmor pinned to 1.29.0 | #452 |

82 rules, up from 81.

## Bumped

- `.claude-plugin/plugin.json` — the source of truth for the "Check version pins agree" job
- `bin/glsec` — `VERSION=`, which selects the release asset the wrapper downloads
- `README.md` — 10 references (attestation, cosign verify/tree, checksums URL, pre-commit `rev:`, image tags, `GLSEC_VERSION`, the pin-not-`:latest` note)

Ran the pin-check job's own script locally: all pins agree on 1.14.0.

## Also fixed: stale component references

The two `gitlab.com/glsec-io/glsec/...@v1.0.9` examples were five component releases behind — the catalog is at `v1.0.14`, confirmed through the `ciCatalogResource` GraphQL API. Anyone copying those snippets landed on a component that defaults to a much older glsec image. They now point at `v1.0.14`.

Note that the component version is deliberately excluded from the pin-check job (it is released separately, on its own `v1.0.N` scheme), which is why this drift went unnoticed — nothing was watching it. It will move to `v1.0.15` in a follow-up once the component itself is bumped and released for glsec 1.14.0.
