### PR TITLE
feat(GL022): flag ad-hoc dependency installs (npm/yarn/pnpm/bundle add)

### DIFF
--- a/docs/rules/GL022.md
+++ b/docs/rules/GL022.md
@@ -5,11 +5,13 @@
 
 ## What glsec checks
 
-glsec flags two categories of problematic package manager usage in CI scripts:
+glsec flags three categories of problematic package manager usage in CI scripts:
 
 **1. Install without a pinned version** — pulls whatever is latest at the time the job runs, making the pipeline non-reproducible. A compromised or updated package can silently change pipeline behaviour.
 
-**2. Explicit update-to-latest commands** — commands like `npm update`, `composer update`, or `pip install --upgrade` are designed for local development workflows and are almost never appropriate in CI.
+**2. Ad-hoc dependency installs** — a named package installed on top of the manifest (`npm install lodash`, `yarn add left-pad`, `pnpm add chalk`, `bundle add rails`) is in no lockfile, so the registry decides the version on every run and the dependency never shows up in a lockfile diff. `yarn add` and `bundle add` additionally rewrite the manifest in place, so a later strict install works from modified input.
+
+**3. Explicit update-to-latest commands** — commands like `npm update`, `composer update`, or `pip install --upgrade` are designed for local development workflows and are almost never appropriate in CI.
 
 ## Detected package managers
 
@@ -18,7 +20,11 @@ glsec flags two categories of problematic package manager usage in CI scripts:
 | Package manager | Unpinned (flagged) | Pinned (safe) |
 |----------------|-------------------|---------------|
 | pip | `pip install requests` | `pip install requests==2.31.0` |
-| npm (global) | `npm install -g typescript` | `npm install -g typescript@5.4.5` |
+| npm (global) | `npm install -g typescript` (also `npm i -g`, `npm add -g`) | `npm install -g typescript@5.4.5` |
+| npm (ad-hoc) | `npm install lodash` (also `npm i`, `npm add`) | `npm install lodash@4.17.21` |
+| yarn (ad-hoc) | `yarn add left-pad` | `yarn add left-pad@1.3.0` |
+| pnpm (ad-hoc) | `pnpm add chalk` | `pnpm add chalk@5.3.0` |
+| bundler (ad-hoc) | `bundle add rails` | `bundle add rails -v 7.1.3` |
 | apt-get / apt | `apt-get install jq` | `apt-get install jq=1.6-2` |
 | apk | `apk add curl` | `apk add curl=8.5.0-r0` |
 | gem | `gem install bundler` | `gem install bundler -v 2.5.6` |
@@ -39,6 +45,9 @@ glsec flags two categories of problematic package manager usage in CI scripts:
 build:
   script:
     - pip install ansible              # unpinned
+    - npm install lodash               # ad-hoc dependency, no lockfile entry
+    - yarn add left-pad@latest         # dist-tag, not a version
+    - bundle add rails                 # ad-hoc gem
     - npm install -g @angular/cli      # unpinned scoped package
     - apt-get install -y jq            # unpinned
     - composer require guzzlehttp/guzzle  # unpinned
@@ -53,6 +62,9 @@ build:
 build:
   script:
     - pip install ansible==9.2.0
+    - npm install lodash@4.17.21
+    - yarn add left-pad@1.3.0
+    - bundle add rails -v 7.1.3
     - npm install -g @angular/cli@17.3.6
     - apt-get install -y jq=1.6-2
     - apk add --no-cache curl=8.5.0-r0
@@ -64,7 +76,10 @@ build:
 ## Notes
 
 - `pip install -r requirements.txt` and `pip install .` are not flagged — use of a requirements file or local package install is expected.
-- `npm install` without `-g` / `--global` is not flagged — it installs from `package.json` (see GL023 for lockfile concerns).
+- Bare `npm install` (no package argument) is not flagged here — it installs from `package.json`; see GL023 for the lockfile concern. Only an explicitly named package is treated as an ad-hoc install.
+- Dist-tags (`@latest`, `@next`) are not versions and are flagged.
+- Local and workspace targets (`npm install ./pkg`, `yarn add file:../shared`, `pnpm add link:../shared`, `pnpm add workspace:@app/shared`) are not flagged — nothing is fetched from a registry.
+- Package names that appear inside a quoted string (e.g. an error message that reads `echo "run npm install locally"`) are not flagged. As a consequence, a quoted package argument such as `yarn add "left-pad@1.3.0"` is not inspected either.
 - `npm install -g @scope/pkg` (scoped package without version) is flagged; `@scope/pkg@version` is safe.
 - `composer install` (reads `composer.lock`) is not flagged — only `composer require` (adds a new package) and `composer update` (updates to latest) are.
 - `go install` of a remote module without `@version` (or with `@latest`) is flagged; `@v1.2.3` is safe. Local builds (`go install`, `go install ./cmd/...`) are not flagged.

