### PR TITLE
feat(rules): add GL084 for CI variable interpolation in include targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,13 @@ Any inline `# glsec:ignore` without a `-- reason` is then reported with its file
 
 ## Rules
 
-83 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
+84 rules across 8 [OWASP CI/CD security categories](https://owasp.org/www-project-top-10-ci-cd-security-risks/):
 
 | Category | OWASP | Rules |
 |----------|-------|-------|
 | Credential Hygiene | CICD-SEC-6 | GL004, GL005, GL006, GL010, GL014, GL018, GL021, GL027, GL029, GL032, GL033, GL035, GL036, GL037, GL038, GL040, GL052, GL059, GL062, GL066, GL068, GL070, GL073 |
 | Dependency & Image Pinning | CICD-SEC-3 | GL001, GL003, GL011, GL016, GL022, GL023, GL026, GL046, GL064, GL069, GL072, GL075, GL079 |
-| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078, GL083 |
+| Component & Third-Party Integrity | CICD-SEC-4, CICD-SEC-8 | GL002, GL007, GL015, GL025, GL041, GL044, GL051, GL053, GL065, GL067, GL078, GL083, GL084 |
 | Supply Chain Integrity | CICD-SEC-9 | GL020, GL045 |
 | Pipeline Flow & Access Control | CICD-SEC-1, CICD-SEC-5 | GL008, GL009, GL012, GL013, GL017, GL019, GL034, GL039, GL043, GL055, GL071, GL074, GL080, GL081, GL082 |
 | Insecure Configuration | CICD-SEC-7 | GL024, GL028, GL030, GL031, GL042, GL047, GL048, GL049, GL050, GL054, GL056, GL057, GL058, GL060, GL061, GL063, GL076, GL077 |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -76,6 +76,7 @@ User-controlled inputs and unversioned component references that allow malicious
 | [GL067](rules/GL067.md) | `warn`  | `SECURE_ANALYZERS_PREFIX` (or `*_ANALYZER_IMAGE`) repoints managed security scanners off `registry.gitlab.com` |
 | [GL078](rules/GL078.md) | `warn`  | Invisible / bidirectional Unicode control characters (Trojan Source) — rendered file can differ from what runs |
 | [GL083](rules/GL083.md) | `error` | Reverse shell or backdoor payload in `script:` — connects the runner back to an attacker-controlled host |
+| [GL084](rules/GL084.md) | varies  | CI variable interpolation in an `include:` target — the included configuration is picked at pipeline start |
 
 ---
 
@@ -152,7 +153,7 @@ A subset of rules is mapped to [OWASP ASVS](https://owasp.org/www-project-applic
 | V14.2.1 — Components from trusted, maintained sources | GL003, GL011, GL016, GL065, GL067, GL075 |
 | V14.2.2 — Components up to date and pinned | GL001, GL022, GL023, GL026, GL041 |
 | V14.2.3 — Dependencies verified for integrity | GL020 |
-| V14.3.1 — Pipeline config protected from modification | GL003, GL019 |
+| V14.3.1 — Pipeline config protected from modification | GL003, GL019, GL084 |
 | V14.3.2 — Security tools run and failures block the build | GL008, GL039, GL082 |
 | V14.3.3 — Secrets absent from source and logs | GL006, GL014, GL018, GL021, GL027, GL032, GL033, GL035, GL036, GL038, GL066, GL068 |
 | V14.3.4 — Build environment isolated | GL007, GL015, GL025, GL083 |

--- a/docs/rules/GL084.md
+++ b/docs/rules/GL084.md
@@ -1,0 +1,89 @@
+# GL084 — CI variable interpolation in an include: target
+
+**Severity:** `error` for `$CI_COMMIT_REF_NAME`, `warn` for any other variable
+**OWASP:** [CICD-SEC-4 – Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)
+
+## What glsec checks
+
+A CI variable used to build an `include:` target, in either the `$VAR` or `${VAR}` spelling. The fields inspected are `local:`, `project:`, `ref:`, `file:` (including a list of files), and the path part of a `component:` reference before the `@`.
+
+[GL007](GL007.md) flags a variable in an `image:` reference because the variable decides which container the job runs in. This is the same argument one level up: the variable decides which *configuration* the pipeline runs.
+
+## Why it matters
+
+GitLab evaluates `include:` before anything else, and [documents exactly which variables resolve there](https://docs.gitlab.com/ci/yaml/includes/#use-variables-with-include): project, group and instance variables, `CI_PROJECT_*`, trigger variables, scheduled pipeline variables, manual pipeline run variables, `CI_PIPELINE_SOURCE`, `CI_PIPELINE_TRIGGERED`, and `$CI_COMMIT_REF_NAME`. Variables from the file's own `variables:` block do not resolve.
+
+That list splits the cases:
+
+- **`$CI_COMMIT_REF_NAME` resolves**, and its value is the branch or tag name. Anyone who can push a ref picks it. `ref: $CI_COMMIT_REF_NAME` on a project include pulls the template from whatever ref in the other project matches the pusher's branch name. This is the `error` case.
+- **A custom variable** takes its value from a project, group or instance variable, a trigger, a schedule, or the manual run form. Manual pipeline variables sit *above* project, group and instance variables in the [precedence order](https://docs.gitlab.com/ci/variables/#cicd-variable-precedence), so anyone who can start a pipeline supplies the value regardless of the default in project settings. This is the `warn` case.
+
+Either way the included file is chosen when the pipeline starts, by someone who is not the reviewer of the `.gitlab-ci.yml`, and everything the include contributes then runs: jobs, `before_script`, `default:`.
+
+## Trigger example
+
+```yaml
+include:
+  - local: $TEMPLATE_PATH                     # warn
+  - local: "/ci/${CI_COMMIT_REF_NAME}.yml"    # error
+  - project: $TEMPLATE_PROJECT                # warn
+    ref: 3a1f9c2b7e5d4a6f8c0b1d2e3f4a5b6c7d8e9f01
+    file: $TEMPLATE_FILE                      # warn
+  - project: my-group/ci-templates
+    ref: $CI_COMMIT_REF_NAME                  # error
+    file: /jobs/deploy.yml
+```
+
+## What is not flagged
+
+Predefined variables whose value the GitLab instance sets, rather than a pipeline caller:
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/scan@1.2.3   # GitLab's own documented idiom
+  - project: $CI_PROJECT_NAMESPACE/ci-templates
+    ref: 9f8e7d6c5b4a39281706f5e4d3c2b1a098765432
+    file: /jobs/test.yml
+```
+
+That covers `CI_PROJECT_*`, `CI_SERVER_*`, `CI_API_*`, `CI_PIPELINE_SOURCE` and `CI_PIPELINE_TRIGGERED`.
+
+## Safe alternative
+
+Name the file and pin the ref:
+
+```yaml
+include:
+  - project: my-group/ci-templates
+    ref: 3a1f9c2b7e5d4a6f8c0b1d2e3f4a5b6c7d8e9f01
+    file: /jobs/deploy.yml
+```
+
+If the pipeline genuinely needs to switch between configurations, do it with `include:rules` on fixed paths rather than by building a path from a variable:
+
+```yaml
+include:
+  - local: /ci/deploy-prod.yml
+    rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  - local: /ci/deploy-review.yml
+    rules:
+      - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+Every reachable configuration is then visible in the file and reviewable.
+
+## Notes
+
+- `remote:` is not inspected. [GL003](GL003.md) already reports every remote include as an error, so a second finding on the same line adds nothing.
+- The version after `@` in a `component:` reference belongs to [GL041](GL041.md), which checks that it is a pinned semver tag or SHA.
+- `CI_DEFAULT_BRANCH` is treated as server-controlled and not flagged. It does not actually resolve in an include section, so using it there is a correctness bug rather than a security one, and no pipeline caller can set its value.
+- `template:` takes a GitLab-shipped path and `inputs:` are passed *to* the included configuration rather than selecting it. Neither is inspected.
+- One finding per field. When a value mixes variables, `$CI_COMMIT_REF_NAME` is the one reported, because it carries the higher severity.
+
+## See also
+
+- [GL003](GL003.md) — include with a mutable or missing `ref`
+- [GL007](GL007.md) — CI variable interpolation in an `image:` reference
+- [GL041](GL041.md) — `include: component:` without a pinned version
+- [GL075](GL075.md) — include source not on the opt-in allowlist

--- a/rules/all.go
+++ b/rules/all.go
@@ -87,5 +87,6 @@ func All() []rule.Rule {
 		GL081,
 		GL082,
 		GL083,
+		GL084,
 	}
 }

--- a/rules/asvs.go
+++ b/rules/asvs.go
@@ -28,6 +28,7 @@ var asvsRequirements = map[string][]string{
 	"GL008": {"ASVS-V14.3.2"},
 	"GL082": {"ASVS-V14.3.2"},
 	"GL083": {"ASVS-V14.3.4"},
+	"GL084": {"ASVS-V14.3.1"},
 	"GL011": {"ASVS-V14.2.1"},
 	"GL014": {"ASVS-V14.3.3"},
 	"GL015": {"ASVS-V14.3.4"},

--- a/rules/cwe.go
+++ b/rules/cwe.go
@@ -85,6 +85,7 @@ var cweIDs = map[string]string{
 	"GL081": "CWE-284",
 	"GL082": "CWE-693",
 	"GL083": "CWE-506",
+	"GL084": "CWE-829",
 }
 
 // cweNames maps CWE IDs to their short names.

--- a/rules/gl084.go
+++ b/rules/gl084.go
@@ -1,0 +1,166 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+	"gopkg.in/yaml.v3"
+)
+
+type gl084 struct{}
+
+var GL084 = &gl084{}
+
+func (r *gl084) ID() string { return "GL084" }
+
+// includeVarRe matches a CI variable reference anywhere in an include value,
+// in both the $VAR and ${VAR} spellings.
+var includeVarRe = regexp.MustCompile(`\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?`)
+
+// refNameVar is the one user-controlled variable GitLab resolves in an include
+// section. Its value is the branch or tag name, chosen by whoever pushes.
+const refNameVar = "CI_COMMIT_REF_NAME"
+
+// serverControlledVarPrefixes and serverControlledVars are the predefined
+// variables whose value the GitLab instance sets, not a pipeline caller. They
+// are the documented way to write a portable include — the component reference
+// $CI_SERVER_FQDN/$CI_PROJECT_PATH/my-component@1.0.0 is GitLab's own example —
+// so they must never be flagged.
+var serverControlledVarPrefixes = []string{"CI_PROJECT_", "CI_SERVER_", "CI_API_"}
+
+var serverControlledVars = map[string]bool{
+	"CI_PIPELINE_SOURCE":    true,
+	"CI_PIPELINE_TRIGGERED": true,
+	// Not resolvable in an include section, but its value is the project's
+	// default branch, which no pipeline caller can set. Flagging it would be a
+	// correctness complaint, not a security one.
+	"CI_DEFAULT_BRANCH": true,
+}
+
+func serverControlled(name string) bool {
+	if serverControlledVars[name] {
+		return true
+	}
+	for _, p := range serverControlledVarPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *gl084) Check(doc *yaml.Node, file string) []finding.Finding {
+	mapping := parser.Unwrap(doc)
+	includeNode := parser.FindKey(mapping, "include")
+	if includeNode == nil {
+		return nil
+	}
+
+	var findings []finding.Finding
+	switch includeNode.Kind {
+	case yaml.ScalarNode:
+		// include: '$TEMPLATE_PATH' is the local-include shorthand.
+		findings = append(findings, checkIncludeField(includeNode, "local", file)...)
+	case yaml.SequenceNode:
+		for _, item := range includeNode.Content {
+			switch item.Kind {
+			case yaml.ScalarNode:
+				findings = append(findings, checkIncludeField(item, "local", file)...)
+			case yaml.MappingNode:
+				findings = append(findings, checkIncludeVarItem(item, file)...)
+			}
+		}
+	case yaml.MappingNode:
+		findings = append(findings, checkIncludeVarItem(includeNode, file)...)
+	}
+	return findings
+}
+
+// checkIncludeVarItem inspects the location keys of one include entry.
+//
+// remote: is left to GL003, which already reports every remote include as an
+// error; a second finding on the same line adds nothing. template: names a
+// GitLab-shipped file and takes no variables. inputs: are passed to the
+// included configuration, they do not select it.
+func checkIncludeVarItem(node *yaml.Node, file string) []finding.Finding {
+	var findings []finding.Finding
+	for _, key := range []string{"local", "project", "ref", "file", "component"} {
+		value := parser.FindKey(node, key)
+		if value == nil {
+			continue
+		}
+		switch value.Kind {
+		case yaml.ScalarNode:
+			findings = append(findings, checkIncludeField(value, key, file)...)
+		case yaml.SequenceNode:
+			// file: accepts a list of paths.
+			for _, item := range value.Content {
+				if item.Kind == yaml.ScalarNode {
+					findings = append(findings, checkIncludeField(item, key, file)...)
+				}
+			}
+		}
+	}
+	return findings
+}
+
+func checkIncludeField(node *yaml.Node, key, file string) []finding.Finding {
+	value := node.Value
+	if key == "component" {
+		// The version after @ is GL041's business, not this rule's.
+		if at := strings.LastIndex(value, "@"); at >= 0 {
+			value = value[:at]
+		}
+	}
+
+	varName := offendingIncludeVar(value)
+	if varName == "" {
+		return nil
+	}
+
+	severity := finding.Warn
+	msg := fmt.Sprintf(
+		"include %s: built from CI variable $%s — the included configuration is chosen when the pipeline starts (trigger, schedule or manual run), not in review; use a fixed value",
+		key, varName,
+	)
+	if varName == refNameVar {
+		severity = finding.Error
+		msg = fmt.Sprintf(
+			"include %s: built from $%s — the branch or tag name selects the included configuration, so anyone who can push a ref controls it; use a fixed path and a pinned ref",
+			key, refNameVar,
+		)
+	}
+
+	return []finding.Finding{{
+		RuleID:   "GL084",
+		Severity: severity,
+		Message:  msg,
+		File:     file,
+		Line:     node.Line,
+		Col:      node.Column,
+	}}
+}
+
+// offendingIncludeVar returns the name of the variable to report for value, or
+// the empty string when every reference in it is server-controlled.
+// CI_COMMIT_REF_NAME wins over any other match because it carries the higher
+// severity.
+func offendingIncludeVar(value string) string {
+	first := ""
+	for _, m := range includeVarRe.FindAllStringSubmatch(value, -1) {
+		name := m[1]
+		if name == refNameVar {
+			return name
+		}
+		if serverControlled(name) {
+			continue
+		}
+		if first == "" {
+			first = name
+		}
+	}
+	return first
+}

--- a/rules/gl084_test.go
+++ b/rules/gl084_test.go
@@ -1,0 +1,165 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glsec/glsec/internal/finding"
+	"github.com/glsec/glsec/internal/parser"
+)
+
+func findings084(t *testing.T, yaml string) []finding.Finding {
+	t.Helper()
+	doc, err := parser.Parse([]byte(yaml), "test.yml")
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return GL084.Check(doc.Root, "test.yml")
+}
+
+func TestGL084_RefNameIsError(t *testing.T) {
+	cases := map[string]string{
+		"project ref": `
+include:
+  - project: my-group/ci-templates
+    ref: $CI_COMMIT_REF_NAME
+    file: /jobs/deploy.yml
+`,
+		"local path": `
+include:
+  - local: "/ci/${CI_COMMIT_REF_NAME}.yml"
+`,
+		"component path": `
+include:
+  - component: $CI_SERVER_FQDN/$CI_COMMIT_REF_NAME/scan@1.2.3
+`,
+	}
+
+	for name, yaml := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := findings084(t, yaml)
+			if len(f) != 1 {
+				t.Fatalf("expected 1 finding, got %d", len(f))
+			}
+			if f[0].Severity != finding.Error {
+				t.Errorf("expected Error severity for CI_COMMIT_REF_NAME, got %s", f[0].Severity)
+			}
+			if !strings.Contains(f[0].Message, "CI_COMMIT_REF_NAME") {
+				t.Errorf("message does not name the variable: %s", f[0].Message)
+			}
+		})
+	}
+}
+
+func TestGL084_CustomVariableIsWarn(t *testing.T) {
+	cases := map[string]string{
+		"local":            "include:\n  - local: $TEMPLATE_PATH\n",
+		"scalar shorthand": "include: $TEMPLATE_PATH\n",
+		"sequence of scalars": `
+include:
+  - $TEMPLATE_PATH
+`,
+		"single mapping": `
+include:
+  local: $TEMPLATE_PATH
+`,
+		"project":        "include:\n  - project: $TEMPLATE_PROJECT\n    ref: 3a1f9c2b7e5d4a6f8c0b1d2e3f4a5b6c7d8e9f01\n    file: /a.yml\n",
+		"braced":         "include:\n  - local: /ci/${TEMPLATE_NAME}.yml\n",
+		"component path": "include:\n  - component: $CI_SERVER_FQDN/$COMPONENT_PROJECT/scan@1.2.3\n",
+	}
+
+	for name, yaml := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := findings084(t, yaml)
+			if len(f) != 1 {
+				t.Fatalf("expected 1 finding, got %d", len(f))
+			}
+			if f[0].Severity != finding.Warn {
+				t.Errorf("expected Warn severity, got %s", f[0].Severity)
+			}
+		})
+	}
+}
+
+func TestGL084_FileSequence(t *testing.T) {
+	f := findings084(t, `
+include:
+  - project: my-group/ci-templates
+    ref: 3a1f9c2b7e5d4a6f8c0b1d2e3f4a5b6c7d8e9f01
+    file:
+      - /jobs/build.yml
+      - $TEMPLATE_FILE
+      - /ci/${CI_COMMIT_REF_NAME}.yml
+`)
+	if len(f) != 2 {
+		t.Fatalf("expected 2 findings across the file: list, got %d", len(f))
+	}
+}
+
+func TestGL084_ServerControlledVariables(t *testing.T) {
+	cases := map[string]string{
+		"documented component idiom": "include:\n  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/scan@1.2.3\n",
+		"project path":               "include:\n  - project: $CI_PROJECT_PATH\n    ref: 3a1f9c2b7e5d4a6f8c0b1d2e3f4a5b6c7d8e9f01\n    file: /a.yml\n",
+		"project namespace":          "include:\n  - project: $CI_PROJECT_NAMESPACE/ci\n    ref: 3a1f9c2b7e5d4a6f8c0b1d2e3f4a5b6c7d8e9f01\n    file: /a.yml\n",
+		"server host":                "include:\n  - component: $CI_SERVER_HOST/my-group/scan@1.2.3\n",
+		"api url":                    "include:\n  - local: $CI_API_V4_URL\n",
+		"pipeline source":            "include:\n  - local: /ci/$CI_PIPELINE_SOURCE.yml\n",
+		"default branch":             "include:\n  - project: my-group/ci\n    ref: $CI_DEFAULT_BRANCH\n    file: /a.yml\n",
+		"no variables":               "include:\n  - local: /ci/build.yml\n  - template: Jobs/SAST.gitlab-ci.yml\n",
+	}
+
+	for name, yaml := range cases {
+		t.Run(name, func(t *testing.T) {
+			if f := findings084(t, yaml); len(f) != 0 {
+				t.Fatalf("expected no finding, got %d: %s", len(f), f[0].Message)
+			}
+		})
+	}
+}
+
+func TestGL084_RemoteAndTemplateLeftAlone(t *testing.T) {
+	f := findings084(t, `
+include:
+  - remote: https://example.com/${CI_COMMIT_REF_NAME}/pipeline.yml
+  - template: $TEMPLATE_NAME
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no finding for remote:/template:, got %d: %s", len(f), f[0].Message)
+	}
+}
+
+func TestGL084_ComponentVersionLeftToGL041(t *testing.T) {
+	f := findings084(t, `
+include:
+  - component: $CI_SERVER_FQDN/my-group/scan@$COMPONENT_VERSION
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no finding for a variable version, got %d: %s", len(f), f[0].Message)
+	}
+}
+
+func TestGL084_RefNameWinsOverCustomVariable(t *testing.T) {
+	f := findings084(t, `
+include:
+  - local: /ci/$TEMPLATE_DIR/${CI_COMMIT_REF_NAME}.yml
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Severity != finding.Error {
+		t.Errorf("expected the higher CI_COMMIT_REF_NAME severity, got %s", f[0].Severity)
+	}
+}
+
+func TestGL084_ReportsPositionOfTheValue(t *testing.T) {
+	f := findings084(t, `
+include:
+  - local: $TEMPLATE_PATH
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Line != 3 {
+		t.Errorf("expected line 3, got %d", f[0].Line)
+	}
+}

--- a/rules/owasp.go
+++ b/rules/owasp.go
@@ -86,6 +86,7 @@ var owaspCategories = map[string][]string{
 	"GL081": {"CICD-SEC-5"},
 	"GL082": {"CICD-SEC-1"},
 	"GL083": {"CICD-SEC-4"},
+	"GL084": {"CICD-SEC-4"},
 }
 
 // owaspCategoryNames maps OWASP CI/CD Security Risks category IDs to their names.

--- a/testdata/fixtures/gl084-include-variable.yml
+++ b/testdata/fixtures/gl084-include-variable.yml
@@ -1,0 +1,23 @@
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+include:
+  - local: "$TEMPLATE_PATH.yml"
+  - local: "/ci/$CI_COMMIT_REF_NAME.yml"
+  - project: $TEMPLATE_PROJECT
+    ref: 3a1f9c2b7e5d4a6f8c0b1d2e3f4a5b6c7d8e9f01
+    file: "$TEMPLATE_FILE.yml"
+  - project: my-group/ci-templates
+    ref: $CI_COMMIT_REF_NAME
+    file: /jobs/deploy.yml
+  - component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/scan@1.2.3
+  - project: my-group/ci-templates
+    ref: 9f8e7d6c5b4a39281706f5e4d3c2b1a098765432
+    file: /jobs/test.yml
+
+build:
+  stage: build
+  image: alpine:3.19.1
+  script:
+    - make


### PR DESCRIPTION
Closes #477.

## What changed

New rule **GL084**, CICD-SEC-4 / CWE-829 / ASVS V14.3.1: a CI variable used to build an `include:` target.

`error` when the variable is `$CI_COMMIT_REF_NAME`, `warn` for anything else. Inspected fields are `local:`, `project:`, `ref:`, `file:` (including a list of files), and the path part of a `component:` reference before the `@`. Both the `$VAR` and `${VAR}` spellings, and the scalar shorthand (`include: $PATH`) as well as the sequence and single-mapping forms.

## Why

GL007 flags a variable in an `image:` reference because the variable decides which container the job runs in. The same argument applies one level up: the variable decides which *configuration* the pipeline runs, and nothing checked for it. GL003 does not catch it either, because `isMutableRef` (`rules/gl003.go:137-141`) is an allowlist by exception: it returns `mutableRefs[ref]`, so `$TEMPLATE_REF` is neither a known branch name nor SHA-shaped and passes as if it were a pinned tag.

The severity split follows [GitLab's own list of what resolves in an include section](https://docs.gitlab.com/ci/yaml/includes/#use-variables-with-include):

- `$CI_COMMIT_REF_NAME` resolves, and its value is the branch or tag name. Anyone who can push a ref picks it.
- A custom variable comes from a project, group or instance variable, a trigger, a schedule, or the manual run form. Manual pipeline variables outrank project, group and instance variables in the [precedence order](https://docs.gitlab.com/ci/variables/#cicd-variable-precedence), so anyone who can start a pipeline supplies the value whatever the project settings say.

## What is not flagged

- Server-controlled predefined variables: `CI_PROJECT_*`, `CI_SERVER_*`, `CI_API_*`, `CI_PIPELINE_SOURCE`, `CI_PIPELINE_TRIGGERED`. GitLab's own documented component idiom is `component: $CI_SERVER_FQDN/$CI_PROJECT_PATH/my-component@1.0.0` and it has to stay silent.
- `remote:`, which GL003 already reports in full.
- The version after `@` in a `component:` reference, which is GL041's.
- `template:` and `inputs:`.

One addition beyond the exclusion list in the issue: **`CI_DEFAULT_BRANCH`** is treated as server-controlled. It is not in GitLab's list of variables that resolve in an include, so using it there is a correctness bug rather than a security one, and no pipeline caller can set its value. Flagging it would have been a pure false positive.

## False positives

Scanned against 198 real root `.gitlab-ci.yml` files harvested from the most-starred public projects on gitlab.com:

- 44 of them use `include:`, for 245 include entries in total.
- 4 entries interpolate a variable into a location field. All four are `$CI_SERVER_FQDN` in a component reference.
- **GL084 reports 0 findings across the corpus.**

So the exclusion list is exercised by the only real-world usage present, and nothing else trips.

## How to test

```bash
go test ./rules/ -run GL084
go test ./...                       # includes the rule-consistency test
golangci-lint run ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl084-include-variable.yml

go run ./cmd/glsec --no-cache testdata/fixtures/gl084-include-variable.yml
```

The fixture yields 5 findings (2 `error` on `$CI_COMMIT_REF_NAME`, 3 `warn` on custom variables) and stays silent on the `$CI_SERVER_FQDN/$CI_PROJECT_PATH` component entry and the fully pinned project include.

Note the fixture writes `local: "$TEMPLATE_PATH.yml"` rather than a bare `$TEMPLATE_PATH`: the GitLab CI JSON schema requires include paths to end in `.yml`/`.yaml` and to be valid URI references, which also rules out the `${VAR}` spelling there. Both forms are covered by unit tests instead.

## Also in this PR

`docs/rules/GL084.md`, the `docs/rules.md` row under *Poisoned Pipeline Execution*, the ASVS V14.3.1 mapping row, and the README count and category row.
