### PR TITLE
chore: bump zizmor pin to 1.30.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install zizmor
-        run: pip install zizmor==1.30.0
+        run: pip install zizmor==1.30.1
       - name: Run zizmor
         run: zizmor --gh-token "${{ secrets.GITHUB_TOKEN }}" .github/workflows/
 


### PR DESCRIPTION
## What changed

`.github/workflows/ci.yml:94` — `pip install zizmor==1.30.0` → `1.30.1`. One line, no other pin in the repo references zizmor.

## Why

zizmor 1.30.1 shipped on 2026-09-09 and is the current stable release; 1.30.0 has been the pin since #471. It is a bugfix release (crash on pre-commit inputs with an explicit `.git` suffix, `self-repository` auto-fix safety marking) with no new audits, so this is a keep-current bump rather than a coverage change.

Nothing watches this pin automatically, so it drifts until someone looks.

## Verification

Both versions were run against `.github/workflows/` exactly as CI does, with a token passed:

| Version | Exit | Output |
| --- | --- | --- |
| 1.30.0 (current pin) | 0 | `No findings to report. Good job! (11 suppressed)` |
| 1.30.1 (this PR) | 0 | `No findings to report. Good job! (11 suppressed)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHcp2NJbnvrfDjgd1EHWm6