### PR TITLE
docs: point component examples at v1.0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.14
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.15
 
 stages:
   - test
@@ -381,7 +381,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.14
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.15
 
 stages:
   - test


### PR DESCRIPTION
Follow-up to the 1.14.0 release.

The GitLab CI/CD Catalog component has been bumped and released as [`v1.0.15`](https://gitlab.com/glsec-io/glsec/-/releases/v1.0.15), which defaults to the `ghcr.io/glsec/glsec:1.14.0` image. The two component snippets in the README now point at it.

#456 deliberately set these to `v1.0.14` — the version that was actually released at the time — rather than referencing a tag that did not exist yet. This closes that gap now that it does.

Verified through the catalog API: `ciCatalogResource(fullPath: "glsec-io/glsec")` lists `v1.0.15`, released 2026-08-03T12:42:33Z.