### PR TITLE
docs: point component examples at v1.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.15
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.16
 
 stages:
   - test
@@ -381,7 +381,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.15
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.16
 
 stages:
   - test


### PR DESCRIPTION
Follow-up to #462. The GitLab CI/CD Catalog component has been bumped and released for glsec 1.15.0, so the two component examples in the README can now move to the new tag.

## What changed

Both `include: - component:` examples go from `@v1.0.15` to `@v1.0.16`:

- `gitlab.com/glsec-io/glsec/glsec@v1.0.16`
- `gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.16`

`v1.0.16` defaults to `ghcr.io/glsec/glsec:1.15.0`.

## Why this is a separate PR

The component lives in its own repository on its own `v1.0.N` scheme, and the tag has to exist before the README can point at it — so the release PR cannot carry this change. The component version is also deliberately excluded from the `Check version pins agree` job, since it moves independently of the scanner version. Nothing watches it, which is exactly how these references went five releases stale before #456 caught it, so it is worth doing in the same sitting as the release rather than later.

## How to test

- `grep -n 'v1\.0\.1[0-9]' README.md` → both hits on `v1.0.16`.
- The tag is live and published to the Catalog: `ciCatalogResource(fullPath: "glsec-io/glsec")` lists `v1.0.16`, released 2026-08-16.
- The component's own `main` pipeline for that commit is green, including `lint-templates`, which pulls `ghcr.io/glsec/glsec:1.15.0` — so the image the component defaults to is confirmed pullable.
