### PR TITLE
docs: point component examples at v1.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.16
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.17
 
 stages:
   - test
@@ -386,7 +386,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.16
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.17
 
 stages:
   - test


### PR DESCRIPTION
Follow-up to the v1.16.0 release. Points the two GitLab CI/CD Catalog component examples in the README at `v1.0.17`.

This lands as a separate PR by necessity: the component is released from `gitlab.com/glsec-io/glsec` on its own `v1.0.N` scheme, so the reference here can only move once that release actually exists. It now does.

## Release chain, for the record

| Step | State |
| --- | --- |
| glsec `v1.16.0` tagged and released | done — 13 assets (6 archives, 6 SBOMs, checksums) |
| `ghcr.io/glsec/glsec:1.16.0` and `:latest` | published, both pullable |
| Component bumped to glsec 1.16.0 and tagged `v1.0.17` | done — pipeline green before tagging, `lint-templates` pulled the new image |
| `v1.0.17` visible in the CI/CD Catalog | verified via unauthenticated GraphQL |
| README component examples (this PR) | pending |

Nothing else in the tree references `v1.0.16`.

Worth noting why this step is easy to lose: the component version is deliberately excluded from the `Check version pins agree` job, since it is released separately. Nothing watches it, so it only stays current if the release checklist is followed to the end. It had previously drifted to `@v1.0.9` while the released component was at `v1.0.14`.
