### PR TITLE
docs: note run: step coverage; extend ShellCheck to run: steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ glsec --recursive --name '*.gitlab-ci.yml' --name 'ci/pipeline.yml' .
 # rules that a template fragment cannot satisfy.
 glsec templates/my-component.yml
 
+# jobs written with `run:` (CI/CD Steps) are scanned too — every script rule and
+# the ShellCheck integration read each step's `script:` the same way they read
+# `script:`, `before_script:`, and `after_script:`.
+glsec .gitlab-ci.yml
+
 # aligned table view, easier to scan when there are many findings
 glsec --format table .gitlab-ci.yml
 

--- a/docs/rules/GL004.md
+++ b/docs/rules/GL004.md
@@ -38,7 +38,7 @@ upload:
 
 - GitLab.com and `*.gitlab.com` subdomains are always considered safe
 - Self-hosted GitLab instances contacted via `$CI_SERVER_URL` or `$CI_API_V4_URL` are safe
-- This rule does not flag token usage in `variables:` blocks — only in `script:`, `before_script:`, and `after_script:`
+- This rule does not flag token usage in `variables:` blocks — only in `script:`, `before_script:`, `after_script:`, and `run:` step scripts
 
 ## See also
 

--- a/docs/rules/GL020.md
+++ b/docs/rules/GL020.md
@@ -10,7 +10,7 @@ glsec flags jobs that download a file with `curl` or `wget` (saving to disk) but
 This rule complements GL011 (download-and-execute): GL011 catches the immediate `curl | bash` pattern, GL020 catches the subtler two-step variant where the file is saved first and verified later (or not at all).
 
 A job is flagged when:
-1. Any `script`/`before_script`/`after_script` line downloads to disk via `curl -o`, `curl -O`, `curl --output`, `curl -sSLO`, or `wget`
+1. Any `script`/`before_script`/`after_script` line, or any `run:` step script, downloads to disk via `curl -o`, `curl -O`, `curl --output`, `curl -sSLO`, or `wget`
 2. No checksum/signature verification command (`sha256sum`, `shasum`, `md5sum`, `gpg --verify`, `cosign verify`, `openssl dgst`) appears anywhere in the job's script
 
 ## Trigger example
@@ -57,5 +57,5 @@ install:
 ## Notes
 
 - One finding is emitted per job, pointing to the first unverified download line.
-- If checksum verification appears in `before_script`, it counts — the check considers all three script keys together.
+- If checksum verification appears in `before_script`, it counts — the check considers all script sources in the job together, including `run:` steps.
 - For the immediate `curl | bash` pattern, see GL011.

--- a/docs/rules/GL024.md
+++ b/docs/rules/GL024.md
@@ -65,5 +65,5 @@ build:
 
 - One finding is emitted per job, pointing to the first piped line.
 - `||` (logical OR) and `|&` (stderr+stdout redirect) are not treated as pipes and do not trigger this rule.
-- `pipefail` set anywhere in `before_script`, `script`, or `after_script` suppresses the finding.
+- `pipefail` set anywhere in `before_script`, `script`, `after_script`, or a `run:` step suppresses the finding.
 - If you intentionally ignore a pipe failure (e.g. `cmd | true`), suppress the finding inline: `# glsec:ignore GL024 -- intentional, fallback handled`.

--- a/docs/rules/GL025.md
+++ b/docs/rules/GL025.md
@@ -61,6 +61,6 @@ notify:
 ## Notes
 
 - One finding is emitted per offending line (unlike most GL rules which emit one per job), because each line is an independent request that may reach a different host.
-- The rule checks `before_script`, `script`, and `after_script`.
+- The rule checks `before_script`, `script`, `after_script`, and `run:` step scripts.
 - Variables that are not in the list above (e.g. `$MY_TOKEN`, `$CI_PROJECT_ID`) do not trigger this rule.
 - If you have a genuine need and the value is sanitised inline, suppress with: `# glsec:ignore GL025 -- value sanitised above`.

--- a/docs/rules/GL026.md
+++ b/docs/rules/GL026.md
@@ -39,7 +39,7 @@ build:
 
 ## Notes
 
