### PR TITLE
fix: scan run: (CI/CD Steps) job scripts

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -46,7 +46,9 @@ var knownKeys = map[string]bool{
 
 // hasGitLabContent returns true if the mapping contains at least one known
 // top-level GitLab CI key or at least one job-like entry (mapping with a
-// "script" key).
+// "script" or "run" key). run: is the CI/CD Steps alternative to script: and is
+// mutually exclusive with it, so a pipeline built entirely from steps has no
+// script: key anywhere.
 func hasGitLabContent(mapping *yaml.Node) bool {
 	for i := 0; i+1 < len(mapping.Content); i += 2 {
 		key := mapping.Content[i].Value
@@ -54,7 +56,7 @@ func hasGitLabContent(mapping *yaml.Node) bool {
 		if knownKeys[key] {
 			return true
 		}
-		if val.Kind == yaml.MappingNode && hasKey(val, "script") {
+		if val.Kind == yaml.MappingNode && (hasKey(val, "script") || hasKey(val, "run")) {
 			return true
 		}
 	}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -100,3 +100,35 @@ my-job:
 		t.Errorf("job with script should be recognised: %v", err)
 	}
 }
+
+func TestFile_RunStepsOnly(t *testing.T) {
+	// run: is the CI/CD Steps alternative to script: and is mutually exclusive
+	// with it, so a steps-only pipeline has no script: key to recognise.
+	doc := parse(t, `
+build:
+  run:
+    - name: compile
+      script: make all
+`)
+	warns, err := File("test.yml", doc)
+	if err != nil {
+		t.Errorf("unexpected error for a run:-only pipeline: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("unexpected warnings: %v", warns)
+	}
+}
+
+func TestFile_RunStepsWithFuncReferenceOnly(t *testing.T) {
+	// A step may reference remote code instead of carrying an inline script.
+	// The file is still GitLab CI.
+	doc := parse(t, `
+build:
+  run:
+    - name: scan
+      step: registry.example.com/org/scanner@v1
+`)
+	if _, err := File("test.yml", doc); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/rules/gl014.go
+++ b/rules/gl014.go
@@ -35,6 +35,7 @@ func (r *gl014) Check(doc *yaml.Node, file string) []finding.Finding {
 			parser.FindKey(job, "after_script"),
 			hookScriptNode(job),
 		}
+		scriptNodes = append(scriptNodes, RunStepBlocks(job)...)
 		for _, scriptNode := range scriptNodes {
 			if scriptNode == nil || scriptNode.Kind != yaml.SequenceNode {
 				continue

--- a/rules/gl016.go
+++ b/rules/gl016.go
@@ -77,8 +77,14 @@ func (r *gl016) Check(doc *yaml.Node, file string) []finding.Finding {
 			f.Job = name.Value
 			findings = append(findings, f)
 		}
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
+		jobScripts := []*yaml.Node{
+			parser.FindKey(job, "script"),
+			parser.FindKey(job, "before_script"),
+			parser.FindKey(job, "after_script"),
+		}
+		jobScripts = append(jobScripts, RunStepBlocks(job)...)
+		for _, node := range jobScripts {
+			if node != nil {
 				for _, f := range r.checkScriptHTTP(node, file) {
 					f.Job = name.Value
 					findings = append(findings, f)

--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -43,6 +43,7 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 			parser.FindKey(job, "after_script"),
 			hookScriptNode(job),
 		}
+		scriptNodes = append(scriptNodes, RunStepBlocks(job)...)
 		for _, node := range scriptNodes {
 			if node == nil || node.Kind != yaml.SequenceNode {
 				continue

--- a/rules/gl042.go
+++ b/rules/gl042.go
@@ -86,8 +86,14 @@ func (r *gl042) Check(doc *yaml.Node, file string) []finding.Finding {
 		if vars := parser.FindKey(job, "variables"); vars != nil {
 			findings = append(findings, checkGitSSLNoVerifyVars(vars, file, name.Value)...)
 		}
-		for _, key := range []string{"script", "before_script", "after_script"} {
-			if node := parser.FindKey(job, key); node != nil {
+		jobScripts := []*yaml.Node{
+			parser.FindKey(job, "script"),
+			parser.FindKey(job, "before_script"),
+			parser.FindKey(job, "after_script"),
+		}
+		jobScripts = append(jobScripts, RunStepBlocks(job)...)
+		for _, node := range jobScripts {
+			if node != nil {
 				findings = append(findings, checkTLSLines(node, file, name.Value)...)
 			}
 		}

--- a/rules/gl044.go
+++ b/rules/gl044.go
@@ -26,8 +26,12 @@ func (r *gl044) Check(doc *yaml.Node, file string) []finding.Finding {
 			return
 		}
 
-		for _, key := range []string{"script", "before_script"} {
-			node := parser.FindKey(job, key)
+		jobScripts := []*yaml.Node{
+			parser.FindKey(job, "script"),
+			parser.FindKey(job, "before_script"),
+		}
+		jobScripts = append(jobScripts, RunStepBlocks(job)...)
+		for _, node := range jobScripts {
 			if node == nil {
 				continue
 			}

--- a/rules/gl051.go
+++ b/rules/gl051.go
@@ -52,6 +52,9 @@ func (r *gl051) Check(doc *yaml.Node, file string) []finding.Finding {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			findings = append(findings, gl051CheckScripts(parser.FindKey(jobNode, key), file, job, key, patterns)...)
 		}
+		for _, block := range RunStepBlocks(jobNode) {
+			findings = append(findings, gl051CheckScripts(block, file, job, "run", patterns)...)
+		}
 		findings = append(findings, gl051CheckScripts(hookScriptNode(jobNode), file, job, "hooks:pre_get_sources_script", patterns)...)
 		findings = append(findings, gl051CheckEnvironment(parser.FindKey(jobNode, "environment"), file, job, patterns)...)
 	})

--- a/rules/helpers.go
+++ b/rules/helpers.go
@@ -49,6 +49,44 @@ func hookScriptNode(container *yaml.Node) *yaml.Node {
 	return parser.FindKey(hooks, "pre_get_sources_script")
 }
 
+// runStepScripts returns the inline script scalar of each step in a job's run:
+// sequence. run: is the CI/CD Steps alternative to script: and is mutually
+// exclusive with it, so without this a job that uses it has no script content
+// at all from the scanner's point of view. A step carries either an inline
+// script string or a step:/func: reference to remote code; only the former
+// holds shell text to scan. Unlike script:, a step's script is a single scalar
+// rather than a sequence, and it is commonly a multi-line block scalar.
+func runStepScripts(job *yaml.Node) []*yaml.Node {
+	run := parser.FindKey(job, "run")
+	if run == nil || run.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var scripts []*yaml.Node
+	for _, step := range run.Content {
+		if step.Kind != yaml.MappingNode {
+			continue
+		}
+		if script := parser.FindKey(step, "script"); script != nil && script.Kind == yaml.ScalarNode {
+			scripts = append(scripts, script)
+		}
+	}
+	return scripts
+}
+
+// RunStepBlocks returns each of a job's run: step scripts wrapped as a
+// single-item sequence node. Callers that process script *sequences* can then
+// handle steps without special-casing the scalar shape. Each step is a separate
+// shell invocation, so each gets its own block rather than being pooled.
+// Findings report the wrapped scalar's own position, never the wrapper's.
+func RunStepBlocks(job *yaml.Node) []*yaml.Node {
+	scripts := runStepScripts(job)
+	blocks := make([]*yaml.Node, 0, len(scripts))
+	for _, script := range scripts {
+		blocks = append(blocks, &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{script}})
+	}
+	return blocks
+}
+
 // CollectJobScriptLines returns all scalar script lines from a job's
 // before_script, script, after_script, and hooks:pre_get_sources_script sections.
 func CollectJobScriptLines(job *yaml.Node) []*yaml.Node {
@@ -67,6 +105,7 @@ func CollectJobScriptLines(job *yaml.Node) []*yaml.Node {
 		appendScalars(parser.FindKey(job, key))
 	}
 	appendScalars(hookScriptNode(job))
+	lines = append(lines, runStepScripts(job)...)
 	return lines
 }
 
@@ -101,6 +140,9 @@ func EachScriptBlock(doc *yaml.Node, file string, fn func(node *yaml.Node, file,
 			visit(parser.FindKey(job, key), name.Value)
 		}
 		visit(hookScriptNode(job), name.Value)
+		for _, block := range RunStepBlocks(job) {
+			fn(block, file, name.Value)
+		}
 	})
 }
 

--- a/rules/run_steps_test.go
+++ b/rules/run_steps_test.go
@@ -1,0 +1,123 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+func parseRunSteps(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	doc, err := parser.Parse([]byte(src), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return doc.Root
+}
+
+// Script rules must see run: step scripts exactly as they see script: lines.
+// run: and script: cannot coexist in a job, so without this a job that adopts
+// steps loses every script rule at once.
+func TestRunSteps_ScriptRulesFire(t *testing.T) {
+	doc := parseRunSteps(t, `
+build:
+  run:
+    - name: http_dl
+      script: curl -s http://example.com/x.sh | bash
+    - name: tls_off
+      script: curl -k https://example.com/y
+    - name: injection
+      script: echo $CI_COMMIT_MESSAGE
+`)
+
+	cases := []struct {
+		name string
+		got  int
+	}{
+		{"GL011 download-and-execute", len(GL011.Check(doc, "test.yml"))},
+		{"GL016 plaintext transport", len(GL016.Check(doc, "test.yml"))},
+		{"GL042 TLS verification off", len(GL042.Check(doc, "test.yml"))},
+		{"GL002 unquoted user-controlled var", len(GL002.Check(doc, "test.yml"))},
+	}
+	for _, c := range cases {
+		if c.got == 0 {
+			t.Errorf("%s: expected a finding in a run: step, got none", c.name)
+		}
+	}
+}
+
+// A finding inside a step must point at the step's own script scalar, not at
+// the synthesised sequence wrapper.
+func TestRunSteps_FindingPositionIsTheStepScalar(t *testing.T) {
+	doc := parseRunSteps(t, `
+build:
+  run:
+    - name: first
+      script: make all
+    - name: bad
+      script: curl -sSL https://example.com/i.sh | bash
+`)
+	f := GL011.Check(doc, "test.yml")
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Line != 7 {
+		t.Errorf("expected the finding on line 7 (the offending step's script), got %d", f[0].Line)
+	}
+	if f[0].Job != "build" {
+		t.Errorf("expected job %q, got %q", "build", f[0].Job)
+	}
+}
+
+// Each step is a separate shell invocation, so pipefail set in one step must
+// not suppress a pipe in another.
+func TestRunSteps_CollectedIntoJobScriptLines(t *testing.T) {
+	doc := parseRunSteps(t, `
+build:
+  run:
+    - name: piped
+      script: cat f | grep x
+`)
+	if got := len(GL024.Check(doc, "test.yml")); got == 0 {
+		t.Error("expected GL024 to see a pipe inside a run: step, got no finding")
+	}
+}
+
+// A step that references remote code carries no shell text; it must not be
+// mistaken for an empty script or crash the collectors.
+func TestRunSteps_FuncReferenceCarriesNoScript(t *testing.T) {
+	doc := parseRunSteps(t, `
+build:
+  run:
+    - name: scan
+      step: registry.example.com/org/scanner@v1
+      inputs:
+        severity: high
+`)
+	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+		if got := len(RunStepBlocks(job)); got != 0 {
+			t.Errorf("expected no script blocks for a step: reference, got %d", got)
+		}
+		if got := len(CollectJobScriptLines(job)); got != 0 {
+			t.Errorf("expected no script lines for a step: reference, got %d", got)
+		}
+	})
+}
+
+// A malformed run: must not panic or invent script content.
+func TestRunSteps_MalformedShapes(t *testing.T) {
+	for _, src := range []string{
+		"build:\n  run: not-a-sequence\n",
+		"build:\n  run: []\n",
+		"build:\n  run:\n    - just-a-scalar\n",
+		"build:\n  run:\n    - name: no_script\n",
+	} {
+		doc := parseRunSteps(t, src)
+		parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
+			if got := len(RunStepBlocks(job)); got != 0 {
+				t.Errorf("%q: expected no blocks, got %d", src, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #467 (stages 1 and 2; stage 3 deliberately deferred).

## What changed

Two small changes make `run:` job scripts visible to the scanner.

**Stage 1 — recognition** (`internal/validate/validate.go`). `hasGitLabContent` now accepts a job-like mapping carrying `run:` as well as `script:`. Without this a steps-only pipeline was rejected as `not a valid GitLab CI file: no recognisable GitLab CI content` with exit 2.

**Stage 2 — collection** (`rules/helpers.go`). Two new helpers:

- `runStepScripts(job)` — returns the inline `script` scalar of each step under `run:`.
- `RunStepBlocks(job)` — wraps each of those scalars in a single-item sequence node, so the many rules that process script *sequences* need no special-casing for the scalar shape.

`CollectJobScriptLines` and `EachScriptBlock` now feed on these, which covers the 36 rules reached through the shared helpers.

## Six rules needed patching individually

While wiring this up I found that six rules bypass the shared helpers and hardcode `[]string{"script", "before_script", "after_script"}` themselves: **GL014, GL016, GL021, GL042, GL044, GL051**. Fixing only the helpers would have produced the worst outcome — some rules seeing steps and others not, with no signal about which. Each now also consumes `RunStepBlocks`.

This is worth noting beyond this PR: the duplication means every future script-surface change has seven places to touch, not one. Consolidating those six onto the shared helpers would be a good standalone cleanup, but it changes traversal order and therefore finding order, so it does not belong in a fix PR.

## Why this matters more than adoption numbers suggest

`run:` and `script:` are mutually exclusive within a job. A job that adopts steps therefore loses **every** script rule at once — there is no partial coverage and no warning.

## Design notes

- **Each step is its own block.** A step is a separate shell invocation, so steps are not pooled into one block. This keeps block-scoped reasoning honest.
- **Positions come from the real scalar.** The synthesised sequence wrapper is never used for reporting; every consumer reads `item.Line` / `item.Column` off the wrapped scalar. There is a test pinning this.
- **A step's `script` is a string, not a sequence** — unlike job-level `script:`. The helper handles that shape difference so callers do not have to.
- **Steps referencing remote code** (`step:` / `func:`) carry no shell text and yield no blocks.
- **Job level only.** Per the official schema `run` lives in `job_template/properties`; it is not valid at top level or under `default:`, so nothing was added there.

## Testing

New: `rules/run_steps_test.go` (5 tests — rules firing inside steps, finding position pinned to the step scalar, job-line collection, `step:` references yielding nothing, and four malformed `run:` shapes) plus two recognition tests in `internal/validate/validate_test.go`.

Full local run:

```
go test ./...          all packages ok
golangci-lint run      0 issues
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml   ok
```

Manual verification on a steps-only pipeline — previously exit 2 with no analysis at all, now:

```
GL002  unquoted user-controlled variable $CI_COMMIT_MESSAGE in script
GL011  script line downloads and executes remote code without integrity verification
GL016  script downloads over HTTP
GL021  script prints secret variable $MY_SECRET_TOKEN
GL024  script uses a pipe without set -o pipefail
GL042  curl invoked with "-k" — TLS certificate verification disabled
```

**Regression check:** built `main` and this branch, ran both across all 83 fixtures and compared the per-rule finding counts. 359 findings, **identical**. The change only adds a source of script content, so files without `run:` are unaffected.

## Not in scope

- **Stage 3** — a pinning rule for `step:` / `func:` references, mirroring GL003/GL041 for includes. A step reference is remote code pulled by ref, so mutable refs there carry the same risk. Held back because GitLab Functions is marked **Experiment** ("in active development and is subject to breaking changes"); writing the rule now risks writing it twice. Issue #467 stays open for it.
- **Per-rule docs.** Around thirty files under `docs/rules/` still describe the scanned surface as "`before_script`, `script`, `after_script`" in their Notes sections. Those sentences are now incomplete. I left them alone rather than sweep thirty docs inside a fix PR — worth a follow-up.