--- a/rules/gl022.go
+++ b/rules/gl022.go
@@ -21,7 +21,17 @@ type pmInstallCheck struct {
 	trigger *regexp.Regexp // matches the install command
 	pinned  *regexp.Regexp // if present, version is pinned → no finding
 	skip    *regexp.Regexp // if present, skip the line entirely (e.g. -r file)
+	// mask matches the check against a quote-masked copy of the line, so that
+	// package names mentioned in prose (`echo "run npm install locally"`) are
+	// not read as install commands.
+	mask bool
 }
+
+// adhocFirstArg matches the first non-flag argument of an install command,
+// i.e. an explicitly named package. The argument must be unquoted: after
+// masking, a quoted argument carries no version information, so flagging it
+// would report `yarn add "pkg@1.2.3"` as unpinned.
+const adhocFirstArg = `\s+(?:-{1,2}[\w=@./:-]+\s+)*[^-\s"']`
 
 // pmUpdateCheck describes explicit update-to-latest commands that are always wrong in CI.
 type pmUpdateCheck struct {
@@ -39,9 +49,41 @@ var (
 		},
 		{
 			manager: "npm (global)",
-			trigger: regexp.MustCompile(`\bnpm\s+install\b.*(?:-g\b|--global\b)`),
+			trigger: regexp.MustCompile(`\bnpm\s+(?:install|i|add)\b.*(?:-g\b|--global\b)`),
 			pinned:  regexp.MustCompile(`@\d`),
 			skip:    nil,
+		},
+		{
+			// A named package installed on top of the manifest — the dependency
+			// is in no package.json and no lockfile, so the registry decides the
+			// version on every run. Bare `npm install` is GL023's territory.
+			manager: "npm (ad-hoc)",
+			trigger: regexp.MustCompile(`\bnpm\s+(?:install|i|add)` + adhocFirstArg),
+			pinned:  regexp.MustCompile(`@\d`),
+			skip:    regexp.MustCompile(`-g\b|--global\b|\s\.{1,2}/|\sfile:|\s\.\s*(?:$|&&|\|)`),
+			mask:    true,
+		},
+		{
+			manager: "yarn (ad-hoc)",
+			trigger: regexp.MustCompile(`\byarn\s+add` + adhocFirstArg),
+			pinned:  regexp.MustCompile(`@\d`),
+			skip:    regexp.MustCompile(`\s\.{1,2}/|\sfile:|\slink:`),
+			mask:    true,
+		},
+		{
+			manager: "pnpm (ad-hoc)",
+			trigger: regexp.MustCompile(`\bpnpm\s+add` + adhocFirstArg),
+			pinned:  regexp.MustCompile(`@\d`),
+			skip:    regexp.MustCompile(`\s\.{1,2}/|\sfile:|\slink:|\sworkspace:`),
+			mask:    true,
+		},
+		{
+			manager: "bundler (ad-hoc)",
+			trigger: regexp.MustCompile(`\bbundle\s+add` + adhocFirstArg),
+			// Accepts a quoted constraint too: --version '~> 7.1'.
+			pinned: regexp.MustCompile(`(?:-v|--version)\s+["']?[~^><=\s]*\d`),
+			skip:   nil,
+			mask:   true,
 		},
 		{
 			manager: "apt-get",
@@ -151,7 +193,15 @@ func checkPMLine(line, file string, lineNum, col int) *finding.Finding {
 
 	// Install without version pin.
 	for _, ic := range pmInstallChecks {
-		if !ic.trigger.MatchString(line) {
+		// Only the trigger runs against the masked copy: masking exists to stop
+		// prose inside a quoted string from reading as a command. The pin check
+		// stays on the raw line so that a quoted version constraint
+		// (`bundle add rails --version '~> 7.1'`) still counts as pinned.
+		probe := line
+		if ic.mask {
+			probe = maskShellQuotes(line)
+		}
+		if !ic.trigger.MatchString(probe) {
 			continue
 		}
 		if ic.skip != nil && ic.skip.MatchString(line) {

--- a/rules/gl022_test.go
+++ b/rules/gl022_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/glsec/glsec/internal/finding"
@@ -530,4 +531,118 @@ api:
 	if len(f) != 0 {
 		t.Errorf("composer install reads lockfile — expected no finding, got %d", len(f))
 	}
+}
+
+// --- ad-hoc dependency installs (issue #459) ---
+
+func TestGL022_AdhocInstalls(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"npm install pkg", "npm install lodash"},
+		{"npm i pkg", "npm i lodash"},
+		{"npm add pkg", "npm add lodash"},
+		{"yarn add", "yarn add left-pad"},
+		{"pnpm add", "pnpm add chalk"},
+		{"bundle add", "bundle add rails"},
+		{"npm install dist-tag", "npm install lodash@latest"},
+		{"yarn add dist-tag", "yarn add pkg@next"},
+		{"npm install with flags", "npm install --no-save lodash"},
+		{"bundle add in a compound command", `'[[ ! -f "Gemfile" ]] && bundle init && bundle add gitlab-dangerfiles'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := findings022(t, "build:\n  script:\n    - "+tc.line+"\n")
+			if len(f) != 1 {
+				t.Fatalf("expected 1 finding for %q, got %d", tc.line, len(f))
+			}
+			if f[0].Severity != finding.Warn {
+				t.Errorf("expected Warn, got %s", f[0].Severity)
+			}
+		})
+	}
+}
+
+func TestGL022_AdhocInstallsPinned_NoFinding(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"npm install pinned", "npm install lodash@4.17.21"},
+		{"npm i pinned", "npm i lodash@4.17.21"},
+		{"yarn add pinned", "yarn add left-pad@1.3.0"},
+		{"pnpm add pinned", "pnpm add chalk@5.3.0"},
+		{"pnpm add scoped pinned", "pnpm add @scope/pkg@1.0.0"},
+		{"bundle add pinned short flag", "bundle add rails -v 7.1.3"},
+		{"bundle add pinned long flag", "bundle add rails --version 7.1.3"},
+		{"bundle add pinned constraint", `bundle add rails --version '~> 7.1'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := findings022(t, "build:\n  script:\n    - "+tc.line+"\n")
+			if len(f) != 0 {
+				t.Errorf("expected no finding for %q, got %d (%s)", tc.line, len(f), first022Msg(f))
+			}
+		})
+	}
+}
+
+func TestGL022_AdhocSkips_NoFinding(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"bare npm install is GL023", "npm install"},
+		{"npm install flags only", "npm install --ignore-scripts"},
+		{"npm ci", "npm ci --cache .npm --prefer-offline"},
+		{"yarn install", "yarn install --frozen-lockfile"},
+		{"local path", "npm install ./packages/cli"},
+		{"file protocol", "yarn add file:../shared"},
+		{"link protocol", "pnpm add link:../shared"},
+		{"workspace protocol", "pnpm add workspace:@app/shared"},
+		{"variable package name", "npm install $PKG"},
+		{"package name in prose", `'diff a b || (echo "out of sync. Run npm install locally to fix it." && exit 1)'`},
+		{"quoted package argument", `yarn add "left-pad@1.3.0"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := findings022(t, "build:\n  script:\n    - "+tc.line+"\n")
+			if len(f) != 0 {
+				t.Errorf("expected no finding for %q, got %d (%s)", tc.line, len(f), first022Msg(f))
+			}
+		})
+	}
+}
+
+func TestGL022_NpmGlobalSpellings(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want int
+	}{
+		{"npm i -g unpinned", "npm i markdown-spellcheck -g", 1},
+		{"npm add -g unpinned", "npm add -g markdownlint", 1},
+		{"npm install -g unpinned", "npm install -g typescript", 1},
+		{"npm i -g pinned", "npm i markdown-spellcheck@1.3.1 -g", 0},
+		{"npm add --global pinned", "npm add --global markdownlint@0.34.0", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := findings022(t, "build:\n  script:\n    - "+tc.line+"\n")
+			if len(f) != tc.want {
+				t.Fatalf("expected %d finding(s) for %q, got %d (%s)", tc.want, tc.line, len(f), first022Msg(f))
+			}
+			if tc.want == 1 && !strings.Contains(f[0].Message, "npm (global)") {
+				t.Errorf("expected the global entry to report %q, got %q", tc.line, f[0].Message)
+			}
+		})
+	}
+}
+
+func first022Msg(f []finding.Finding) string {
+	if len(f) == 0 {
+		return ""
+	}
+	return f[0].Message
 }

--- a/testdata/fixtures/gl022-unpinned-packages.yml
+++ b/testdata/fixtures/gl022-unpinned-packages.yml
@@ -13,3 +13,8 @@ build:
     - dnf install -y nginx
     - zypper install -y curl
     - go install golang.org/x/tools/cmd/goimports@latest
+    - npm install lodash
+    - npm i markdown-spellcheck -g
+    - yarn add left-pad
+    - pnpm add chalk
+    - bundle add rails


### PR DESCRIPTION
Closes #459.

## What changed

**1. GL022 now flags ad-hoc dependency installs** — a named package installed on top of the manifest, which is in no lockfile:

```yaml
build:
  script:
    - npm install lodash    # also: npm i / npm add
    - yarn add left-pad
    - pnpm add chalk
    - bundle add rails
```

All four were silent before: GL022's npm entry was global-only, and there were no `yarn add` / `pnpm add` / `bundle add` entries. GL023 does not cover them either — it handles lockfile strictness of bare install commands and deliberately stops matching once a package argument follows.

**2. The existing `npm (global)` trigger hardcoded `install`**, so two spellings slipped through entirely. Widened to `(?:install|i|add)`:

```yaml
- npm i markdown-spellcheck -g     # was silent
- npm add -g markdownlint          # was silent
```

Both were found in real pipelines during the FP scan (fdroid/fdroid-website, gitlab-org/gitlab-environment-toolkit).

## Why

Same class GL022 already covers for pip/gem/cargo: the resolved version is whatever the registry serves at that moment, so the build is not reproducible and an upstream release lands in the pipeline with no review. `yarn add` and `bundle add` additionally rewrite the manifest in place, so a job that later runs a strict install is working from modified input.

## Implementation notes

- New entries are plain `pmInstallCheck` rows — no new rule ID, no new severity, `warn` like the rest of GL022.
- Added a `mask bool` field: the new entries match their **trigger** against `maskShellQuotes(line)` (already in `rules/gl002.go`, same package). Without it, prose inside a quoted string is read as a command — the one FP the corpus scan produced was `diff … || (echo "… Run npm install locally to fix it." && exit 1)`, where `locally` parses as a package name. Existing entries are untouched and still match the raw line.
- **Only the trigger is masked.** `skip` and `pinned` stay on the raw line, so a quoted version constraint such as `bundle add rails --version '~> 7.1'` still counts as pinned.
- The trigger requires the first non-flag argument to be **unquoted** (`[^-\s"']`). After masking, a quoted argument carries no version information, so inspecting it would report `yarn add "left-pad@1.3.0"` as unpinned. Conservative by design: quoted package arguments are skipped rather than guessed at.
- Local and workspace targets are skipped (`./pkg`, `file:`, `link:`, `workspace:`) — nothing is fetched from a registry. `$VAR` package names were already covered by the existing `pmVarPkg` skip.
- The bundler pin regex accepts a quoted constraint (`--version '~> 7.1'`) in addition to `-v 7.1.3`.
- No double-reporting: the global entry runs first, and the ad-hoc npm entry skips `-g` / `--global`.

## How to test

```
go test ./rules/ -run TestGL022
```

31 new subtests across four table-driven cases: flagged forms (incl. `@latest` / `@next` dist-tags and a compound `&&` command), pinned forms, skipped forms (bare `npm install`, `npm ci`, local paths, `$VAR`, prose-in-quotes, quoted argument), and the global spellings.

Manual check:

```
glsec testdata/fixtures/gl022-unpinned-packages.yml
```

## False-positive scan

199 root `.gitlab-ci.yml` harvested from the most-starred public projects on gitlab.com, `-no-cache`, before vs. after:

| | GL022 findings |
|---|---|
| `main` (8ac4918) | 403 |
| this branch | **407** |

Zero pre-existing findings changed or disappeared. The four new ones are all true positives:

| Project | Line | Finding |
|---|---|---|
| Bockiii/deemix-docker | 54 | `yarn add pkg@latest` |
| gitlab-org/gitlab-ui | 493 | `bundle init && bundle add gitlab-dangerfiles` |
| fdroid/fdroid-website | 226 | `npm i markdown-spellcheck -g` |
| gitlab-org/gitlab-environment-toolkit | 133 | `npm add -g markdownlint markdownlint-cli` |

An earlier prototype without quote masking produced 406 with one false positive; the masking is what brings it to zero.

## Also updated

- `docs/rules/GL022.md` — new manager rows, the ad-hoc category, dist-tag / local-target / quoted-argument notes, and the now-wrong note claiming non-global `npm install` is never flagged.
- `testdata/fixtures/gl022-unpinned-packages.yml` — five new trigger lines (schema-validated).

Local: `golangci-lint run ./...` clean, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml` ok, `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
