### PR TITLE
fix: upgrade alpine packages to patch CVE-2026-14456

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -o glsec ./cmd/glsec
 
 FROM alpine:3.24
+# alpine:3.24 has not been rebuilt since the openssl fix for CVE-2026-14456
+# landed in v3.24/main; drop this once the base image ships 3.5.8-r0.
+# hadolint ignore=DL3017
+RUN apk --no-cache upgrade
 COPY --from=builder /build/glsec /usr/local/bin/glsec
 
 # ARGs do not cross build stages, so re-declare them here for the LABELs


### PR DESCRIPTION
## What changed

Adds `RUN apk --no-cache upgrade` to the runtime stage of the `Dockerfile`, with a `# hadolint ignore=DL3017` directive and a comment recording why it is there and when it can go.

## Why

The `Security (Trivy image)` job started failing on every PR. Both open Dependabot PRs (#464, #465) are red on this job and green on all eleven others:

```
glsec:ci (alpine 3.24.1)
Total: 2 (HIGH: 2, CRITICAL: 0)
libcrypto3 | CVE-2026-14456 | HIGH | fixed | 3.5.7-r0 | 3.5.8-r0
libssl3    |                |      |       |          |
```

CVE-2026-14456 is an OpenSSL denial of service (unbounded memory growth in the QUIC server). The finding comes from the runtime stage's `FROM alpine:3.24`, which neither PR touches — #464 only bumps the builder stage (`golang:1.26-alpine` → `1.27-alpine`, discarded in the final image) and #465 only bumps a GitHub Action. `main` is green only because the CI workflow runs on `push`/`pull_request` and the last push to `main` was 2026-08-16, before the CVE was published; a rerun on `main` would fail identically. This is not a regression introduced by either PR.

Waiting it out would not have worked either. The patched package is available, the image is not:

| | State as of 2026-08-27 |
| --- | --- |
| `openssl 3.5.8-r0` in the Alpine `v3.24/main` repo | available since 2026-08-25 20:58 |
| `alpine:3.24` image on Docker Hub | not rebuilt since 2026-06-16, digest `sha256:28bd5fe8…` — the same one CI built against |
| `alpine:3.24.2` tag | does not exist yet |

Since the Dockerfile does not upgrade packages, the image inherits 3.5.7-r0 and the job stays red until Docker Official Images rebuilds the base. Upgrading at build time pulls the fixed package now.

### Why a blanket upgrade rather than a pinned package

The narrower `apk add --no-cache libcrypto3=3.5.8-r0 libssl3=3.5.8-r0` would satisfy hadolint DL3018 without needing an ignore directive, but Alpine only keeps the current version of a package in its repositories. The exact pin would break the build the moment `3.5.9-r0` is published. The blanket upgrade holds until the base image is rebuilt, which is when the whole block should be removed.

## How to test

Run the three image jobs exactly as CI does:

```sh
docker run --rm -i hadolint/hadolint:v2.14.0 hadolint - < Dockerfile

docker build -t glsec:ci .

docker run --rm \
  -v /var/run/docker.sock:/var/run/docker.sock \
  aquasec/trivy:0.74.0 image \
  --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 glsec:ci

docker run --rm \
  -v /var/run/docker.sock:/var/run/docker.sock \
  goodwithtech/dockle:v0.4.15 --exit-code 1 --exit-level warn glsec:ci
```

Verified locally before opening this PR:

| Check | Before | After |
| --- | --- | --- |
| hadolint v2.14.0 | — | exit 0 |
| Trivy (CI settings) | 2 HIGH, exit 1 | 0 findings, exit 0 |
| dockle v0.4.15 | — | exit 0, two unchanged INFO entries |
| `go test ./...` | — | all packages ok |
| `golangci-lint run` | — | 0 issues |

Confirm the package actually landed:

```sh
docker run --rm --entrypoint /bin/sh glsec:ci \
  -c "apk list --installed | grep -Ei 'libcrypto|libssl'"
# libcrypto3-3.5.8-r0 x86_64 {openssl} (Apache-2.0) [installed]
# libssl3-3.5.8-r0 x86_64 {openssl} (Apache-2.0) [installed]
```

## Follow-ups

- #464 and #465 branch off a `main` from before this fix and will need `@dependabot rebase` after merge to pick it up.
- Remove the `apk upgrade` block and the ignore directive once `alpine:3.24` ships 3.5.8-r0 (or `alpine:3.24.2` lands).
- Worth considering separately: the runtime stage only copies a `CGO_ENABLED=0` binary and sets `USER`, and the code imports neither `net/http` nor `crypto/tls`, so Alpine contributes 16 packages of attack surface and recurring CVE noise that the image never uses. A `scratch` or distroless-static base would retire this class of failure for good.

## Notes

Branch is named `fix/alpine-openssl-cve-2026-14456` rather than the `<type>/issue-<N>-<slug>` convention in `CLAUDE.md`, as there is no tracking issue for this. Happy to file one and rename.
