### PR TITLE
chore: bump version refs to 1.17.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "glsec",
   "description": "Static security scanner for GitLab CI/CD pipelines",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "author": {
     "name": "glsec",
     "url": "https://github.com/glsec/glsec"

--- a/README.md
+++ b/README.md
@@ -60,18 +60,18 @@ Every release is signed and carries build provenance, so you can confirm an arti
 **Release binaries** carry a SLSA provenance attestation. Verify a downloaded archive with the [GitHub CLI](https://cli.github.com/):
 
 ```sh
-gh attestation verify glsec_1.16.0_linux_amd64.tar.gz --owner glsec
+gh attestation verify glsec_1.17.0_linux_amd64.tar.gz --owner glsec
 ```
 
 **The container image** is signed with [cosign](https://github.com/sigstore/cosign) and carries provenance plus an SBOM attestation:
 
 ```sh
-cosign verify ghcr.io/glsec/glsec:1.16.0 \
+cosign verify ghcr.io/glsec/glsec:1.17.0 \
   --certificate-identity-regexp 'https://github.com/glsec/glsec/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # list everything attached to the image (signature, provenance, SBOM)
-cosign tree ghcr.io/glsec/glsec:1.16.0
+cosign tree ghcr.io/glsec/glsec:1.17.0
 ```
 
 The two `--certificate-*` flags are what bind the signature to this repository's GitHub Actions workflow. Without them `cosign verify` accepts a signature from any identity, which defeats the point.
@@ -79,7 +79,7 @@ The two `--certificate-*` flags are what bind the signature to this repository's
 **Checksums** are published as `checksums.txt` next to the archives:
 
 ```sh
-curl -sSLO https://github.com/glsec/glsec/releases/download/v1.16.0/checksums.txt
+curl -sSLO https://github.com/glsec/glsec/releases/download/v1.17.0/checksums.txt
 sha256sum -c checksums.txt --ignore-missing
 ```
 
@@ -322,7 +322,7 @@ glsec ships a [pre-commit](https://pre-commit.com/) hook so `.gitlab-ci.yml` iss
 ```yaml
 repos:
   - repo: https://github.com/glsec/glsec
-    rev: v1.16.0
+    rev: v1.17.0
     hooks:
       - id: glsec
 ```
@@ -413,13 +413,13 @@ If you need more control than the Catalog component offers, use the pre-built im
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.16.0
+    name: ghcr.io/glsec/glsec:1.17.0
     entrypoint: [""]
   script:
     - glsec .gitlab-ci.yml
 ```
 
-The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.16.0`, not `:latest`) for reproducible pipelines.
+The `entrypoint: [""]` override is required: the image sets `ENTRYPOINT ["glsec"]` for `docker run` convenience, which conflicts with GitLab Runner's shell wrapper. Pin to a specific tag (`1.17.0`, not `:latest`) for reproducible pipelines.
 
 ### GitLab CI — binary download
 
@@ -427,7 +427,7 @@ For pipelines that cannot pull from GHCR:
 
 ```yaml
 variables:
-  GLSEC_VERSION: "1.16.0"
+  GLSEC_VERSION: "1.17.0"
 
 glsec:
   stage: test
@@ -449,7 +449,7 @@ Publish findings to GitLab's Security Dashboard by emitting SARIF and exposing i
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.16.0
+    name: ghcr.io/glsec/glsec:1.17.0
     entrypoint: [""]
   script:
     - glsec --format sarif .gitlab-ci.yml > glsec.sarif || true
@@ -468,7 +468,7 @@ Show findings **inline on merge request diffs** using GitLab's Code Quality widg
 glsec:
   stage: test
   image:
-    name: ghcr.io/glsec/glsec:1.16.0
+    name: ghcr.io/glsec/glsec:1.17.0
     entrypoint: [""]
   script:
     - glsec --format codeclimate .gitlab-ci.yml > gl-code-quality.json || true

--- a/bin/glsec
+++ b/bin/glsec
@@ -12,7 +12,7 @@
 # Supports linux + darwin only. VERSION is kept in lockstep with the release.
 set -eu
 
-VERSION="1.16.0"
+VERSION="1.17.0"
 REPO="glsec/glsec"
 
 hint() {


### PR DESCRIPTION
Version bump ahead of the v1.17.0 tag. Same three files as every release: `.claude-plugin/plugin.json`, `bin/glsec`, and the ten pinned references in `README.md`.

## What lands in 1.17.0

Two new rules, taking the set from 82 to 84:

- **GL083** (`error`, CICD-SEC-4) — reverse shell and backdoor payloads in `script:`. Five patterns, each requiring a combination rather than a single token, covering every script surface including `run:` steps. (#476, #478)
- **GL084** (`error` / `warn`, CICD-SEC-4) — CI variable interpolation in an `include:` target, so the included configuration is not picked at pipeline start by someone other than the reviewer. (#477, #479)

Plus the GL083 false-positive fix found by the pre-release corpus scan (#480, #481).

## Pre-release checks

Both rules were scanned against real pipelines, not only fixtures:

| Rule | Corpus | Findings |
|---|---|---|
| GL083 | 265 files that all contain `nc`/`socat`/`mkfifo`/`/dev/tcp` | 1, and it is a genuine reverse shell in a deliberately insecure test fixture |
| GL084 | 198 files, 44 of which use `include:` (245 entries) | 0, with the exclusion list exercised by the four real `$CI_SERVER_FQDN` component references |

GL083 originally reported 23 on its corpus; #481 removed the four false-positive classes behind the other 22 without losing the true positive.

## How to test

```bash
go test ./...
golangci-lint run ./...
check-jsonschema --builtin-schema gitlab-ci testdata/fixtures/*.yml
```

The `Check version pins agree` job is the one that matters here: `plugin.json`, `bin/glsec` and every pinned README reference must resolve to the same version. Verified locally, all report `1.17.0`.

## After the merge

Tag `v1.17.0` to trigger the release workflow, then bump and release the GitLab CI/CD Catalog component so catalog users do not stay on the old image.
