### PR TITLE
chore: bump zizmor pin to 1.30.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install zizmor
-        run: pip install zizmor==1.29.0
+        run: pip install zizmor==1.30.0
       - name: Run zizmor
         run: zizmor --gh-token "${{ secrets.GITHUB_TOKEN }}" .github/workflows/
 


### PR DESCRIPTION
## What changed

`.github/workflows/ci.yml:94` — `pip install zizmor==1.29.0` → `1.30.0`. One line, no other pin in the repo references zizmor.

## Why

zizmor 1.30.0 shipped on 2026-08-30 and is now the stable release; 1.29.0 has been the pin since #452. Keeping it current is what makes the `Security (zizmor)` job worth running — a stale pin quietly stops picking up new audits.

Nothing watches this automatically. The `Check version pins agree` job only compares the Claude Code plugin pins against the README, and `check-framework-versions.yml` is ASVS-only, so the pin drifts silently until someone looks.

## Verification

Both versions were installed locally and run against `.github/workflows/` exactly as CI does, with a token passed:

| Version | Exit | Output |
| --- | --- | --- |
| 1.29.0 (current pin) | 0 | `No findings to report. Good job! (11 suppressed)` |
| 1.30.0 (this PR) | 0 | `No findings to report. Good job! (11 suppressed)` |

Identical, including the suppressed count. This matters because 1.30.0 is not a pure bugfix release — it adds the `self-repository` audit and reworks the `cache-poisoning` and `unpinned-tools` diagnostics, any of which could have surfaced a new finding and turned the job red on merge. It does not.

`self-repository` flags the old workspace-relative form for local reusable workflows and actions, which this repo does not use, so it has nothing to fire on here.