-- A bare `git clone <url>` (no `--branch`) is suppressed when the same job also contains a `git checkout <sha>` (40-character hex) in any of `before_script`, `script`, or `after_script` — that is the intended safe pattern.
+- A bare `git clone <url>` (no `--branch`) is suppressed when the same job also contains a `git checkout <sha>` (40-character hex) in any of `before_script`, `script`, `after_script`, or a `run:` step — that is the intended safe pattern.
 - `git checkout -b <name>` (local branch creation) does not trigger this rule.
 - `git checkout <sha>` with a full 40-character SHA does not trigger this rule.
 - Suppress intentionally mutable checkouts with: `# glsec:ignore GL026 -- upstream repo is trusted and content-addressed by other means`.

--- a/docs/rules/GL045.md
+++ b/docs/rules/GL045.md
@@ -33,7 +33,7 @@ Jobs whose name or `stage:` contains a release/publish keyword (`release`, `publ
 | `notation sign` | Notary v2 |
 | `slsa-verifier` | SLSA |
 
-Signing commands in `before_script:` or `after_script:` also count.
+Signing commands in `before_script:`, `after_script:`, or a `run:` step also count.
 
 ## Trigger example
 

--- a/docs/rules/GL047.md
+++ b/docs/rules/GL047.md
@@ -10,7 +10,7 @@ Connecting to a remote server as `root` from a CI job grants full, unrestricted 
 
 ## What is flagged
 
-Script lines (in `script:`, `before_script:`, `after_script:`) that invoke `ssh` with `root` as the login user, in any common form:
+Script lines (in `script:`, `before_script:`, `after_script:`, or a `run:` step) that invoke `ssh` with `root` as the login user, in any common form:
 
 ```
 ssh root@host

--- a/docs/rules/GL048.md
+++ b/docs/rules/GL048.md
@@ -14,7 +14,7 @@ GL030 flags `ssh-keyscan` (which blindly trusts whatever key the remote host pre
 
 ## What is flagged
 
-Script lines (in `script:`, `before_script:`, `after_script:`) that contain `StrictHostKeyChecking` set to `no` or `off`, in any common form:
+Script lines (in `script:`, `before_script:`, `after_script:`, or a `run:` step) that contain `StrictHostKeyChecking` set to `no` or `off`, in any common form:
 
 ```sh
 ssh -o StrictHostKeyChecking=no deploy@host

--- a/docs/rules/GL050.md
+++ b/docs/rules/GL050.md
@@ -16,7 +16,7 @@ In both cases `sudo` in a pipeline script is a security smell.
 
 ## What is flagged
 
-Script lines (in `script:`, `before_script:`, `after_script:`) that contain `sudo` as a standalone word. Shell comment lines (starting with `#`) are not flagged.
+Script lines (in `script:`, `before_script:`, `after_script:`, or a `run:` step) that contain `sudo` as a standalone word. Shell comment lines (starting with `#`) are not flagged.
 
 ## Trigger example
 

--- a/docs/rules/GL051.md
+++ b/docs/rules/GL051.md
@@ -6,13 +6,13 @@
 
 ## Risk
 
-GitLab CI Catalog components accept caller-supplied values via `spec:inputs`. When an input is interpolated into a sensitive keyword — `image:`, `services:`, `script:`, `before_script:`, `after_script:`, or `environment:name:` — without a `regex:` constraint or an `options:` allowlist, any consumer of the component can supply an arbitrary value.
+GitLab CI Catalog components accept caller-supplied values via `spec:inputs`. When an input is interpolated into a sensitive keyword — `image:`, `services:`, `script:`, `before_script:`, `after_script:`, a `run:` step script, or `environment:name:` — without a `regex:` constraint or an `options:` allowlist, any consumer of the component can supply an arbitrary value.
 
 This differs from GL002 (predefined GitLab variables): here the tainted value originates from whoever _calls_ the component, not from the commit author, making the attack surface wider and the trust model distinct.
 
 Without constraints, an attacker can:
 - Substitute an arbitrary image and execute malicious code (`image:`, `services:`)
-- Inject shell commands into the pipeline (`script:`, `before_script:`, `after_script:`)
+- Inject shell commands into the pipeline (`script:`, `before_script:`, `after_script:`, `run:` steps)
 - Redirect deployments to an unintended environment (`environment:name:`)
 
 ## Trigger example

--- a/docs/rules/GL068.md
+++ b/docs/rules/GL068.md
@@ -5,7 +5,7 @@
 
 ## What glsec checks
 
-glsec flags any command in `script`, `before_script`, or `after_script` (top-level, `default:`, or job-level) that turns on shell command tracing:
+glsec flags any command in `script`, `before_script`, or `after_script` (top-level, `default:`, or job-level), or in a `run:` step, that turns on shell command tracing:
 
 - `set -x`
 - `set -euxo pipefail` — any clustered short-flag form containing `x`

--- a/docs/rules/GL069.md
+++ b/docs/rules/GL069.md
@@ -5,7 +5,7 @@
 
 ## What glsec checks
 
-glsec flags package-manager invocations in `script` / `before_script` / `after_script` that turn off the package manager's **signature/authentication** check:
+glsec flags package-manager invocations in `script` / `before_script` / `after_script` / `run:` steps that turn off the package manager's **signature/authentication** check:
 
 - `apt-get … --allow-unauthenticated`
 - `-o APT::Get::AllowUnauthenticated=true`

--- a/docs/rules/GL070.md
+++ b/docs/rules/GL070.md
@@ -5,7 +5,7 @@
 
 ## What glsec checks
 
-glsec flags `script` / `before_script` / `after_script` commands that authenticate to a cloud provider with a **long-lived static service-account credential**:
+glsec flags `script` / `before_script` / `after_script` / `run:`-step commands that authenticate to a cloud provider with a **long-lived static service-account credential**:
 
 - **GCP** — `gcloud auth activate-service-account` or any `gcloud … --key-file`
 - **AWS** — `aws configure set aws_secret_access_key …`, or `AWS_SECRET_ACCESS_KEY=…` set in a script line

--- a/docs/rules/GL079.md
+++ b/docs/rules/GL079.md
@@ -9,7 +9,7 @@ Adding a public package index **alongside** a private one is the classic **depen
 
 ## What glsec checks
 
-GL079 flags a `pip install` (`pip`, `pip3`, or `python -m pip install`) that passes **`--extra-index-url`** in any `script:`, `before_script:`, `after_script:`, or `hooks:pre_get_sources_script` line:
+GL079 flags a `pip install` (`pip`, `pip3`, or `python -m pip install`) that passes **`--extra-index-url`** in any `script:`, `before_script:`, `after_script:`, `run:`-step, or `hooks:pre_get_sources_script` line:
 
 ```yaml
 build:

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -144,6 +144,43 @@ var reservedKeys = map[string]bool{
 	"after_script":  true,
 }
 
+// RunStepScripts returns the inline script scalar of each step in a job's run:
+// sequence. run: is the CI/CD Steps alternative to script: and is mutually
+// exclusive with it, so without this a job that uses it has no script content
+// at all from the scanner's point of view. A step carries either an inline
+// script string or a step:/func: reference to remote code; only the former
+// holds shell text to scan.
+func RunStepScripts(job *yaml.Node) []*yaml.Node {
+	run := FindKey(job, "run")
+	if run == nil || run.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var scripts []*yaml.Node
+	for _, step := range run.Content {
+		if step.Kind != yaml.MappingNode {
+			continue
+		}
+		if script := FindKey(step, "script"); script != nil && script.Kind == yaml.ScalarNode {
+			scripts = append(scripts, script)
+		}
+	}
+	return scripts
+}
+
+// RunStepBlocks wraps each script from RunStepScripts in a single-item sequence
+// node, so callers that process script *sequences* need no special case for the
+// scalar shape a step uses. Each step is a separate shell invocation, so each
+// gets its own block rather than being pooled. Findings report the wrapped
+// scalar's own position, never the wrapper's.
+func RunStepBlocks(job *yaml.Node) []*yaml.Node {
+	scripts := RunStepScripts(job)
+	blocks := make([]*yaml.Node, 0, len(scripts))
+	for _, script := range scripts {
+		blocks = append(blocks, &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{script}})
+	}
+	return blocks
+}
+
 // CountJobs returns the number of job definitions in the document.
 func CountJobs(doc *yaml.Node) int {
 	n := 0

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -164,3 +164,64 @@ func TestParse_MultiDocumentWithoutSpecUsesFirst(t *testing.T) {
 		t.Error("expected the first document to be linted")
 	}
 }
+
+func TestRunStepScripts(t *testing.T) {
+	doc, err := Parse([]byte(`
+build:
+  run:
+    - name: inline
+      script: make all
+    - name: remote
+      step: registry.example.com/org/scanner@v1
+    - name: second_inline
+      script: make test
+`), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	EachJob(doc.Root, func(_ *yaml.Node, job *yaml.Node) {
+		scripts := RunStepScripts(job)
+		if len(scripts) != 2 {
+			t.Fatalf("expected 2 inline scripts (the step: reference carries none), got %d", len(scripts))
+		}
+		if scripts[0].Value != "make all" || scripts[1].Value != "make test" {
+			t.Errorf("unexpected scripts: %q, %q", scripts[0].Value, scripts[1].Value)
+		}
+		blocks := RunStepBlocks(job)
+		if len(blocks) != 2 {
+			t.Fatalf("expected 2 blocks, got %d", len(blocks))
+		}
+		for i, b := range blocks {
+			if b.Kind != yaml.SequenceNode || len(b.Content) != 1 {
+				t.Errorf("block %d: expected a single-item sequence", i)
+				continue
+			}
+			// The wrapped node must be the original scalar, so findings keep
+			// their real position.
+			if b.Content[0] != scripts[i] {
+				t.Errorf("block %d: wrapper does not hold the original scalar node", i)
+			}
+		}
+	})
+}
+
+func TestRunStepScripts_MalformedAndAbsent(t *testing.T) {
+	for _, src := range []string{
+		"build:\n  script: [make]\n",
+		"build:\n  run: not-a-sequence\n",
+		"build:\n  run: []\n",
+		"build:\n  run:\n    - just-a-scalar\n",
+		"build:\n  run:\n    - name: no_script\n",
+		"build:\n  run:\n    - name: seq_script\n      script: [a, b]\n",
+	} {
+		doc, err := Parse([]byte(src), "test.yml")
+		if err != nil {
+			t.Fatalf("parse error for %q: %v", src, err)
+		}
+		EachJob(doc.Root, func(_ *yaml.Node, job *yaml.Node) {
+			if got := len(RunStepScripts(job)); got != 0 {
+				t.Errorf("%q: expected no scripts, got %d", src, got)
+			}
+		})
+	}
+}

--- a/internal/shellcheck/shellcheck.go
+++ b/internal/shellcheck/shellcheck.go
@@ -81,6 +81,14 @@ func Run(doc *yaml.Node, file string, binPath string) []finding.Finding {
 				blocks = append(blocks, scriptBlock{jobName: name.Value, lines: lines})
 			}
 		}
+		// run: is the CI/CD Steps alternative to script: and excludes it, so a
+		// job using steps has no script: block for ShellCheck to see. Each step
+		// is a separate shell invocation and is checked on its own.
+		for _, node := range parser.RunStepBlocks(job) {
+			if lines := extractLines(node); len(lines) > 0 {
+				blocks = append(blocks, scriptBlock{jobName: name.Value, lines: lines})
+			}
+		}
 	})
 
 	var findings []finding.Finding

--- a/rules/gl014.go
+++ b/rules/gl014.go
@@ -35,7 +35,7 @@ func (r *gl014) Check(doc *yaml.Node, file string) []finding.Finding {
 			parser.FindKey(job, "after_script"),
 			hookScriptNode(job),
 		}
-		scriptNodes = append(scriptNodes, RunStepBlocks(job)...)
+		scriptNodes = append(scriptNodes, parser.RunStepBlocks(job)...)
 		for _, scriptNode := range scriptNodes {
 			if scriptNode == nil || scriptNode.Kind != yaml.SequenceNode {
 				continue

--- a/rules/gl016.go
+++ b/rules/gl016.go
@@ -82,7 +82,7 @@ func (r *gl016) Check(doc *yaml.Node, file string) []finding.Finding {
 			parser.FindKey(job, "before_script"),
 			parser.FindKey(job, "after_script"),
 		}
-		jobScripts = append(jobScripts, RunStepBlocks(job)...)
+		jobScripts = append(jobScripts, parser.RunStepBlocks(job)...)
 		for _, node := range jobScripts {
 			if node != nil {
 				for _, f := range r.checkScriptHTTP(node, file) {

--- a/rules/gl021.go
+++ b/rules/gl021.go
@@ -43,7 +43,7 @@ func (r *gl021) Check(doc *yaml.Node, file string) []finding.Finding {
 			parser.FindKey(job, "after_script"),
 			hookScriptNode(job),
 		}
-		scriptNodes = append(scriptNodes, RunStepBlocks(job)...)
+		scriptNodes = append(scriptNodes, parser.RunStepBlocks(job)...)
 		for _, node := range scriptNodes {
 			if node == nil || node.Kind != yaml.SequenceNode {
 				continue

--- a/rules/gl042.go
+++ b/rules/gl042.go
@@ -91,7 +91,7 @@ func (r *gl042) Check(doc *yaml.Node, file string) []finding.Finding {
 			parser.FindKey(job, "before_script"),
 			parser.FindKey(job, "after_script"),
 		}
-		jobScripts = append(jobScripts, RunStepBlocks(job)...)
+		jobScripts = append(jobScripts, parser.RunStepBlocks(job)...)
 		for _, node := range jobScripts {
 			if node != nil {
 				findings = append(findings, checkTLSLines(node, file, name.Value)...)

--- a/rules/gl044.go
+++ b/rules/gl044.go
@@ -30,7 +30,7 @@ func (r *gl044) Check(doc *yaml.Node, file string) []finding.Finding {
 			parser.FindKey(job, "script"),
 			parser.FindKey(job, "before_script"),
 		}
-		jobScripts = append(jobScripts, RunStepBlocks(job)...)
+		jobScripts = append(jobScripts, parser.RunStepBlocks(job)...)
 		for _, node := range jobScripts {
 			if node == nil {
 				continue

--- a/rules/gl051.go
+++ b/rules/gl051.go
@@ -52,7 +52,7 @@ func (r *gl051) Check(doc *yaml.Node, file string) []finding.Finding {
 		for _, key := range []string{"script", "before_script", "after_script"} {
 			findings = append(findings, gl051CheckScripts(parser.FindKey(jobNode, key), file, job, key, patterns)...)
 		}
-		for _, block := range RunStepBlocks(jobNode) {
+		for _, block := range parser.RunStepBlocks(jobNode) {
 			findings = append(findings, gl051CheckScripts(block, file, job, "run", patterns)...)
 		}
 		findings = append(findings, gl051CheckScripts(hookScriptNode(jobNode), file, job, "hooks:pre_get_sources_script", patterns)...)

--- a/rules/helpers.go
+++ b/rules/helpers.go
@@ -49,44 +49,6 @@ func hookScriptNode(container *yaml.Node) *yaml.Node {
 	return parser.FindKey(hooks, "pre_get_sources_script")
 }
 
-// runStepScripts returns the inline script scalar of each step in a job's run:
-// sequence. run: is the CI/CD Steps alternative to script: and is mutually
-// exclusive with it, so without this a job that uses it has no script content
-// at all from the scanner's point of view. A step carries either an inline
-// script string or a step:/func: reference to remote code; only the former
-// holds shell text to scan. Unlike script:, a step's script is a single scalar
-// rather than a sequence, and it is commonly a multi-line block scalar.
-func runStepScripts(job *yaml.Node) []*yaml.Node {
-	run := parser.FindKey(job, "run")
-	if run == nil || run.Kind != yaml.SequenceNode {
-		return nil
-	}
-	var scripts []*yaml.Node
-	for _, step := range run.Content {
-		if step.Kind != yaml.MappingNode {
-			continue
-		}
-		if script := parser.FindKey(step, "script"); script != nil && script.Kind == yaml.ScalarNode {
-			scripts = append(scripts, script)
-		}
-	}
-	return scripts
-}
-
-// RunStepBlocks returns each of a job's run: step scripts wrapped as a
-// single-item sequence node. Callers that process script *sequences* can then
-// handle steps without special-casing the scalar shape. Each step is a separate
-// shell invocation, so each gets its own block rather than being pooled.
-// Findings report the wrapped scalar's own position, never the wrapper's.
-func RunStepBlocks(job *yaml.Node) []*yaml.Node {
-	scripts := runStepScripts(job)
-	blocks := make([]*yaml.Node, 0, len(scripts))
-	for _, script := range scripts {
-		blocks = append(blocks, &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{script}})
-	}
-	return blocks
-}
-
 // CollectJobScriptLines returns all scalar script lines from a job's
 // before_script, script, after_script, and hooks:pre_get_sources_script sections.
 func CollectJobScriptLines(job *yaml.Node) []*yaml.Node {
@@ -105,7 +67,7 @@ func CollectJobScriptLines(job *yaml.Node) []*yaml.Node {
 		appendScalars(parser.FindKey(job, key))
 	}
 	appendScalars(hookScriptNode(job))
-	lines = append(lines, runStepScripts(job)...)
+	lines = append(lines, parser.RunStepScripts(job)...)
 	return lines
 }
 
@@ -140,7 +102,7 @@ func EachScriptBlock(doc *yaml.Node, file string, fn func(node *yaml.Node, file,
 			visit(parser.FindKey(job, key), name.Value)
 		}
 		visit(hookScriptNode(job), name.Value)
-		for _, block := range RunStepBlocks(job) {
+		for _, block := range parser.RunStepBlocks(job) {
 			fn(block, file, name.Value)
 		}
 	})

--- a/rules/run_steps_test.go
+++ b/rules/run_steps_test.go
@@ -96,7 +96,7 @@ build:
         severity: high
 `)
 	parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
-		if got := len(RunStepBlocks(job)); got != 0 {
+		if got := len(parser.RunStepBlocks(job)); got != 0 {
 			t.Errorf("expected no script blocks for a step: reference, got %d", got)
 		}
 		if got := len(CollectJobScriptLines(job)); got != 0 {
@@ -115,7 +115,7 @@ func TestRunSteps_MalformedShapes(t *testing.T) {
 	} {
 		doc := parseRunSteps(t, src)
 		parser.EachJob(doc, func(_ *yaml.Node, job *yaml.Node) {
-			if got := len(RunStepBlocks(job)); got != 0 {
+			if got := len(parser.RunStepBlocks(job)); got != 0 {
 				t.Errorf("%q: expected no blocks, got %d", src, got)
 			}
 		})


### PR DESCRIPTION
Follow-up to #468, which shipped `run:` (CI/CD Steps) script coverage but left two things behind: the docs still described the old surface, and one traversal was still blind to steps.

## Docs

Sixteen prose statements across fourteen files under `docs/rules/` described the scanned surface as "`before_script`, `script`, `after_script`". As of #468 those sentences are incomplete — the rules do read `run:` steps, the docs just did not say so.

Updated: **GL004, GL020 (×2), GL024, GL025, GL026, GL045, GL047, GL048, GL050, GL051 (×2), GL068, GL069, GL070, GL079.**

Two constraints were applied deliberately:

- **Only prose that enumerates the surface.** YAML examples containing `before_script:` and generic phrasings like "script lines" or "in scripts" were left alone — the latter are still accurate.
- **Only rules that actually cover `run:`.** Each of the fourteen was checked against the list of rules reaching steps through the shared helpers before its doc was touched.

The README gains a short note in the usage section, since this is user-visible behaviour rather than an internal detail.

## ShellCheck was still blind to steps

While verifying the doc wording I found that `internal/shellcheck/shellcheck.go` hardcodes `[]string{"script", "before_script", "after_script"}` — a third copy of the surface, alongside the shared helpers and the six rules #468 patched.

That made this sentence, which appears in every rule doc I was editing, false for steps:

> Enable the ShellCheck integration to surface additional shell issues in these script blocks.

So the fix landed here rather than in a separate PR: fixing the sentence without fixing the traversal would have documented behaviour that does not exist.

## Small refactor to avoid a third copy

`RunStepScripts` / `RunStepBlocks` moved from `rules/helpers.go` to `internal/parser`. `internal/shellcheck` can now use them without depending on the rules package, and the logic has one home instead of being duplicated a third time. The six rules from #468 and the helpers were updated to call `parser.RunStepBlocks`; behaviour is unchanged.

## Testing

Two new tests in `internal/parser/parser_test.go` exercise the helpers directly — inline scripts collected in order, `step:` references yielding nothing, the wrapper holding the *original* scalar node (so finding positions stay real), and six malformed or absent `run:` shapes.

```
go test ./...          12 packages ok, 0 failures
golangci-lint run      0 issues
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml   ok
```

**Regression check:** rebuilt and re-ran across all 83 fixtures against `main`. 359 findings, **identical**.

ShellCheck is not installed in this environment, so its new branch is covered by the parser-level tests rather than an end-to-end run — worth a look from anyone with it installed.

## Still open

#467 remains open for stage 3, the pinning rule for `step:` / `func:` references, held until GitLab Functions leaves Experiment status.
