### PR TITLE
chore: bump version refs to 1.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glsec",
   "description": "Static security scanner for GitLab CI/CD pipelines",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "author": {
     "name": "glsec",
     "url": "https://github.com/glsec/glsec"

--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ Every release is signed and carries build provenance, so you can confirm an arti
 **Release binaries** carry a SLSA provenance attestation. Verify a downloaded archive with the [GitHub CLI](https://cli.github.com/):
 
 ```sh
-gh attestation verify glsec_1.15.0_linux_amd64.tar.gz --owner glsec
+gh attestation verify glsec_1.16.0_linux_amd64.tar.gz --owner glsec
 ```
 
 **The container image** is signed with [cosign](https://github.com/sigstore/cosign) and carries provenance plus an SBOM attestation:
 
 ```sh
-cosign verify ghcr.io/glsec/glsec:1.15.0 \
+cosign verify ghcr.io/glsec/glsec:1.16.0 \
   --certificate-identity-regexp 'https://github.com/glsec/glsec/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # list everything attached to the image (signature, provenance, SBOM)
-cosign tree ghcr.io/glsec/glsec:1.15.0
+cosign tree ghcr.io/glsec/glsec:1.16.0
 ```
 
 The two `--certificate-*` flags are what bind the signature to this repository's GitHub Actions workflow. Without them `cosign verify` accepts a signature from any identity, which defeats the point.
@@ -79,7 +79,7 @@ The two `--certificate-*` flags are what bind the signature to this repository's
 **Checksums** are published as `checksums.txt` next to the archives:
 
 ```sh
-curl -sSLO https://github.com/glsec/glsec/releases/download/v1.15.0/checksums.txt
+curl -sSLO https://github.com/glsec/glsec/releases/download/v1.16.0/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
 ```
 
@@ -322,7 +322,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.15.0
+    rev: v1.16.0
     hooks:
       - id: glsec
 ```
@@ -413,13 +413,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.15.0
+    name: ghcr.io/glsec/glsec:1.16.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.15.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.16.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -427,7 +427,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.15.0"
+  GLSEC_VERSION: "1.16.0"
 
 glsec:
   stage: test
@@ -449,7 +449,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.15.0
+    name: ghcr.io/glsec/glsec:1.16.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -468,7 +468,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.15.0
+    name: ghcr.io/glsec/glsec:1.16.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true

--- a/bin/glsec
+++ b/bin/glsec
@@ -12,7 +12,7 @@
 # Supports linux + darwin only. VERSION is kept in lockstep with the release.
 set -eu
 
-VERSION="1.15.0"
+VERSION="1.16.0"
 REPO="glsec/glsec"
 
 hint() {


### PR DESCRIPTION
Version bump for the v1.16.0 release. Bumps `README.md` (10 refs), `bin/glsec` (`VERSION=`), and `.claude-plugin/plugin.json` — the three places the `Check version pins agree` job compares. No `1.15.0` string is left in the tree.

Minor rather than patch: this release adds a detection surface that did not exist before.

## What ships in 1.16.0

| PR | Change |
| --- | --- |
| #468 | `run:` (CI/CD Steps) job scripts are scanned. A steps-only pipeline was previously rejected outright as `not a valid GitLab CI file` with exit 2; `run:` jobs in a mixed file were silently skipped by every script rule. |
| #469 | Rule docs corrected for the above, and the ShellCheck integration extended to `run:` steps. |
| #466 | Runtime image picks up the openssl fix for CVE-2026-14456 (temporary `apk upgrade`, tracked for removal). |
| #464, #465 | Dependabot: golang 1.27-alpine, docker/setup-buildx-action 4.3.0. |
| #471 | zizmor pin 1.29.0 → 1.30.0 (CI only). |

Rule count is unchanged at 82. The user-visible change is that `run:`-based jobs are no longer a blind spot.

## Pre-release validation

Per the usual pre-release check, both builds were run over a corpus of **273 real `.gitlab-ci.yml` files** harvested from the most-starred public GitLab projects, with `--no-cache` on every run:

| Build | Findings |
| --- | --- |
| v1.15.0 | 3392 |
| this branch | 3392 |

**Byte-identical**, file for file, rule for rule, line for line. That is the result you want here: #468 touched the script-collection layer feeding 40+ rules, so the risk was a silent regression on ordinary pipelines rather than a false positive from a new rule.

Two corpus files matched a naive `^\s*run:` grep. Both turned out to be jobs *named* `run:triage` — a job name containing a colon, not the `run:` keyword — and neither changed its findings. No pipeline in the corpus uses CI/CD Steps, which matches expectations while GitLab Functions is still an Experiment.

Local checks on this branch: `go test ./...` 12 packages ok, `golangci-lint run` 0 issues, `check-jsonschema` ok.

## After merge

1. Tag `v1.16.0` on the merge commit; the Release and Docker workflows publish the archives, SBOMs, checksums and `ghcr.io/glsec/glsec:1.16.0`.
2. Bump and release the GitLab CI/CD Catalog component at `gitlab.com/glsec-io/glsec` (its own `v1.0.N` scheme, currently v1.0.16), otherwise catalog users stay pinned to the old image.
3. Small follow-up PR here to point the README's component examples at the new component tag — that reference can only move once the component release exists.
