### PR TITLE
docs: point component examples at v1.0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Use the official component from the [GitLab CI Catalog](https://gitlab.com/explo
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.17
+  - component: gitlab.com/glsec-io/glsec/glsec@v1.0.18
 
 stages:
   - test
@@ -386,7 +386,7 @@ For inline findings on merge request diffs, add the `glsec-code-quality` templat
 
 ```yaml
 include:
-  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.17
+  - component: gitlab.com/glsec-io/glsec/glsec-code-quality@v1.0.18
 
 stages:
   - test


### PR DESCRIPTION
Follow-up to the v1.17.0 release. The GitLab CI/CD Catalog component is now released as **v1.0.18** and defaults to the `1.17.0` image, so the two examples in the README should point at it.

The component version is deliberately excluded from the `Check version pins agree` job, since it is released separately and can only move after the catalog release exists. That is why this is a separate PR rather than part of the version bump.

## Verified

The component release is live in the catalog:

```
ciCatalogResource(fullPath: "glsec-io/glsec") { versions(first: 3) { nodes { name } } }
  v1.0.18  2026-09-08T21:16:27Z
  v1.0.17  2026-09-01T17:32:57Z
  v1.0.16  2026-08-16T14:38:25Z
```

Its pipeline went green before tagging, including `lint-templates`, which pulls `ghcr.io/glsec/glsec:1.17.0` and therefore also proves the image is published and pullable.
