### PR TITLE
chore: bump version refs to 1.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glsec",
   "description": "Static security scanner for GitLab CI/CD pipelines",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "author": {
     "name": "glsec",
     "url": "https://github.com/glsec/glsec"

--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ Every release is signed and carries build provenance, so you can confirm an arti
 **Release binaries** carry a SLSA provenance attestation. Verify a downloaded archive with the [GitHub CLI](https://cli.github.com/):
 
 ```sh
-gh attestation verify glsec_1.14.0_linux_amd64.tar.gz --owner glsec
+gh attestation verify glsec_1.15.0_linux_amd64.tar.gz --owner glsec
 ```
 
 **The container image** is signed with [cosign](https://github.com/sigstore/cosign) and carries provenance plus an SBOM attestation:
 
 ```sh
-cosign verify ghcr.io/glsec/glsec:1.14.0 \
+cosign verify ghcr.io/glsec/glsec:1.15.0 \
   --certificate-identity-regexp 'https://github.com/glsec/glsec/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # list everything attached to the image (signature, provenance, SBOM)
-cosign tree ghcr.io/glsec/glsec:1.14.0
+cosign tree ghcr.io/glsec/glsec:1.15.0
 ```
 
 The two `--certificate-*` flags are what bind the signature to this repository's GitHub Actions workflow. Without them `cosign verify` accepts a signature from any identity, which defeats the point.
@@ -79,7 +79,7 @@ The two `--certificate-*` flags are what bind the signature to this repository's
 **Checksums** are published as `checksums.txt` next to the archives:
 
 ```sh
-curl -sSLO https://github.com/glsec/glsec/releases/download/v1.14.0/checksums.txt
+curl -sSLO https://github.com/glsec/glsec/releases/download/v1.15.0/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
 ```
 
@@ -317,7 +317,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.14.0
+    rev: v1.15.0
     hooks:
       - id: glsec
 ```
@@ -408,13 +408,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.14.0
+    name: ghcr.io/glsec/glsec:1.15.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.14.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.15.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -422,7 +422,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.14.0"
+  GLSEC_VERSION: "1.15.0"
 
 glsec:
   stage: test
@@ -444,7 +444,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.14.0
+    name: ghcr.io/glsec/glsec:1.15.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -463,7 +463,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.14.0
+    name: ghcr.io/glsec/glsec:1.15.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true

--- a/bin/glsec
+++ b/bin/glsec
@@ -12,7 +12,7 @@
 # Supports linux + darwin only. VERSION is kept in lockstep with the release.
 set -eu
 
-VERSION="1.14.0"
+VERSION="1.15.0"
 REPO="glsec/glsec"
 
 hint() {


### PR DESCRIPTION
Version bump for the 1.15.0 release. No behaviour change.

## What is in 1.15.0

| Change | PR |
|---|---|
| **GL022 extended** — ad-hoc dependency installs (`npm install <pkg>`, `npm i`, `npm add`, `yarn add`, `pnpm add`, `bundle add`) are now flagged when unpinned, and the missed global spellings `npm i -g` / `npm add -g` are caught | #460 |
| Docs — component examples point at `v1.0.15` | #457 |
| Deps — `docker/login-action` 4.6.0, `actions/attest-build-provenance` 4.2.2 | #458, #461 |

82 rules, unchanged from 1.14.0 — the GL022 work is an extension of an existing rule, not a new ID.

The GL022 change was validated against the 199-pipeline corpus before merge: 403 findings on `main` → 407 on the branch, all four new findings true positives, zero regressions on the pre-existing 403.

## Bumped

- `.claude-plugin/plugin.json` — the source of truth for the "Check version pins agree" job
- `bin/glsec` — `VERSION=`, which selects the release asset the wrapper downloads
- `README.md` — 10 references (attestation, cosign verify/tree, checksums URL, pre-commit `rev:`, image tags, `GLSEC_VERSION`, the pin-not-`:latest` note)

Ran the pin-check job's own script locally: all pins agree on 1.15.0, and no `1.14.0` reference is left outside `testdata/`.

The GitLab component examples stay at `v1.0.15` here. The component is released separately on its own `v1.0.N` scheme and can only move once it has been bumped and released for glsec 1.15.0, so those two references follow in a small PR afterwards.

## How to test

- CI's `Check version pins agree` job is the direct check.
- Locally: `golangci-lint run ./...`, `check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml`, `go test ./...` — all green.
